### PR TITLE
fix: Add descriptive runtime error when getStorybookUI is called…

### DIFF
--- a/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
+++ b/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
@@ -36,6 +36,14 @@ function getStorybookComponent({
     };
   }
 
+  if (!view?.getStorybookUI) {
+    throw new Error(
+      'Storybook framework not found in the bundle. ' +
+        'If you are using the Metro withStorybook plugin, make sure "enabled" is set to true ' +
+        'and "onDisabledRemoveStorybook" is not stripping Storybook modules from this build.'
+    );
+  }
+
   return view.getStorybookUI(params);
 }
 

--- a/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
+++ b/packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts
@@ -39,8 +39,7 @@ function getStorybookComponent({
   if (!view?.getStorybookUI) {
     throw new Error(
       'Storybook framework not found in the bundle. ' +
-        'If you are using the Metro withStorybook plugin, make sure "enabled" is set to true ' +
-        'and "onDisabledRemoveStorybook" is not stripping Storybook modules from this build.'
+        'Make sure the Metro withStorybook wrapper does not have "enabled" set to false.'
     );
   }
 


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-602

## TL;DR

getStorybookUI throws a generic TypeError: Cannot read property 'getStorybookUI' of undefined when Storybook modules are stubbed out by Metro withStorybook({enabled: false, onDisabledRemoveStorybook: true}). Add a check that throws a descriptive error instead.

## Acceptance Criteria

- getStorybookComponent validates that view is defined before calling view.getStorybookUI()
- When view is undefined, throws a clear error explaining that Storybook framework modules are missing from the bundle
- Error message suggests checking Metro withStorybook plugin configuration

## Additional Context

This was part of SHERLO-436's AC but the PR (sherlo#98) only shipped JSDoc + README changes. The runtime validation was never implemented.

The fix belongs in packages/react-native-storybook/src/getStorybook/helpers/getStorybookComponent.ts (line 39).

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
