### PR TITLE
fix(react-native-storybook): Persist Storybook mode only on refresh

### DIFF
--- a/packages/react-native-storybook/src/hoc/withStorybook/withStorybook.tsx
+++ b/packages/react-native-storybook/src/hoc/withStorybook/withStorybook.tsx
@@ -87,9 +87,9 @@ const withStorybook =
               shouldCollapse: false,
             },
           ]);
+        } else {
+          DevSettings.addMenuItem(TOGGLE_STORYBOOK_DEV_SETTINGS_MENU_ITEM, callback);
         }
-
-        DevSettings.addMenuItem(TOGGLE_STORYBOOK_DEV_SETTINGS_MENU_ITEM, callback);
       }
     }, []);
 


### PR DESCRIPTION
This PR aims to improve DX. We want to persist the app being in Storybook mode if dev is reloading metro, but we want to leave Storybook mode if the close the app and open once more. There is no straightforward way to do it so we detect if user backgrounded the app, and if so, we no longer persist the state, so if they kill the app (usually from background state) it won't open in Storybook mode next time.

![ScreenRecording2024-03-22at19 32 34-ezgif com-video-to-gif-converter](https://github.com/sherlo-io/sherlo/assets/6643306/1604f651-e85d-499b-a6ed-c85bd90b0b11)
