### PR TITLE
fix: Fix release workflow: update lock files after npm publish

### DIFF
--- a/.github/workflows/release-sherlo-packages.yml
+++ b/.github/workflows/release-sherlo-packages.yml
@@ -79,16 +79,10 @@ jobs:
             cd $dir
             jq --arg version "$NEW_VERSION_NUMBER" '.dependencies["@sherlo/react-native-storybook"] = "^" + $version' package.json > package.json.tmp
             mv package.json.tmp package.json
-            yarn install --no-immutable
             cd ../..
           done
 
-      - name: Update yarn.lock files in test directories
-        run: |
-          cd testing/expo && yarn install --no-immutable
-          cd ../react-native && yarn install --no-immutable
-
-      - name: Commit and push updated files
+      - name: Commit and push version updates
         uses: EndBug/add-and-commit@v7
         with:
           author_name: Sherlo Bot
@@ -113,6 +107,25 @@ jobs:
           tag_name: ${{ github.event.inputs.NEW_VERSION_NUMBER }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update lock files in examples and test directories
+        run: |
+          for dir in examples/standard examples/eas-update examples/eas-cloud-build; do
+            cd $dir
+            yarn install --no-immutable
+            cd ../..
+          done
+          cd testing/expo && yarn install --no-immutable
+          cd ../react-native && yarn install --no-immutable
+
+      - name: Commit and push updated lock files
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: Sherlo Bot
+          author_email: admin@sherlo.io
+          message: Update lock files for ${{ github.event.inputs.NEW_VERSION_NUMBER }}
+          push: true
+          branch: ${{ github.ref_name }}
 
       - name: notify failure on Slack
         if: failure()


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-599

## TL;DR

Release workflow fails because yarn install in examples resolves new version from npm before publish

## Acceptance Criteria

- Examples package.json updated before publish (no yarn install)
- Lock files updated after npm publish in a second commit
- Release workflow completes successfully

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
