### PR TITLE
feat: Fix EAS local build failures caused by Yarn 4 detection miss…

### DIFF
--- a/testing/expo/.yarnrc.yml
+++ b/testing/expo/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: ../../.yarn/releases/yarn-4.12.0.cjs

--- a/testing/react-native/.yarnrc.yml
+++ b/testing/react-native/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: ../../.yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-616

## TL;DR

EAS CLI 18.2+ detects Yarn 4 by looking for .yarnrc.yml in the project root. Because testing/expo and testing/react-native don't have their own .yarnrc.yml, EAS falls back to Yarn Classic flags (--production false) which Yarn 4 rejects. Fix: add .yarnrc.yml to both testing app dirs pointing to the monorepo's Yarn release.

## Acceptance Criteria

- testing/expo/.yarnrc.yml exists and references the correct yarnPath (../../.yarn/releases/yarn-4.12.0.cjs)
- testing/react-native/.yarnrc.yml exists and references the correct yarnPath
- yarn install works locally in testing/expo and testing/react-native after the change
- Sherlo Builds workflow triggered manually with Expo Development iOS and Expo Development Android both pass the Build step
- Sherlo Builds workflow triggered manually with RN Development iOS and RN Development Android both pass the Build step

## Additional Context

**Problem**

Sherlo Builds CI started failing on 2026-03-10 after EAS CLI updated to v18.2.0 (shipped 2026-03-09). The new version added `--production false` to its `yarn install` call for Yarn Classic projects ([expo/eas-cli PR #3459](https://github.com/expo/eas-cli/pull/3459)). EAS detects Yarn 4/Berry by checking for `.yarnrc.yml` in the project root directory. Since `testing/expo` and `testing/react-native` don't have their own `.yarnrc.yml`, EAS treats them as Yarn Classic and passes the invalid `--production false` flag — which Yarn 4 rejects with: `Unknown Syntax Error: Extraneous positional argument ("false")`.

Background: `--production false` is not a valid Yarn 4 flag ([yarnpkg/berry #4608](https://github.com/yarnpkg/berry/issues/4608)). The monorepo root has `.yarnrc.yml` but EAS only checks the project-level directory.

**Solution**

Add `.yarnrc.yml` to `testing/expo/` and `testing/react-native/` referencing the monorepo's Yarn release binary. This signals to EAS that Yarn 4 is in use, causing it to use `--immutable` instead of `--frozen-lockfile --production false`.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
