### PR TITLE
chore: Fix build type detection and rename isExpoDev to buildType i…

### DIFF
--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getBinaryInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getBinaryInfo.ts
@@ -4,7 +4,7 @@ import {
   PLATFORM_LABEL,
   TEST_EAS_UPDATE_COMMAND,
 } from '../../../constants';
-import { BinaryInfo, Command, CommandParams } from '../../../types';
+import { BinaryInfo, BuildType, Command, CommandParams } from '../../../types';
 import { validatePlatformPaths } from '../../shared';
 import throwError from '../../throwError';
 import getLocalBinariesInfo from './getLocalBinariesInfo';
@@ -53,7 +53,7 @@ function getBinaryInfo(params: Params): BinaryInfo | undefined {
   }
 
   let binaryInfo = {
-    ...remoteBinariesInfoOrUploadInfo[platform],
+    ...mapRemoteBinaryInfo(remoteBinariesInfoOrUploadInfo[platform]),
     ...localBinariesInfo[platform],
   };
 
@@ -92,7 +92,7 @@ export default getBinaryInfo;
 
 /* ========================================================================== */
 
-const REQUIRED_BINARY_INFO_FIELDS: (keyof BinaryInfo)[] = ['hash', 'isExpoDev', 's3Key'];
+const REQUIRED_BINARY_INFO_FIELDS: (keyof BinaryInfo)[] = ['hash', 'buildType', 's3Key'];
 
 function checkIfBinaryInfoIsMissingRequiredFields(binaryInfo: any): binaryInfo is BinaryInfo {
   return REQUIRED_BINARY_INFO_FIELDS.some((field) => {
@@ -104,4 +104,17 @@ function checkIfBinaryInfoIsMissingRequiredFields(binaryInfo: any): binaryInfo i
 
 function isValidBinaryInfo(binaryInfo: any): binaryInfo is BinaryInfo {
   return REQUIRED_BINARY_INFO_FIELDS.every((field) => field in binaryInfo);
+}
+
+function mapRemoteBinaryInfo(remote: any): Partial<BinaryInfo> | undefined {
+  if (!remote) return undefined;
+
+  // Map API's isExpoDev boolean to CLI's buildType
+  const { isExpoDev, isDevelopmentBuild, ...rest } = remote;
+  const isDev = isDevelopmentBuild ?? isExpoDev;
+
+  return {
+    ...rest,
+    ...(isDev != null ? { buildType: (isDev ? 'development' : 'preview') as BuildType } : {}),
+  };
 }

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { PLATFORMS, PLATFORM_LABEL, TEST_EAS_UPDATE_COMMAND } from '../../../../constants';
 import { getErrorWithCustomMessage } from '../../../../helpers';
-import { BinaryInfo, Command } from '../../../../types';
+import { BinaryInfo, BuildType, Command } from '../../../../types';
 import { validatePlatformPaths } from '../../../shared';
 import throwError from '../../../throwError';
 import accessFileInArchive from './accessFileInArchive';
@@ -12,13 +12,13 @@ import accessFileInDirectory from './accessFileInDirectory';
 
 const SHERLO_JSON_FILENAME = 'sherlo.json';
 const SHERLO_JSON_PATH = `assets/${SHERLO_JSON_FILENAME}`;
-const DEV_BUILD_FILE_PATH = {
-  android: 'res/xml/rn_dev_preferences.xml',
-  ios: 'EXDevLauncher.bundle',
+const PREVIEW_BUILD_BUNDLE_PATH = {
+  android: 'assets/index.android.bundle',
+  ios: 'main.jsbundle',
 };
 
 type LocalBinariesInfo = { android?: LocalBinaryInfo; ios?: LocalBinaryInfo };
-type LocalBinaryInfo = Pick<BinaryInfo, 'hash' | 'isExpoDev' | 'sdkVersion' | 'fileName'>;
+type LocalBinaryInfo = Pick<BinaryInfo, 'hash' | 'buildType' | 'sdkVersion' | 'fileName'>;
 
 async function getLocalBinariesInfo({
   paths,
@@ -57,7 +57,7 @@ async function getLocalBinariesInfo({
         platform,
         platformPath: paths[platform],
         sherloFilePath: SHERLO_JSON_PATH,
-        devBuildFilePath: DEV_BUILD_FILE_PATH[platform],
+        previewBundlePath: PREVIEW_BUILD_BUNDLE_PATH[platform],
         projectRoot,
       });
     }
@@ -74,25 +74,25 @@ async function getLocalBinaryInfoForPlatform({
   platform,
   platformPath,
   sherloFilePath,
-  devBuildFilePath,
+  previewBundlePath,
   projectRoot,
 }: {
   platform: Platform;
   platformPath: string;
   sherloFilePath: string;
-  devBuildFilePath: string;
+  previewBundlePath: string;
   projectRoot: string;
 }): Promise<LocalBinaryInfo> {
   const fileName = path.basename(platformPath);
 
-  let checkIsDevBuild;
+  let checkHasBundle: () => Promise<boolean>;
   let readSherloFile;
 
   if (fileName.endsWith('.app')) {
-    checkIsDevBuild = () =>
+    checkHasBundle = () =>
       accessFileInDirectory({
         operation: 'exists',
-        file: devBuildFilePath,
+        file: previewBundlePath,
         directory: platformPath,
       });
 
@@ -109,10 +109,10 @@ async function getLocalBinaryInfoForPlatform({
   ) {
     const archiveType = fileName.endsWith('.apk') ? 'unzip' : 'tar';
 
-    checkIsDevBuild = () =>
+    checkHasBundle = () =>
       accessFileInArchive({
         operation: 'exists',
-        file: devBuildFilePath,
+        file: previewBundlePath,
         archive: platformPath,
         type: archiveType,
         projectRoot,
@@ -135,7 +135,8 @@ async function getLocalBinaryInfoForPlatform({
 
   const hash = await getBinaryHash(platformPath);
 
-  const isExpoDev = await checkIsDevBuild();
+  const hasBundle = await checkHasBundle();
+  const buildType: BuildType = hasBundle ? 'preview' : 'development';
 
   let sdkVersion: string | undefined;
   const sherloFileContent = await readSherloFile();
@@ -153,7 +154,7 @@ async function getLocalBinaryInfoForPlatform({
     }
   }
 
-  return { hash, isExpoDev, sdkVersion, fileName };
+  return { hash, buildType, sdkVersion, fileName };
 }
 
 async function getBinaryHash(filePath: string): Promise<string> {

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
@@ -24,7 +24,7 @@ function validateBinariesInfo({
 }) {
   validateHasSherlo(binariesInfo);
 
-  validateIsDevBuild({ binariesInfo, command });
+  validateBuildType({ binariesInfo, command });
 
   validateSdkVersion(binariesInfo);
 }
@@ -51,7 +51,7 @@ function validateHasSherlo({ android, ios }: BinariesInfo) {
   }
 }
 
-function validateIsDevBuild({
+function validateBuildType({
   binariesInfo: { android, ios },
   command,
 }: {
@@ -59,26 +59,26 @@ function validateIsDevBuild({
   command: Command;
 }) {
   if (command === TEST_EAS_UPDATE_COMMAND) {
-    const isNonDevAndroid = android && !android.isExpoDev;
-    const isNonDevIos = ios && !ios.isExpoDev;
+    const isPreviewAndroid = android && android.buildType !== 'development';
+    const isPreviewIos = ios && ios.buildType !== 'development';
 
-    if (isNonDevAndroid || isNonDevIos) {
+    if (isPreviewAndroid || isPreviewIos) {
       throwError(
         getError({
           type: 'not_dev_build',
-          platformLabels: getPlatformLabels({ android: isNonDevAndroid, ios: isNonDevIos }),
+          platformLabels: getPlatformLabels({ android: isPreviewAndroid, ios: isPreviewIos }),
         })
       );
     }
   } else {
-    const isDevAndroid = android && android.isExpoDev;
-    const isDevIos = ios && ios.isExpoDev;
+    const isDevelopmentAndroid = android && android.buildType === 'development';
+    const isDevelopmentIos = ios && ios.buildType === 'development';
 
-    if (isDevAndroid || isDevIos) {
+    if (isDevelopmentAndroid || isDevelopmentIos) {
       throwError(
         getError({
           type: 'dev_build',
-          platformLabels: getPlatformLabels({ android: isDevAndroid, ios: isDevIos }),
+          platformLabels: getPlatformLabels({ android: isDevelopmentAndroid, ios: isDevelopmentIos }),
           command,
         })
       );

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -114,6 +114,8 @@ export type InvalidatedCommandParams<C extends Command | 'any' = 'any'> = Invali
 
 /* === OTHERS === */
 
+export type BuildType = 'preview' | 'development';
+
 export type BinariesInfo = {
   android?: BinaryInfo;
   ios?: BinaryInfo;
@@ -121,7 +123,7 @@ export type BinariesInfo = {
 
 export type BinaryInfo = {
   hash: string;
-  isExpoDev: boolean;
+  buildType: BuildType;
   fileName: string;
   s3Key: string;
   buildCreatedAt?: string;


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-490

## TL;DR

Fix broken build type detection in CLI. Replace unreliable rn_dev_preferences.xml/EXDevLauncher.bundle markers with JS bundle presence check. Rename isExpoDev to buildType for clarity.

## Acceptance Criteria

- CLI correctly detects preview builds (JS bundle present) and development builds (JS bundle absent)
- isExpoDev renamed to buildType: 'preview' | 'development' in CLI code
- TypeScript compiles without errors

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
