### PR TITLE
fix(react-native-storybook): add SafeAreaProvider and simplify SB imports

### DIFF
--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-example",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.38-alpha",
+    "@sherlo/react-native-storybook": "^1.0.37",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-example",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha.2",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-example",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/action",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "description": "A github action that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "license": "MIT",
   "author": "Sherlo",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@sherlo/cli": "^1.0.38-alpha"
+    "@sherlo/cli": "^1.0.37"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/action",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "description": "A github action that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "license": "MIT",
   "author": "Sherlo",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@sherlo/cli": "^1.0.37"
+    "@sherlo/cli": "^1.0.38-alpha.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/action",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "description": "A github action that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "license": "MIT",
   "author": "Sherlo",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@sherlo/cli": "^1.0.37"
+    "@sherlo/cli": "^1.0.38-alpha"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/cli",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "description": "A CLI that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "keywords": [
     "visual testing",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/cli",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "description": "A CLI that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "keywords": [
     "visual testing",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/cli",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "description": "A CLI that uploads provided iOS & Android builds to Sherlo and starts a test run",
   "keywords": [
     "visual testing",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/react-native-storybook",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "description": "Sherlo is a Visual Testing tool for React Native Storybook",
   "keywords": [
     "visual testing",
@@ -49,7 +49,7 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@sherlo/cli": "^1.0.37",
+    "@sherlo/cli": "^1.0.38-alpha.2",
     "base-64": "^0.1.0",
     "jsencrypt": "^3.3.2",
     "node-forge": "^1.3.1",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/react-native-storybook",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "description": "Sherlo is a Visual Testing tool for React Native Storybook",
   "keywords": [
     "visual testing",
@@ -49,7 +49,7 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@sherlo/cli": "^1.0.38-alpha",
+    "@sherlo/cli": "^1.0.37",
     "base-64": "^0.1.0",
     "jsencrypt": "^3.3.2",
     "node-forge": "^1.3.1",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/react-native-storybook",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "description": "Sherlo is a Visual Testing tool for React Native Storybook",
   "keywords": [
     "visual testing",
@@ -49,7 +49,7 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@sherlo/cli": "^1.0.37",
+    "@sherlo/cli": "^1.0.38-alpha",
     "base-64": "^0.1.0",
     "jsencrypt": "^3.3.2",
     "node-forge": "^1.3.1",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -63,7 +63,8 @@
   },
   "peerDependencies": {
     "@storybook/react-native": ">=7.6.11",
-    "react-native": ">=0.64.0"
+    "react-native": ">=0.64.0",
+    "react-native-safe-area-context": "*"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/react-native-storybook/src/getStorybook/components/Layout.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/Layout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, StyleSheet, ViewProps } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface LayoutProps extends ViewProps {
+  shouldAddSafeArea: boolean;
+}
+
+export const Layout: React.FC<LayoutProps> = ({ shouldAddSafeArea, children, style, ...props }) => {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={[
+        StyleSheet.absoluteFillObject,
+        shouldAddSafeArea && { paddingTop: insets.top, paddingBottom: insets.bottom },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+};

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, ReactElement } from 'react';
 import { Keyboard, Platform, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { RunnerBridge, SherloModule } from '../helpers';
 import { getGlobalStates } from '../utils';
 import { Snapshot, StorybookParams, StorybookView } from '../types';
@@ -9,6 +9,7 @@ import { SherloContext } from './contexts';
 import generateStorybookComponent from './generateStorybookComponent';
 import { useKeyboardStatusEffect, useOriginalMode, useStoryEmitter, useTestingMode } from './hooks';
 import { setupErrorSilencing } from './utils';
+import { Layout } from './components/Layout';
 
 setupErrorSilencing();
 
@@ -25,7 +26,6 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
 
     // Safe area handling
     const [shouldAddSafeArea, setShouldAddSafeArea] = useState(mode === 'testing');
-    const insets = useSafeAreaInsets();
 
     const renderedStoryHasError = useRef(false);
 
@@ -175,12 +175,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             mode,
           }}
         >
-          <View
-            style={[
-              StyleSheet.absoluteFillObject,
-              shouldAddSafeArea && { paddingTop: insets.top, paddingBottom: insets.bottom },
-            ]}
-          >
+          <Layout shouldAddSafeArea={shouldAddSafeArea}>
             <ErrorBoundary
               onError={() => {
                 renderedStoryHasError.current = true;
@@ -189,7 +184,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             >
               {memoizedStorybook}
             </ErrorBoundary>
-          </View>
+          </Layout>
         </SherloContext.Provider>
       </SafeAreaProvider>
     );

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, ReactElement } from 'react';
 import { Keyboard, Platform, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RunnerBridge, SherloModule } from '../helpers';
 import { getGlobalStates } from '../utils';
 import { Snapshot, StorybookParams, StorybookView } from '../types';
@@ -23,13 +23,22 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
 
     const mode = SherloModule.getInitialMode();
 
+    // Safe area handling
+    const [shouldAddSafeArea, setShouldAddSafeArea] = useState(mode === 'testing');
+    const insets = useSafeAreaInsets();
+
     const renderedStoryHasError = useRef(false);
 
     const { waitForKeyboardStatus } = useKeyboardStatusEffect(RunnerBridge.log);
 
-    const emitStory = useStoryEmitter((id) => {
-      RunnerBridge.log('rendered story', { id });
-      setRenderedStoryId(id);
+    const emitStory = useStoryEmitter({
+      onEmit: (snapshot) => {
+        setShouldAddSafeArea(!snapshot.parameters?.noSafeArea);
+      },
+      updateRenderedStoryId: (snapshot) => {
+        RunnerBridge.log('rendered story', { id: snapshot.storyId });
+        setRenderedStoryId(snapshot.storyId);
+      },
     });
 
     const prepareSnapshotForTesting = async (snapshot: Snapshot): Promise<void> => {
@@ -65,7 +74,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             testedIndex,
           });
 
-          emitStory(testedSnapshot.storyId);
+          emitStory(testedSnapshot);
         }
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -113,7 +122,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
               const nextSnapshot = snapshots[response.nextSnapshotIndex];
 
               setTestedIndex(response.nextSnapshotIndex);
-              emitStory(nextSnapshot.storyId);
+              emitStory(nextSnapshot);
             }
           } catch (error) {
             RunnerBridge.log('story capturing failed', { error });
@@ -167,7 +176,9 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             mode,
           }}
         >
-          <View style={StyleSheet.absoluteFillObject}>
+          <View
+            style={[StyleSheet.absoluteFillObject, shouldAddSafeArea && { paddingTop: insets.top }]}
+          >
             <ErrorBoundary
               onError={() => {
                 renderedStoryHasError.current = true;

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -177,7 +177,10 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
           }}
         >
           <View
-            style={[StyleSheet.absoluteFillObject, shouldAddSafeArea && { paddingTop: insets.top }]}
+            style={[
+              StyleSheet.absoluteFillObject,
+              shouldAddSafeArea && { paddingTop: insets.top, paddingBottom: insets.bottom },
+            ]}
           >
             <ErrorBoundary
               onError={() => {

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, ReactElement } from 'react';
 import { Keyboard, Platform, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { RunnerBridge, SherloModule } from '../helpers';
 import { getGlobalStates } from '../utils';
 import { Snapshot, StorybookParams, StorybookView } from '../types';
@@ -159,23 +160,25 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
     }
 
     return (
-      <SherloContext.Provider
-        value={{
-          renderedSnapshot: snapshots?.find(({ storyId }) => storyId === renderedStoryId),
-          mode,
-        }}
-      >
-        <View style={StyleSheet.absoluteFillObject}>
-          <ErrorBoundary
-            onError={() => {
-              renderedStoryHasError.current = true;
-            }}
-            log={RunnerBridge.log}
-          >
-            {memoizedStorybook}
-          </ErrorBoundary>
-        </View>
-      </SherloContext.Provider>
+      <SafeAreaProvider>
+        <SherloContext.Provider
+          value={{
+            renderedSnapshot: snapshots?.find(({ storyId }) => storyId === renderedStoryId),
+            mode,
+          }}
+        >
+          <View style={StyleSheet.absoluteFillObject}>
+            <ErrorBoundary
+              onError={() => {
+                renderedStoryHasError.current = true;
+              }}
+              log={RunnerBridge.log}
+            >
+              {memoizedStorybook}
+            </ErrorBoundary>
+          </View>
+        </SherloContext.Provider>
+      </SafeAreaProvider>
     );
   };
 

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -32,9 +32,9 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
     const { waitForKeyboardStatus } = useKeyboardStatusEffect(RunnerBridge.log);
 
     const emitStory = useStoryEmitter({
-      updateRenderedStoryId: (snapshot) => {
-        RunnerBridge.log('rendered story', { id: snapshot.storyId });
-        setRenderedStoryId(snapshot.storyId);
+      updateRenderedStoryId: (storyId) => {
+        RunnerBridge.log('rendered story', { id: storyId });
+        setRenderedStoryId(storyId);
       },
     });
 

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -32,9 +32,6 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
     const { waitForKeyboardStatus } = useKeyboardStatusEffect(RunnerBridge.log);
 
     const emitStory = useStoryEmitter({
-      onEmit: (snapshot) => {
-        setShouldAddSafeArea(!snapshot.parameters?.noSafeArea);
-      },
       updateRenderedStoryId: (snapshot) => {
         RunnerBridge.log('rendered story', { id: snapshot.storyId });
         setRenderedStoryId(snapshot.storyId);
@@ -74,6 +71,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             testedIndex,
           });
 
+          setShouldAddSafeArea(!testedSnapshot.parameters?.noSafeArea);
           emitStory(testedSnapshot);
         }
       }
@@ -121,6 +119,7 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
             if (response.nextSnapshotIndex !== undefined) {
               const nextSnapshot = snapshots[response.nextSnapshotIndex];
 
+              setShouldAddSafeArea(!nextSnapshot.parameters?.noSafeArea);
               setTestedIndex(response.nextSnapshotIndex);
               emitStory(nextSnapshot);
             }

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -1,7 +1,14 @@
 import { useEffect } from 'react';
 import { getAddons, SET_CURRENT_STORY } from '../utils/storybookImports';
+import { Snapshot } from '../../types';
 
-function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id: string) => void {
+function useStoryEmitter({
+  onEmit,
+  updateRenderedStoryId,
+}: {
+  onEmit: (snapshot: Snapshot) => void;
+  updateRenderedStoryId: (snapshot: Snapshot) => void;
+}): (snapshot: Snapshot) => void {
   useEffect(() => {
     const handleStoryRendered = (...args: any[]): void => {
       const storyId = args?.[0]?.storyId;
@@ -17,11 +24,11 @@ function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return async (storyId: string) => {
+  return async (snapshot: Snapshot) => {
     const _channel = await getAddons().ready();
-    _channel.emit(SET_CURRENT_STORY, { storyId });
+    _channel.emit(SET_CURRENT_STORY, { storyId: snapshot.storyId });
     // if we don't call it twice going back from preview to original mode doesn't work
-    _channel.emit(SET_CURRENT_STORY, { storyId });
+    _channel.emit(SET_CURRENT_STORY, { storyId: snapshot.storyId });
   };
 }
 

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -25,6 +25,7 @@ function useStoryEmitter({
   }, []);
 
   return async (snapshot: Snapshot) => {
+    onEmit(snapshot);
     const _channel = await getAddons().ready();
     _channel.emit(SET_CURRENT_STORY, { storyId: snapshot.storyId });
     // if we don't call it twice going back from preview to original mode doesn't work

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { getAddons } from '../utils/storybookImports';
+import { getAddons, SET_CURRENT_STORY } from '../utils/storybookImports';
 
 function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id: string) => void {
   useEffect(() => {
@@ -10,7 +10,7 @@ function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id:
 
     const initialize = async (): Promise<void> => {
       const _channel = await getAddons().ready();
-      _channel.on('setCurrentStory', handleStoryRendered);
+      _channel.on(SET_CURRENT_STORY, handleStoryRendered);
     };
 
     setTimeout(() => initialize(), 500);
@@ -19,9 +19,9 @@ function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id:
 
   return async (storyId: string) => {
     const _channel = await getAddons().ready();
-    _channel.emit('setCurrentStory', { storyId });
+    _channel.emit(SET_CURRENT_STORY, { storyId });
     // if we don't call it twice going back from preview to original mode doesn't work
-    _channel.emit('setCurrentStory', { storyId });
+    _channel.emit(SET_CURRENT_STORY, { storyId });
   };
 }
 

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -3,10 +3,8 @@ import { getAddons, SET_CURRENT_STORY } from '../utils/storybookImports';
 import { Snapshot } from '../../types';
 
 function useStoryEmitter({
-  onEmit,
   updateRenderedStoryId,
 }: {
-  onEmit: (snapshot: Snapshot) => void;
   updateRenderedStoryId: (snapshot: Snapshot) => void;
 }): (snapshot: Snapshot) => void {
   useEffect(() => {
@@ -25,7 +23,6 @@ function useStoryEmitter({
   }, []);
 
   return async (snapshot: Snapshot) => {
-    onEmit(snapshot);
     const _channel = await getAddons().ready();
     _channel.emit(SET_CURRENT_STORY, { storyId: snapshot.storyId });
     // if we don't call it twice going back from preview to original mode doesn't work

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { getAddons, getSetCurrentStory } from '../utils/storybookImports';
+import { getAddons } from '../utils/storybookImports';
 
 function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id: string) => void {
   useEffect(() => {
@@ -10,17 +10,18 @@ function useStoryEmitter(updateRenderedStoryId: (storyId: string) => void): (id:
 
     const initialize = async (): Promise<void> => {
       const _channel = await getAddons().ready();
-      _channel.on(getSetCurrentStory(), handleStoryRendered);
+      _channel.on('setCurrentStory', handleStoryRendered);
     };
 
     setTimeout(() => initialize(), 500);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return async (storyId: string) => {
     const _channel = await getAddons().ready();
-    _channel.emit(getSetCurrentStory(), { storyId });
+    _channel.emit('setCurrentStory', { storyId });
     // if we don't call it twice going back from preview to original mode doesn't work
-    _channel.emit(getSetCurrentStory(), { storyId });
+    _channel.emit('setCurrentStory', { storyId });
   };
 }
 

--- a/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
+++ b/packages/react-native-storybook/src/getStorybook/hooks/useStoryEmitter.ts
@@ -5,7 +5,7 @@ import { Snapshot } from '../../types';
 function useStoryEmitter({
   updateRenderedStoryId,
 }: {
-  updateRenderedStoryId: (snapshot: Snapshot) => void;
+  updateRenderedStoryId: (storyId: string) => void;
 }): (snapshot: Snapshot) => void {
   useEffect(() => {
     const handleStoryRendered = (...args: any[]): void => {

--- a/packages/react-native-storybook/src/getStorybook/utils/storybookImports.ts
+++ b/packages/react-native-storybook/src/getStorybook/utils/storybookImports.ts
@@ -1,14 +1,7 @@
-// storybookAdapter.js
-let addonsV7: any, SET_CURRENT_STORY_V7: any, addonsV8: any, SET_CURRENT_STORY_V8: any;
+let addonsV7: any, addonsV8: any;
 
 try {
   addonsV7 = require('@storybook/manager-api').addons;
-} catch (error) {
-  // Ignore if module is not found
-}
-
-try {
-  SET_CURRENT_STORY_V7 = require('@storybook/core-events').SET_CURRENT_STORY;
 } catch (error) {
   // Ignore if module is not found
 }
@@ -19,11 +12,4 @@ try {
   // Ignore if module is not found
 }
 
-try {
-  SET_CURRENT_STORY_V8 = require('@storybook/core/core-events').SET_CURRENT_STORY;
-} catch (error) {
-  // Ignore if module is not found
-}
-
 export const getAddons = (): any => addonsV8 ?? addonsV7;
-export const getSetCurrentStory = (): any => SET_CURRENT_STORY_V8 ?? SET_CURRENT_STORY_V7;

--- a/packages/react-native-storybook/src/getStorybook/utils/storybookImports.ts
+++ b/packages/react-native-storybook/src/getStorybook/utils/storybookImports.ts
@@ -13,3 +13,9 @@ try {
 }
 
 export const getAddons = (): any => addonsV8 ?? addonsV7;
+
+// This was originally imported from:
+// - @storybook/core-events in Storybook 7
+// - @storybook/core/core-events in Storybook 8
+// We keep it hardcoded as some users didn't have dependency in their versions of the library.
+export const SET_CURRENT_STORY = 'setCurrentStory';

--- a/packages/react-native-storybook/src/helpers/SherloModule.ts
+++ b/packages/react-native-storybook/src/helpers/SherloModule.ts
@@ -2,6 +2,7 @@ import base64 from 'base-64';
 import { NativeModules } from 'react-native';
 import utf8 from 'utf8';
 import isExpoGo from './isExpoGo';
+import { getGlobalStates } from '../utils';
 
 type SherloModule = {
   getInitialMode: () => 'testing' | 'default';
@@ -37,7 +38,14 @@ function createSherloModule(): SherloModule {
     storybookRegistered: async () => {
       await SherloNativeModule.storybookRegistered();
     },
-    getInitialMode: () => SherloNativeModule.getConstants().initialMode,
+    getInitialMode: () => {
+      const { testConfig, isVerifySetupTest } = getGlobalStates();
+      if (testConfig && !isVerifySetupTest) {
+        return 'testing';
+      }
+
+      return SherloNativeModule.getConstants().initialMode;
+    },
     appendFile: (path: string, data: string) => {
       const encodedData = base64.encode(utf8.encode(data));
 

--- a/testing/expo-storybook-7/package.json
+++ b/testing/expo-storybook-7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-7",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/testing/expo-storybook-7/package.json
+++ b/testing/expo-storybook-7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-7",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.38-alpha",
+    "@sherlo/react-native-storybook": "^1.0.37",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/testing/expo-storybook-7/package.json
+++ b/testing/expo-storybook-7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-7",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha.2",
     "@storybook/addon-actions": "^7.6.10",
     "@storybook/addon-controls": "^7.6.10",
     "@storybook/addon-designs": "^7.0.9",

--- a/testing/expo-storybook-8/builds/preview/android.apk
+++ b/testing/expo-storybook-8/builds/preview/android.apk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:531c5b2e28b0de9c8611f4e9a3692762ba1f9c56cf346b0478b985016d9cb54e
-size 69781551
+oid sha256:5c1e90bc58a199add4ce79a88d0d73b258f3953d5c1764b3640f4ebcd4f15c47
+size 69781910

--- a/testing/expo-storybook-8/builds/preview/ios.tar.gz
+++ b/testing/expo-storybook-8/builds/preview/ios.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba4d589a68065fcf90ac907f4f51d5a7376fa1138a7fe48ec310ee3db0673cfc
-size 15744272
+oid sha256:b8cdc3ecd748957d45bf611b23c794244c5d568a6efc47e1eaf294fe25703de7
+size 15745159

--- a/testing/expo-storybook-8/package.json
+++ b/testing/expo-storybook-8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-8",
-  "version": "1.0.38-alpha",
+  "version": "1.0.37",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.38-alpha",
+    "@sherlo/react-native-storybook": "^1.0.37",
     "@storybook/addon-essentials": "^8.3.5",
     "@storybook/addon-interactions": "^8.3.5",
     "@storybook/addon-links": "^8.3.5",

--- a/testing/expo-storybook-8/package.json
+++ b/testing/expo-storybook-8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-8",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha.2",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha.2",
     "@storybook/addon-essentials": "^8.3.5",
     "@storybook/addon-interactions": "^8.3.5",
     "@storybook/addon-links": "^8.3.5",

--- a/testing/expo-storybook-8/package.json
+++ b/testing/expo-storybook-8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherlo/expo-storybook-8",
-  "version": "1.0.37",
+  "version": "1.0.38-alpha",
   "private": true,
   "main": "index.ts",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@sherlo/react-native-storybook": "^1.0.37",
+    "@sherlo/react-native-storybook": "^1.0.38-alpha",
     "@storybook/addon-essentials": "^8.3.5",
     "@storybook/addon-interactions": "^8.3.5",
     "@storybook/addon-links": "^8.3.5",

--- a/testing/expo-storybook-8/src/components/Test/Test.stories.tsx
+++ b/testing/expo-storybook-8/src/components/Test/Test.stories.tsx
@@ -8,3 +8,5 @@ export default {
 } as Meta<typeof Test>;
 
 export const Basic = {};
+
+export const Secondary = { args: { variant: 'secondary' } };

--- a/testing/expo-storybook-8/src/components/Test/Test.tsx
+++ b/testing/expo-storybook-8/src/components/Test/Test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import * as Updates from 'expo-updates';
 import * as Localization from 'expo-localization';
 import { useColorScheme } from 'react-native';
 
-const Test = () => {
+const Test = ({ variant = 'primary' }: { variant: 'primary' | 'secondary' }) => {
   const theme = useColorScheme(); // 'light' or 'dark'
   const backgroundColor = theme === 'dark' ? '#333' : '#FFF';
   const textColor = theme === 'dark' ? '#FFF' : '#333';
@@ -15,14 +16,21 @@ const Test = () => {
 
   return (
     <View style={[styles.container, { backgroundColor }]}>
+      {variant === 'secondary' && (
+        <View style={styles.infoContainer}>
+          <Text style={[styles.text, { color: textColor }]}>SECONDARY VARIANT</Text>
+        </View>
+      )}
       <View style={styles.infoContainer}>
         <MaterialIcons name="record-voice-over" size={24} color={textColor} />
         <Text style={[styles.text, { color: textColor }]}>Language: {language}</Text>
       </View>
+
       <View style={styles.infoContainer}>
         <MaterialIcons name="place" size={24} color={textColor} />
         <Text style={[styles.text, { color: textColor }]}>Country: {country}</Text>
       </View>
+
       <View style={styles.infoContainer}>
         <MaterialIcons name="brightness-4" size={24} color={textColor} />
         <Text style={[styles.text, { color: textColor }]}>Theme: {theme || 'undefined'}</Text>

--- a/testing/expo-storybook-8/src/components/Test/Test.tsx
+++ b/testing/expo-storybook-8/src/components/Test/Test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import * as Updates from 'expo-updates';
 import * as Localization from 'expo-localization';
 import { useColorScheme } from 'react-native';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,7 +136,15 @@
     "@babel/highlight" "^7.24.2"
     picocolors "^1.0.0"
 
-"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.25.7", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.25.9.tgz#895b6c7e04a7271a0cbfd575d2e8131751914cc7"
+  integrity sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==
+  dependencies:
+    "@babel/highlight" "^7.25.9"
+    picocolors "^1.0.0"
+
+"@babel/code-frame@^7.16.7", "@babel/code-frame@^7.25.7", "@babel/code-frame@^7.8.3":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.25.7.tgz#438f2c524071531d643c6f0188e1e28f130cebc7"
   integrity sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==
@@ -167,6 +175,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.8.tgz#0376e83df5ab0eb0da18885c0140041f0747a402"
   integrity sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==
 
+"@babel/compat-data@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.9.tgz#24b01c5db6a3ebf85661b4fb4a946a9bccc72ac8"
+  integrity sha512-yD+hEuJ/+wAJ4Ox2/rpNv5HIuPG82x3ZlQvYVn8iYCprdxzE7P1udpGF1jyjQVBU4dgznN+k2h103vxZ7NdPyw==
+
 "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.20.0", "@babel/core@^7.23.0", "@babel/core@^7.23.2", "@babel/core@^7.23.9":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.5.tgz#15ab5b98e101972d171aeef92ac70d8d6718f06a"
@@ -188,7 +201,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.12.10", "@babel/core@^7.18.9", "@babel/core@^7.23.7":
+"@babel/core@^7.12.10", "@babel/core@^7.18.9":
   version "7.25.8"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.8.tgz#a57137d2a51bbcffcfaeba43cb4dd33ae3e0e1c6"
   integrity sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==
@@ -203,6 +216,27 @@
     "@babel/template" "^7.25.7"
     "@babel/traverse" "^7.25.7"
     "@babel/types" "^7.25.8"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.23.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.9.tgz#855a4cddcec4158f3f7afadacdab2a7de8af7434"
+  integrity sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/helper-compilation-targets" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.25.9"
+    "@babel/helpers" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -244,6 +278,16 @@
   integrity sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==
   dependencies:
     "@babel/types" "^7.25.7"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.9.tgz#c7e828ebe0c2baba103b712924699c9e8a6e32f0"
+  integrity sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==
+  dependencies:
+    "@babel/types" "^7.25.9"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
@@ -322,6 +366,17 @@
     "@babel/compat-data" "^7.24.7"
     "@babel/helper-validator-option" "^7.24.7"
     browserslist "^4.22.2"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz#55af025ce365be3cdc0c1c1e56c6af617ce88875"
+  integrity sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==
+  dependencies:
+    "@babel/compat-data" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
@@ -508,6 +563,14 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
+"@babel/helper-module-imports@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
+  integrity sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-module-transforms@^7.23.3", "@babel/helper-module-transforms@^7.24.5":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz#ea6c5e33f7b262a0ae762fd5986355c45f54a545"
@@ -539,6 +602,16 @@
     "@babel/helper-simple-access" "^7.25.7"
     "@babel/helper-validator-identifier" "^7.25.7"
     "@babel/traverse" "^7.25.7"
+
+"@babel/helper-module-transforms@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.25.9.tgz#12e4fb2969197ef6d78ea8a2f24375ce85b425fb"
+  integrity sha512-TvLZY/F3+GvdRYFZFyxMvnsKi+4oJdgZzU3BoGN9Uc2d9C6zfNwJcKKhjqLAhK8i46mv93jsO74fDh3ih6rpHA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.25.9"
+    "@babel/helper-simple-access" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
 
 "@babel/helper-optimise-call-expression@^7.22.5":
   version "7.22.5"
@@ -653,6 +726,14 @@
     "@babel/traverse" "^7.25.7"
     "@babel/types" "^7.25.7"
 
+"@babel/helper-simple-access@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz#6d51783299884a2c74618d6ef0f86820ec2e7739"
+  integrity sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.20.0", "@babel/helper-skip-transparent-expression-wrappers@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz#007f15240b5751c537c40e77abb4e89eeaaa8847"
@@ -705,6 +786,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz#d50e8d37b1176207b4fe9acedec386c565a44a54"
   integrity sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.22.20", "@babel/helper-validator-identifier@^7.24.5":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz#918b1a7fa23056603506370089bd990d8720db62"
@@ -720,6 +806,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz#77b7f60c40b15c97df735b38a66ba1d7c3e93da5"
   integrity sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==
 
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+
 "@babel/helper-validator-option@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz#907a3fbd4523426285365d1206c423c4c5520307"
@@ -734,6 +825,11 @@
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz#97d1d684448228b30b506d90cace495d6f492729"
   integrity sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==
+
+"@babel/helper-validator-option@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
+  integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
 
 "@babel/helper-wrap-function@^7.22.20":
   version "7.24.5"
@@ -780,6 +876,14 @@
     "@babel/template" "^7.25.7"
     "@babel/types" "^7.25.7"
 
+"@babel/helpers@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.25.9.tgz#9e26aa6fbefdbca4f8c8a1d66dc6f1c00ddadb0a"
+  integrity sha512-oKWp3+usOJSzDZOucZUAMayhPz/xVjzymyDzUN8dk0Wd3RWMlGLXi07UCQ/CgQVb8LvXx3XBajJH4XGgkt7H7g==
+  dependencies:
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.23.4", "@babel/highlight@^7.24.2":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.5.tgz#bc0613f98e1dd0720e99b2a9ee3760194a704b6e"
@@ -810,6 +914,16 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
+"@babel/highlight@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.25.9.tgz#8141ce68fc73757946f983b343f1231f4691acc6"
+  integrity sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.0", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.24.0", "@babel/parser@^7.24.5":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.5.tgz#4a4d5ab4315579e5398a82dcf636ca80c3392790"
@@ -826,6 +940,13 @@
   integrity sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==
   dependencies:
     "@babel/types" "^7.25.8"
+
+"@babel/parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.9.tgz#8fcaa079ac7458facfddc5cd705cc8005e4d3817"
+  integrity sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==
+  dependencies:
+    "@babel/types" "^7.25.9"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.24.5":
   version "7.24.5"
@@ -2958,6 +3079,15 @@
     "@babel/parser" "^7.25.7"
     "@babel/types" "^7.25.7"
 
+"@babel/template@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
+  integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
+  dependencies:
+    "@babel/code-frame" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/traverse@^7.13.0", "@babel/traverse@^7.18.9", "@babel/traverse@^7.25.7":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.7.tgz#83e367619be1cab8e4f2892ef30ba04c26a40fa8"
@@ -3003,6 +3133,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
+  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
+  dependencies:
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.24.0", "@babel/types@^7.24.5", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.5.tgz#7661930afc638a5383eb0c4aee59b74f38db84d7"
@@ -3029,6 +3172,14 @@
     "@babel/helper-string-parser" "^7.24.7"
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.9.tgz#620f35ea1f4233df529ec9a2668d2db26574deee"
+  integrity sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@base2/pretty-print-object@1.0.1":
   version "1.0.1"
@@ -4094,9 +4245,9 @@
   integrity sha512-gIhjdJp/c2beaIWWIlsXdqXVRUz3r2BxBCpfz/F3JXHvSAQ1paMYjLH+maEATtENg+k5eLV7gA+9yPp762ieuw==
 
 "@gorhom/bottom-sheet@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.0.2.tgz#28675943f24fa9787ba58bcf592028af171cdb41"
-  integrity sha512-bctrT0PDeVUdUG4xm/d9A7ikHFgQ9wchhU0oIE1vIBncFri501GTs/8Bf16ryyKHo3Q0220Dnj5CKm3Ed6ejEg==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.0.4.tgz#dd7e82c01eccd4cba6c09bd7700d857dd95b47c5"
+  integrity sha512-DTKFE+KwcS4Du5hbzTzh3r9hdfEfYmChcRi6hSeiDPGiCMq8GQ7VD5VE1WaFRrEbcc0+Seu1ZEjsf+JMcFM4vg==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"
@@ -6189,9 +6340,9 @@
     fast-deep-equal "^2.0.1"
 
 "@storybook/addon-ondevice-actions@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-actions/-/addon-ondevice-actions-8.3.9.tgz#ede2d2f47b2d8fc5e6438d5712c4a68d2acb8ea5"
-  integrity sha512-uO79N52ZVvPnPT8s9bgfrtYHYy4hBIqHj6Jz+OkR58Om8Y935yEx4wDuzgCNkkJl94u/mUKy7+aGyqiagKvurw==
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-actions/-/addon-ondevice-actions-8.3.10.tgz#4dbbc8a99d29ca793c690329e29b0221be9c7b5f"
+  integrity sha512-zje//IY05gBPVSHo4dJ1AFkIKhJFzsLJ7gqd+MihJYIXZv07AlTdQf5+tmwq1GOlPSwRFOUOAn281XmHefJWEw==
   dependencies:
     "@storybook/addon-actions" "^8.3.5"
     "@storybook/core" "^8.3.5"
@@ -6208,12 +6359,12 @@
     "@storybook/react-native-theming" "^7.6.20"
 
 "@storybook/addon-ondevice-backgrounds@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-backgrounds/-/addon-ondevice-backgrounds-8.3.9.tgz#2f64257586ed9d9e3c8b372ed38435377e7f6cec"
-  integrity sha512-petj36TKnTDqa1g6a4iHPB0dcbwB74a3wPspvq/8Q/ZKydSi9i+DVy/rFdTMZ+75hc0K8XyOuNtlas4eGcZpbg==
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-backgrounds/-/addon-ondevice-backgrounds-8.3.10.tgz#26d60d3bebe3df6cca5e1f0591788ea63e0b1fb7"
+  integrity sha512-GsmdHdxdnnHORwfHjVToMhFKeNnAQTfCDklDe5VOw2T0+gVP5RsobvOTMmSDyN6xTkiiYuksTErDT27Hiv68pw==
   dependencies:
     "@storybook/core" "^8.3.5"
-    "@storybook/react-native-theming" "^8.3.9"
+    "@storybook/react-native-theming" "^8.3.10"
 
 "@storybook/addon-ondevice-controls@^7.6.10":
   version "7.6.20"
@@ -6233,14 +6384,14 @@
     tinycolor2 "^1.4.1"
 
 "@storybook/addon-ondevice-controls@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-controls/-/addon-ondevice-controls-8.3.9.tgz#6a6ca564d2bcd3f5f5c92a1b39b36232a9c626ce"
-  integrity sha512-x+WE5ktOwghfKGsh9bYA2EbKrfXtaqAHXEHoUUXjoKm7tUJaDn8KBu8WDCdBh112N30uVFeCVRhrcDI5hpNZ+Q==
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-controls/-/addon-ondevice-controls-8.3.10.tgz#e723b9164da07c7a75f514d8d1f0c0fa124f4cdd"
+  integrity sha512-KTQE/XkzhgbrRskwE5tL20K8Yy05kJqGCHftXKf+v5S3DHZmAAcMm8BmZ/3mw2kekpqcrqunINuGMfu46Xq5Fg==
   dependencies:
     "@storybook/addon-controls" "^8.3.5"
     "@storybook/core" "^8.3.5"
-    "@storybook/react-native-theming" "^8.3.9"
-    "@storybook/react-native-ui" "^8.3.9"
+    "@storybook/react-native-theming" "^8.3.10"
+    "@storybook/react-native-ui" "^8.3.10"
     deep-equal "^1.0.1"
     prop-types "^15.7.2"
     react-native-modal-datetime-picker "^14.0.0"
@@ -6259,12 +6410,12 @@
     react-native-markdown-display "6.1.6"
 
 "@storybook/addon-ondevice-notes@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-notes/-/addon-ondevice-notes-8.3.9.tgz#9657eb17cb6bde71c69582388eb07ff64aaa4c4c"
-  integrity sha512-UNsmdGzzOOPdZZN5Uz9uLT4JQX77aaGZbhRqxrCSx1NbWGn2lPja6XBl8RrLLmEb4NtV1oe3nNIC9Aq+oqidow==
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-ondevice-notes/-/addon-ondevice-notes-8.3.10.tgz#f83b76b71ce4bb85289521a33436a6be60337501"
+  integrity sha512-+1I2GgDlyFyT0JfprEFccDLx4vi2fP85j4KZ3b0Yx/c0BMG9gKqaZ6/VFP5W13nXo4mbKkvD5xXp34yxU1f53w==
   dependencies:
     "@storybook/core" "^8.3.5"
-    "@storybook/react-native-theming" "^8.3.9"
+    "@storybook/react-native-theming" "^8.3.10"
     react-native-markdown-display "^7.0.2"
 
 "@storybook/addon-outline@7.6.20":
@@ -7339,21 +7490,21 @@
   resolved "https://registry.yarnpkg.com/@storybook/react-native-theming/-/react-native-theming-7.6.20.tgz#eab757c9225277e9bed6fc7da9f40a5f10348b97"
   integrity sha512-vwMmR2xUAu4f1BSqJIIy/CbmhOyTCu385RZO8+5nf0ym73NDtwLks6Crp71xcy9fR/NDOHHADO2c4YPSpYyifA==
 
-"@storybook/react-native-theming@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/react-native-theming/-/react-native-theming-8.3.9.tgz#be12f711419cc164c2edd906efd40f298c1199fa"
-  integrity sha512-c7RuFFTZ256NhEknL1GF4T6cJHz3iJdCOWuEkA24Bu+bppdOM3JZwxQWA6KugyF5uxU3eNZRbpEeacnX8KKb+w==
+"@storybook/react-native-theming@^8.3.10", "@storybook/react-native-theming@^8.3.9":
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/react-native-theming/-/react-native-theming-8.3.10.tgz#f1ebe44ffe362952b70b09ba49c28fcc0e397234"
+  integrity sha512-HdDNhVFDJYksaZ+hp+YJQW4RItwobgcCLqQ7lqh3GUmTvctxPsm9eGrsvtOZrdvAONybwn8E8czw5AihnZJqqA==
   dependencies:
     polished "^4.3.1"
 
-"@storybook/react-native-ui@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/react-native-ui/-/react-native-ui-8.3.9.tgz#79b752b9e9e57c325a4f0a645b191ccc50477aea"
-  integrity sha512-O0DK8W8vjWEcLSVF1g5KFeuk8UNIfgSLz0kiT2mB48OL2iFvEjZb1XnSLCqp0Vxyn5AUF/dyq83V/VUfBosB2g==
+"@storybook/react-native-ui@^8.3.10":
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/react-native-ui/-/react-native-ui-8.3.10.tgz#49dcebf435a1207594dc0f1857da51ee1636ce52"
+  integrity sha512-qEySCI6d/tMP682MkRkD+z4bSJKpq0wXkWuE6kqwn2vwMHeN+trA6UXLBq4yLEJarX7dekeAfYb6yD0gsGRUrQ==
   dependencies:
     "@storybook/core" "^8.3.5"
     "@storybook/react" "^8.3.5"
-    "@storybook/react-native-theming" "^8.3.9"
+    "@storybook/react-native-theming" "^8.3.10"
     fuse.js "^7.0.0"
     memoizerific "^1.11.3"
     polished "^4.3.1"
@@ -7388,16 +7539,16 @@
     util "^0.12.4"
 
 "@storybook/react-native@^8.3.9":
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-8.3.9.tgz#bb7ca8805d43f9ad31453d5966d6eea42ea0e9af"
-  integrity sha512-HKDMVEre8ChjCGabGiQ/oUE5BPiYJMl412qDj6BWmKGw8SjmfiEVLGAtE5eiS7HWDUikAQ5dWtKzbTFXxBIyuA==
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-8.3.10.tgz#de25ee99800ac564576153ef352c87b4fa819fec"
+  integrity sha512-SvTdN00bUWomXAnqZkI5q7T1BfRDzco2L0JXEBrcM04tnx+IIt188DVCPBhnYUcmwYm6bXj46F/CzKYf0HPzeA==
   dependencies:
     "@storybook/core" "^8.3.5"
     "@storybook/csf" "^0.1.1"
     "@storybook/global" "^5.0.0"
     "@storybook/react" "^8.3.5"
-    "@storybook/react-native-theming" "^8.3.9"
-    "@storybook/react-native-ui" "^8.3.9"
+    "@storybook/react-native-theming" "^8.3.10"
+    "@storybook/react-native-ui" "^8.3.10"
     chokidar "^3.5.1"
     commander "^8.2.0"
     dedent "^1.5.1"
@@ -8144,10 +8295,18 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react@>=16", "@types/react@^16.8.0 || ^17.0.0 || ^18.0.0":
+"@types/react@>=16":
   version "18.3.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.11.tgz#9d530601ff843ee0d7030d4227ea4360236bd537"
   integrity sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.8.0 || ^17.0.0 || ^18.0.0":
+  version "18.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
+  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -10423,9 +10582,9 @@ case-sensitive-paths-webpack-plugin@^2.3.0, case-sensitive-paths-webpack-plugin@
   integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
 
 chai@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
-  integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"
+  integrity sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==
   dependencies:
     assertion-error "^2.0.1"
     check-error "^2.1.1"


### PR DESCRIPTION
🐛 **Bug where stories would not switch during testing so user sees the same UI for each story**
Sometimes users didn't have access to the "SET_CURRENT_EVENT" import dependeing on their project dependencies

🐛 **Bug where user sees story rendered inside of SafeArea during development but not during testing** 
We will now add SafeAreaProvider by default to match rendering between development and testing