### PR TITLE
chore: Add JSDoc to SherloModule modes and improve README API descr…

### DIFF
--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -60,7 +60,7 @@ export default Storybook;
 
 ### `isStorybookMode`
 
-Boolean that indicates if the app should display Storybook. True when the native SherloModule mode is `'storybook'` (user toggled via Dev Menu or called `openStorybook()`) or `'testing'` (Sherlo is running automated visual tests on a simulator).
+Boolean that indicates if the app should display Storybook. This is the recommended way to switch between your app and Storybook - it handles both manual Storybook access and Sherlo visual testing automatically.
 
 **Type:** `boolean`
 
@@ -116,7 +116,7 @@ addStorybookToDevMenu();
 
 ### `isRunningVisualTests`
 
-Boolean that indicates if Sherlo visual tests are currently running on a simulator. True only when the native SherloModule mode is `'testing'` - not set when the user opens Storybook manually.
+Boolean that indicates if Sherlo visual tests are currently running. Use this to disable animations, mock network data, or apply other deterministic behavior that helps produce consistent screenshots.
 
 **Type:** `boolean`
 
@@ -129,23 +129,6 @@ if (isRunningVisualTests) {
   // Disable animations, mock data, etc.
 }
 ```
-
-<br />
-
-## SherloModule Modes
-
-The native SherloModule reports one of three modes that control SDK behavior:
-
-| Mode | Value | Description |
-|------|-------|-------------|
-| Default | `'default'` | Normal app mode. Storybook is not displayed. This is also the fallback when the native module is not linked. |
-| Storybook | `'storybook'` | User activated Storybook via the Dev Menu toggle or by calling `openStorybook()`. |
-| Testing | `'testing'` | Sherlo is running automated visual tests on a simulator. |
-
-**How modes map to exported flags:**
-
-- `isStorybookMode` = `true` when mode is `'storybook'` or `'testing'`
-- `isRunningVisualTests` = `true` when mode is `'testing'` only
 
 <br />
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -60,7 +60,7 @@ export default Storybook;
 
 ### `isStorybookMode`
 
-Boolean that indicates if the app should display Storybook.
+Boolean that indicates if the app should display Storybook. True when the native SherloModule mode is `'storybook'` (user toggled via Dev Menu or called `openStorybook()`) or `'testing'` (Sherlo is running automated visual tests).
 
 **Type:** `boolean`
 
@@ -116,7 +116,7 @@ addStorybookToDevMenu();
 
 ### `isRunningVisualTests`
 
-Boolean that indicates if Sherlo visual tests are currently running.
+Boolean that indicates if Sherlo visual tests are currently running. True only when the native SherloModule mode is `'testing'` - not set when the user opens Storybook manually.
 
 **Type:** `boolean`
 
@@ -129,6 +129,23 @@ if (isRunningVisualTests) {
   // Disable animations, mock data, etc.
 }
 ```
+
+<br />
+
+## SherloModule Modes
+
+The native SherloModule reports one of three modes that control SDK behavior:
+
+| Mode | Value | Description |
+|------|-------|-------------|
+| Default | `'default'` | Normal app mode. Storybook is not displayed. This is also the fallback when the native module is not linked. |
+| Storybook | `'storybook'` | User activated Storybook via the Dev Menu toggle or by calling `openStorybook()`. |
+| Testing | `'testing'` | Sherlo is running automated visual tests on a device/simulator. |
+
+**How modes map to exported flags:**
+
+- `isStorybookMode` = `true` when mode is `'storybook'` or `'testing'`
+- `isRunningVisualTests` = `true` when mode is `'testing'` only
 
 <br />
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -60,7 +60,7 @@ export default Storybook;
 
 ### `isStorybookMode`
 
-Boolean that indicates if the app should display Storybook. This is the recommended way to switch between your app and Storybook - it handles both manual Storybook access and Sherlo visual testing automatically.
+Checks if the app should render Storybook instead of the normal UI. Use this in your root component to conditionally render Storybook.
 
 **Type:** `boolean`
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -60,7 +60,7 @@ export default Storybook;
 
 ### `isStorybookMode`
 
