### PR TITLE
chore: Fix Storybook WebSocket hijacking vulnerability (CVE-2026-27…

### DIFF
--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -60,7 +60,7 @@
     "utf8": "3.0.0"
   },
   "devDependencies": {
-    "@storybook/react-native": "9.1.2",
+    "@storybook/react-native": "9.1.4",
     "@types/base-64": "^1.0.0",
     "@types/react": "^18.2.0",
     "@types/react-native": "^0.73.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,92 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@apollo/client@npm:3.7.0":
-  version: 3.7.0
-  resolution: "@apollo/client@npm:3.7.0"
-  dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    "@wry/context": "npm:^0.7.0"
-    "@wry/equality": "npm:^0.5.0"
-    "@wry/trie": "npm:^0.3.0"
-    graphql-tag: "npm:^2.12.6"
-    hoist-non-react-statics: "npm:^3.3.2"
-    optimism: "npm:^0.16.1"
-    prop-types: "npm:^15.7.2"
-    response-iterator: "npm:^0.2.6"
-    symbol-observable: "npm:^4.0.0"
-    ts-invariant: "npm:^0.10.3"
-    tslib: "npm:^2.3.0"
-    zen-observable-ts: "npm:^1.2.5"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-  peerDependenciesMeta:
-    graphql-ws:
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    subscriptions-transport-ws:
-      optional: true
-  checksum: 10/952171ba1be366fb18bc6a2749d0bade2206157f990aba1d8302ccfe87a5144e02e42b944889f516bb4443f80e8f2e71308aabc10e8b60f8afaa6523003adc90
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-js@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "@aws-crypto/sha256-js@npm:1.2.2"
-  dependencies:
-    "@aws-crypto/util": "npm:^1.2.2"
-    "@aws-sdk/types": "npm:^3.1.0"
-    tslib: "npm:^1.11.1"
-  checksum: 10/1d49239e1ef93d3c5fda0f5c12eda098b14eb334cb5f604404bc6e4eaf418df9831e45f91985acfb9545eebde7a30815815ce70ab107ed147e515bbab644e791
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/util@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@aws-crypto/util@npm:1.2.2"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.1.0"
-    "@aws-sdk/util-utf8-browser": "npm:^3.0.0"
-    tslib: "npm:^1.11.1"
-  checksum: 10/55cc2bb7923d2242cd58138926a19323b6cb6381b9fcc73c6ed5d7071be29e735e6d964f868b22991772377e6e5e3dc1a8aa640e4150222b509b4f5067c4c659
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.25.0":
-  version: 3.965.0
-  resolution: "@aws-sdk/types@npm:3.965.0"
-  dependencies:
-    "@smithy/types": "npm:^4.11.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10/7382007ab2be375cb9fc0bdb8fd546dd56ac1b6301bec0bc8d24f7a123dce68f41a15f7017a7c1b0ae89fb08c831c3ce2476b24914783a307691b847c47a1028
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:^3.29.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.310.0"
-  dependencies:
-    tslib: "npm:^2.5.0"
-  checksum: 10/9ec0388c9667d4d616c61530be88422a315e3d92bf93b941d6f6d8339d6e703f4cacb2e11402658d716b1166e90d0fddb497284220e11075a0c17821c468c44b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:^3.0.0":
-  version: 3.259.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.259.0"
-  dependencies:
-    tslib: "npm:^2.3.1"
-  checksum: 10/bdcf29a92a9a1010b44bf8bade3f1224cb6577a6550b39df97cc053d353f2868d355c25589d61e1da54691d65350d8578a496840ad770ed916a6c3af0971f657
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -864,15 +778,6 @@ __metadata:
     minimatch: "npm:^3.1.2"
     strip-json-comments: "npm:^3.1.1"
   checksum: 10/e587923ba913d90865eae73308e77750da8b85de941f8df990e0efeec3cc188d2f66c0c5085fdb50748b2e43d11bf7c0cae9f2e743369b3d3a36e14a7704a2b1
-  languageName: node
-  linkType: hard
-
-"@graphql-typed-document-node/core@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "@graphql-typed-document-node/core@npm:3.2.0"
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10/fa44443accd28c8cf4cb96aaaf39d144a22e8b091b13366843f4e97d19c7bfeaf609ce3c7603a4aeffe385081eaf8ea245d078633a7324c11c5ec4b2011bb76d
   languageName: node
   linkType: hard
 
@@ -2949,10 +2854,6 @@ __metadata:
 "@sherlo/common-client@portal:../../sherlo-lib/extracted/@sherlo/common-client::locator=sherlo%40workspace%3Apackages%2Fcli":
   version: 0.0.0-use.local
   resolution: "@sherlo/common-client@portal:../../sherlo-lib/extracted/@sherlo/common-client::locator=sherlo%40workspace%3Apackages%2Fcli"
-  dependencies:
-    graphql-tag: "npm:2.12.6"
-  peerDependencies:
-    "@apollo/client": 3.7.0
   languageName: node
   linkType: soft
 
@@ -2960,7 +2861,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sherlo/react-native-storybook@workspace:packages/react-native-storybook"
   dependencies:
-    "@storybook/react-native": "npm:9.1.2"
+    "@storybook/react-native": "npm:9.1.4"
     "@types/base-64": "npm:^1.0.0"
     "@types/react": "npm:^18.2.0"
     "@types/react-native": "npm:^0.73.0"
@@ -2997,22 +2898,12 @@ __metadata:
 "@sherlo/sdk-client@portal:../../sherlo-lib/extracted/@sherlo/sdk-client::locator=sherlo%40workspace%3Apackages%2Fcli":
   version: 0.0.0-use.local
   resolution: "@sherlo/sdk-client@portal:../../sherlo-lib/extracted/@sherlo/sdk-client::locator=sherlo%40workspace%3Apackages%2Fcli"
-  dependencies:
-    "@apollo/client": "npm:3.7.0"
-    aws-appsync-auth-link: "npm:3.0.7"
-    graphql-tag: "npm:2.12.6"
-    isomorphic-fetch: "npm:3.0.0"
-  peerDependencies:
-    "@sherlo/api-types": "*"
-    "@sherlo/common-client": "*"
   languageName: node
   linkType: soft
 
 "@sherlo/shared@portal:../../sherlo-lib/extracted/@sherlo/shared::locator=sherlo%40workspace%3Apackages%2Fcli":
   version: 0.0.0-use.local
   resolution: "@sherlo/shared@portal:../../sherlo-lib/extracted/@sherlo/shared::locator=sherlo%40workspace%3Apackages%2Fcli"
-  peerDependencies:
-    "@sherlo/api-types": "*"
   languageName: node
   linkType: soft
 
@@ -3106,15 +2997,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.11.0":
-  version: 4.11.0
-  resolution: "@smithy/types@npm:4.11.0"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10/253484df3d0625137c745774af854c3175b0f7d56e826a03348fcb94aa2b60dd164380515920ed539b7e0b070f994d3ab20a0a95ad9fe385233921f5a48193de
-  languageName: node
-  linkType: hard
-
 "@standard-schema/spec@npm:^1.0.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -3140,7 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native-theming@npm:^9.1.2, @storybook/react-native-theming@npm:^9.1.4":
+"@storybook/react-native-theming@npm:^9.1.4":
   version: 9.1.4
   resolution: "@storybook/react-native-theming@npm:9.1.4"
   dependencies:
@@ -3152,7 +3034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native-ui-common@npm:^9.1.2, @storybook/react-native-ui-common@npm:^9.1.4":
+"@storybook/react-native-ui-common@npm:^9.1.4":
   version: 9.1.4
   resolution: "@storybook/react-native-ui-common@npm:9.1.4"
   dependencies:
@@ -3172,7 +3054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native-ui@npm:^9.1.2":
+"@storybook/react-native-ui@npm:^9.1.4":
   version: 9.1.4
   resolution: "@storybook/react-native-ui@npm:9.1.4"
   dependencies:
@@ -3197,15 +3079,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-native@npm:9.1.2":
-  version: 9.1.2
-  resolution: "@storybook/react-native@npm:9.1.2"
+"@storybook/react-native@npm:9.1.4":
+  version: 9.1.4
+  resolution: "@storybook/react-native@npm:9.1.4"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/react": "npm:^9.1.5"
-    "@storybook/react-native-theming": "npm:^9.1.2"
-    "@storybook/react-native-ui": "npm:^9.1.2"
-    "@storybook/react-native-ui-common": "npm:^9.1.2"
+    "@storybook/react": "npm:^9.1.8"
+    "@storybook/react-native-theming": "npm:^9.1.4"
+    "@storybook/react-native-ui": "npm:^9.1.4"
+    "@storybook/react-native-ui-common": "npm:^9.1.4"
     commander: "npm:^8.2.0"
     dedent: "npm:^1.5.1"
     deepmerge: "npm:^4.3.0"
@@ -3233,11 +3115,11 @@ __metadata:
       optional: true
   bin:
     sb-rn-get-stories: ./bin/get-stories.js
-  checksum: 10/0aef322c6618db04f623f48b492b897f29e8a113cf8ce6961f81d0ce0dcad1ed1ecf0f3712d6919d4d8e9a4f7aa270db855c407e406b51cd4f005fb5941fe5a1
+  checksum: 10/bbaa4ebfbcdaf0ea0af1b2d4fd15578fe37b2c8fe0907d2f12f24c8e6825045828ea0231aaedc6dd5d34db4046878019b8cdf3a7ec3a59eb176882c2add8d6f7
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:^9.1.5, @storybook/react@npm:^9.1.8":
+"@storybook/react@npm:^9.1.8":
   version: 9.1.17
   resolution: "@storybook/react@npm:9.1.17"
   dependencies:
@@ -3861,33 +3743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.7.0":
-  version: 0.7.4
-  resolution: "@wry/context@npm:0.7.4"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  checksum: 10/70d648949a97a035b2be2d6ddb716d4162113e850ab2c4c86331b2da94a7e826204080ce04eee2a95665bd3a0b245bf2ea3aae9adfa57b004ae0d2d49bdb5c8f
-  languageName: node
-  linkType: hard
-
-"@wry/equality@npm:^0.5.0":
-  version: 0.5.7
-  resolution: "@wry/equality@npm:0.5.7"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  checksum: 10/69dccf33c0c41fd7ec5550f5703b857c6484a949412ad747001da941270ea436648c3ab988a2091765304249585ac30c7b417fad8be9a7ce19c1221f71548e35
-  languageName: node
-  linkType: hard
-
-"@wry/trie@npm:^0.3.0":
-  version: 0.3.2
-  resolution: "@wry/trie@npm:0.3.2"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  checksum: 10/151d06b519e1ff1c3acf6ee6846161b1d7d50bbecd4c48e5cd1b05f9e37c30602aff02e88f20105f6e6c54ae4123f9c4eb7715044d7fd927d4ba4ec3e755cd36
-  languageName: node
-  linkType: hard
-
 "@yarnpkg/lockfile@npm:^1.1.0":
   version: 1.1.0
   resolution: "@yarnpkg/lockfile@npm:1.1.0"
@@ -4308,20 +4163,6 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
-  languageName: node
-  linkType: hard
-
-"aws-appsync-auth-link@npm:3.0.7":
-  version: 3.0.7
-  resolution: "aws-appsync-auth-link@npm:3.0.7"
-  dependencies:
-    "@aws-crypto/sha256-js": "npm:^1.2.0"
-    "@aws-sdk/types": "npm:^3.25.0"
-    "@aws-sdk/util-hex-encoding": "npm:^3.29.0"
-    debug: "npm:2.6.9"
-  peerDependencies:
-    "@apollo/client": 3.x
-  checksum: 10/6e69200d534b6fa44a09bb3f39ce75c9fa78e665434bd0e99f9e98635102ca32a815a988c70d52093762e6f8636963361018867e3722399ac860deaeed6db2a1
   languageName: node
   linkType: hard
 
@@ -6891,17 +6732,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:2.12.6, graphql-tag@npm:^2.12.6":
-  version: 2.12.6
-  resolution: "graphql-tag@npm:2.12.6"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  peerDependencies:
-    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10/23a2bc1d3fbeae86444204e0ac08522e09dc369559ba75768e47421a7321b59f352fb5b2c9a5c37d3cf6de890dca4e5ac47e740c7cc622e728572ecaa649089e
-  languageName: node
-  linkType: hard
-
 "graphql@npm:^16.6.0":
   version: 16.12.0
   resolution: "graphql@npm:16.12.0"
@@ -7018,15 +6848,6 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.32.0"
   checksum: 10/496210490cb45e97df14796d94aec6c817c4cefa20f1dbe3ba1df323cc58c930033cfec93f3ecfad6b90e09166fc9ffc4f665843d25b4862523aa70dacbae81f
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: "npm:^16.7.0"
-  checksum: 10/1acbe85f33e5a39f90c822ad4d28b24daeb60f71c545279431dc98c312cd28a54f8d64788e477fe21dc502b0e3cf58589ebe5c1ad22af27245370391c2d24ea6
   languageName: node
   linkType: hard
 
@@ -7710,16 +7531,6 @@ __metadata:
   version: 3.1.1
   resolution: "isexe@npm:3.1.1"
   checksum: 10/7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
-  languageName: node
-  linkType: hard
-
-"isomorphic-fetch@npm:3.0.0":
-  version: 3.0.0
-  resolution: "isomorphic-fetch@npm:3.0.0"
-  dependencies:
-    node-fetch: "npm:^2.6.1"
-    whatwg-fetch: "npm:^3.4.1"
-  checksum: 10/568fe0307528c63405c44dd3873b7b6c96c0d19ff795cb15846e728b6823bdbc68cc8c97ac23324509661316f12f551e43dac2929bc7030b8bc4d6aa1158b857
   languageName: node
   linkType: hard
 
@@ -9204,7 +9015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11":
+"node-fetch@npm:^2.6.11":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -9735,16 +9546,6 @@ __metadata:
     is-docker: "npm:^2.1.1"
     is-wsl: "npm:^2.2.0"
   checksum: 10/acd81a1d19879c818acb3af2d2e8e9d81d17b5367561e623248133deb7dd3aefaed527531df2677d3e6aaf0199f84df57b6b2262babff8bf46ea0029aac536c9
-  languageName: node
-  linkType: hard
-
-"optimism@npm:^0.16.1":
-  version: 0.16.2
-  resolution: "optimism@npm:0.16.2"
-  dependencies:
-    "@wry/context": "npm:^0.7.0"
-    "@wry/trie": "npm:^0.3.0"
-  checksum: 10/b9fc5f6549cf98fcb67cd9a2c1c30b4a0f52d4e9c41191def5855ec753ec2b2796f7b114fdc67354b3d3b7f48a7293914e903cedc8c17454a1864051ec50862d
   languageName: node
   linkType: hard
 
@@ -10453,7 +10254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -10532,7 +10333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10/5aa564a1cde7d391ac980bedee21202fc90bdea3b399952117f54fb71a932af1e5902020144fb354b4690b2414a0c7aafe798eb617b76a3d441d956db7726fdf
@@ -10869,13 +10670,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/05fa778de9d0347c8b889eb7a18f1f06bf0f801b0eb4610b4871a4b2f22e220900cf0ad525e94f990bb8d8921c07754ab2122c0c225ab4cdcea98f36e64fa4c2
-  languageName: node
-  linkType: hard
-
-"response-iterator@npm:^0.2.6":
-  version: 0.2.25
-  resolution: "response-iterator@npm:0.2.25"
-  checksum: 10/9156a50901efd94352a60635c3bb2d1ded71dca067fd22e3d42a2c83ac3affd338876f0a9dfb1cba0460ae4ced67cd3473408b4a573594742e9d00d30a24f453
   languageName: node
   linkType: hard
 
@@ -11831,13 +11625,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "symbol-observable@npm:4.0.0"
-  checksum: 10/983aef3912ad080fc834b9ad115d44bc2994074c57cea4fb008e9f7ab9bb4118b908c63d9edc861f51257bc0595025510bdf7263bb09d8953a6929f240165c24
-  languageName: node
-  linkType: hard
-
 "tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -12073,15 +11860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-invariant@npm:^0.10.3":
-  version: 0.10.3
-  resolution: "ts-invariant@npm:0.10.3"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10/bb07d56fe4aae69d8860e0301dfdee2d375281159054bc24bf1e49e513fb0835bf7f70a11351344d213a79199c5e695f37ebbf5a447188a377ce0cd81d91ddb5
-  languageName: node
-  linkType: hard
-
 "ts-node@npm:^10.9.1":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
@@ -12131,14 +11909,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.11.1, tslib@npm:^1.8.1":
+"tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -12675,7 +12453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-fetch@npm:^3.0.0, whatwg-fetch@npm:^3.4.1":
+"whatwg-fetch@npm:^3.0.0":
   version: 3.6.20
   resolution: "whatwg-fetch@npm:3.6.20"
   checksum: 10/2b4ed92acd6a7ad4f626a6cb18b14ec982bbcaf1093e6fe903b131a9c6decd14d7f9c9ca3532663c2759d1bdf01d004c77a0adfb2716a5105465c20755a8c57c
@@ -13092,21 +12870,5 @@ __metadata:
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10/b2144b38807673a4254dae06fe1a212729550609e606289c305e45c585b36fab1dbba44fe6cde90db9b28be465ec63f4c2a50867aeec6672f6bc36b6c9a361a0
-  languageName: node
-  linkType: hard
-
-"zen-observable-ts@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "zen-observable-ts@npm:1.2.5"
-  dependencies:
-    zen-observable: "npm:0.8.15"
-  checksum: 10/2384cf92a60e39e7b9735a0696f119684fee0f8bcc81d71474c92d656eca1bc3e87b484a04e97546e56bd539f8756bf97cf21a28a933ff7a94b35a8d217848eb
-  languageName: node
-  linkType: hard
-
-"zen-observable@npm:0.8.15":
-  version: 0.8.15
-  resolution: "zen-observable@npm:0.8.15"
-  checksum: 10/30eac3f4055d33f446b4cd075d3543da347c2c8e68fbc35c3f5a19fb43be67c6ed27ee136bc8f8933efa547be7ce04957809ad00ee7f1b00a964f199ae6fb514
   languageName: node
   linkType: hard


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-501

## TL;DR

Storybook dev server has a WebSocket hijacking vulnerability (GHSA-mjf5-7g4m-gx5w) allowing RCE and supply chain compromise. Update storybook in sherlo-www from 10.0.5 to >=10.2.10, and @storybook/react-native in sherlo from 9.1.2 to >=9.1.19.

## Acceptance Criteria

- storybook version in sherlo-www is >=10.2.10
- @storybook/react-native version in sherlo is >=9.1.19
- yarn install succeeds in both repos
- storybook dev server starts without errors in sherlo-www

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