-Boolean that indicates if the app should display Storybook. True when the native SherloModule mode is `'storybook'` (user toggled via Dev Menu or called `openStorybook()`) or `'testing'` (Sherlo is running automated visual tests).
+Boolean that indicates if the app should display Storybook. True when the native SherloModule mode is `'storybook'` (user toggled via Dev Menu or called `openStorybook()`) or `'testing'` (Sherlo is running automated visual tests on a simulator).
 
 **Type:** `boolean`
 
@@ -116,7 +116,7 @@ addStorybookToDevMenu();
 
 ### `isRunningVisualTests`
 
-Boolean that indicates if Sherlo visual tests are currently running. True only when the native SherloModule mode is `'testing'` - not set when the user opens Storybook manually.
+Boolean that indicates if Sherlo visual tests are currently running on a simulator. True only when the native SherloModule mode is `'testing'` - not set when the user opens Storybook manually.
 
 **Type:** `boolean`
 
@@ -140,7 +140,7 @@ The native SherloModule reports one of three modes that control SDK behavior:
 |------|-------|-------------|
 | Default | `'default'` | Normal app mode. Storybook is not displayed. This is also the fallback when the native module is not linked. |
 | Storybook | `'storybook'` | User activated Storybook via the Dev Menu toggle or by calling `openStorybook()`. |
-| Testing | `'testing'` | Sherlo is running automated visual tests on a device/simulator. |
+| Testing | `'testing'` | Sherlo is running automated visual tests on a simulator. |
 
 **How modes map to exported flags:**
 

--- a/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
+++ b/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
@@ -11,12 +11,6 @@ function getStorybookComponent({
   isTestingMode?: boolean;
   params?: StorybookParams;
 }): () => JSX.Element {
-  if (!view || typeof view.getStorybookUI !== 'function') {
-    throw new Error(
-      'Storybook framework not found in bundle. If you are using Metro withStorybook plugin, ensure "enabled" is set to true when building for Sherlo.'
-    );
-  }
-
   if (isTestingMode) {
     const lastState = SherloModule.getLastState();
     const storyId = lastState?.nextSnapshot.storyId;

--- a/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
+++ b/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
@@ -11,6 +11,12 @@ function getStorybookComponent({
   isTestingMode?: boolean;
   params?: StorybookParams;
 }): () => JSX.Element {
+  if (!view || typeof view.getStorybookUI !== 'function') {
+    throw new Error(
+      'Storybook framework not found in bundle. If you are using Metro withStorybook plugin, ensure "enabled" is set to true when building for Sherlo.'
+    );
+  }
+
   if (isTestingMode) {
     const lastState = SherloModule.getLastState();
     const storyId = lastState?.nextSnapshot.storyId;

--- a/packages/react-native-storybook/src/isRunningVisualTests.ts
+++ b/packages/react-native-storybook/src/isRunningVisualTests.ts
@@ -3,9 +3,6 @@ import SherloModule from './SherloModule';
 /**
  * True when Sherlo is running automated visual tests on a simulator.
  *
- * Only true when SherloModule mode is `'testing'` - not set when the user
- * opens Storybook manually via Dev Menu or `openStorybook()`.
- *
  * Use this to disable animations, mock network data, or apply other
  * deterministic behavior during visual test runs.
  */

--- a/packages/react-native-storybook/src/isRunningVisualTests.ts
+++ b/packages/react-native-storybook/src/isRunningVisualTests.ts
@@ -1,10 +1,10 @@
 import SherloModule from './SherloModule';
 
 /**
- * True when Sherlo is running automated visual tests on a device/simulator.
+ * True when Sherlo is running automated visual tests on a simulator.
  *
- * Only true for `'testing'` mode - not set when the user opens Storybook
- * manually via Dev Menu or `openStorybook()`.
+ * Only true when SherloModule mode is `'testing'` - not set when the user
+ * opens Storybook manually via Dev Menu or `openStorybook()`.
  *
  * Use this to disable animations, mock network data, or apply other
  * deterministic behavior during visual test runs.

--- a/packages/react-native-storybook/src/isRunningVisualTests.ts
+++ b/packages/react-native-storybook/src/isRunningVisualTests.ts
@@ -1,5 +1,14 @@
 import SherloModule from './SherloModule';
 
+/**
+ * True when Sherlo is running automated visual tests on a device/simulator.
+ *
+ * Only true for `'testing'` mode - not set when the user opens Storybook
+ * manually via Dev Menu or `openStorybook()`.
+ *
+ * Use this to disable animations, mock network data, or apply other
+ * deterministic behavior during visual test runs.
+ */
 const isRunningVisualTests = SherloModule.getMode() === 'testing';
 
 export default isRunningVisualTests;

--- a/packages/react-native-storybook/src/isStorybookMode.ts
+++ b/packages/react-native-storybook/src/isStorybookMode.ts
@@ -1,12 +1,11 @@
 import SherloModule from './SherloModule';
 
 /**
- * isStorybookMode determines whether Storybook should be displayed.
+ * True when the app should display Storybook instead of the normal UI.
  *
- * Returns true if any of the following conditions are met:
- * 1. User selected "Toggle Storybook" in Dev Menu
- * 2. User called "openStorybook" function imported from "@sherlo/react-native-storybook"
- * 3. Build is running tests on Sherlo
+ * Returns true when SherloModule mode is `'storybook'` or `'testing'`:
+ * - `'storybook'` - User selected "Toggle Storybook" in Dev Menu or called `openStorybook()`
+ * - `'testing'` - Sherlo is running automated visual tests on a simulator
  */
 const isStorybookMode = ['storybook', 'testing'].includes(SherloModule.getMode());
 

--- a/packages/react-native-storybook/src/isStorybookMode.ts
+++ b/packages/react-native-storybook/src/isStorybookMode.ts
@@ -3,9 +3,8 @@ import SherloModule from './SherloModule';
 /**
  * True when the app should display Storybook instead of the normal UI.
  *
- * Returns true when SherloModule mode is `'storybook'` or `'testing'`:
- * - `'storybook'` - User selected "Toggle Storybook" in Dev Menu or called `openStorybook()`
- * - `'testing'` - Sherlo is running automated visual tests on a simulator
+ * Use this in your app's root component to conditionally render Storybook
+ * when the user opens it via Dev Menu or when Sherlo runs visual tests.
  */
 const isStorybookMode = ['storybook', 'testing'].includes(SherloModule.getMode());
 

--- a/packages/react-native-storybook/src/types/types.ts
+++ b/packages/react-native-storybook/src/types/types.ts
@@ -65,7 +65,7 @@ export type StorybookParams = StorybookParamsRaw extends infer U
  *
  * - `'default'` - Normal app mode. Storybook is not displayed.
  * - `'storybook'` - User activated Storybook via Dev Menu toggle or `openStorybook()`.
- * - `'testing'` - Sherlo is running automated visual tests on a device/simulator.
+ * - `'testing'` - Sherlo is running automated visual tests on a simulator.
  *
  * Use `isStorybookMode` (true when `'storybook'` or `'testing'`) to decide whether
  * to render Storybook, and `isRunningVisualTests` (true only for `'testing'`) when

--- a/packages/react-native-storybook/src/types/types.ts
+++ b/packages/react-native-storybook/src/types/types.ts
@@ -60,6 +60,17 @@ export type StorybookParams = StorybookParamsRaw extends infer U
     : U
   : never;
 
+/**
+ * Mode reported by the native SherloModule.
+ *
+ * - `'default'` - Normal app mode. Storybook is not displayed.
+ * - `'storybook'` - User activated Storybook via Dev Menu toggle or `openStorybook()`.
+ * - `'testing'` - Sherlo is running automated visual tests on a device/simulator.
+ *
+ * Use `isStorybookMode` (true when `'storybook'` or `'testing'`) to decide whether
+ * to render Storybook, and `isRunningVisualTests` (true only for `'testing'`) when
+ * you need to disable animations or mock data during test runs.
+ */
 export type StorybookViewMode = 'testing' | 'default' | 'storybook';
 
 export type InspectorDataNode = {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-436

## Summary
- Add JSDoc to StorybookViewMode type, isStorybookMode, and isRunningVisualTests
- Fix device/simulator to simulator (Sherlo tests on simulators only)
- Simplify JSDoc to focus on usage guidance rather than internal mode details
- Clean up README isStorybookMode description

## Test Plan
- [x] Existing vitest tests pass (73/73)
- [x] Lint passes
- [ ] Verify JSDoc shows up in IDE tooltips

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
