### PR TITLE
feat: Store mainBranch per build to prevent retroactive relabeling…

### DIFF
--- a/testing/expo/package.json
+++ b/testing/expo/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@expo/config-plugins": "~54.0.1",
-    "@sherlo/react-native-storybook": "portal:../../packages/react-native-storybook",
+    "@sherlo/react-native-storybook": "^1.6.0",
     "@storybook/addon-ondevice-actions": "^9.1.2",
     "@storybook/addon-ondevice-backgrounds": "^9.1.2",
     "@storybook/addon-ondevice-controls": "^9.1.2",

--- a/testing/expo/yarn.lock
+++ b/testing/expo/yarn.lock
@@ -2373,7 +2373,7 @@ __metadata:
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-community/datetimepicker": "npm:8.4.4"
     "@react-native-community/slider": "npm:5.0.1"
-    "@sherlo/react-native-storybook": "portal:../../packages/react-native-storybook"
+    "@sherlo/react-native-storybook": "npm:^1.6.0"
     "@storybook/addon-ondevice-actions": "npm:^9.1.2"
     "@storybook/addon-ondevice-backgrounds": "npm:^9.1.2"
     "@storybook/addon-ondevice-controls": "npm:^9.1.2"
@@ -2412,9 +2412,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sherlo/react-native-storybook@portal:../../packages/react-native-storybook::locator=%40sherlo%2Fexpo%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@sherlo/react-native-storybook@portal:../../packages/react-native-storybook::locator=%40sherlo%2Fexpo%40workspace%3A."
+"@sherlo/react-native-storybook@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@sherlo/react-native-storybook@npm:1.6.0"
   dependencies:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
@@ -2426,8 +2426,9 @@ __metadata:
     react: "*"
     react-native: ">=0.64.0"
     react-native-safe-area-context: "*"
+  checksum: 10/e50db4391a1774bc629380fe11c6d04eb627751565ab93c7f93e63d2d6c14c18b689f2ea27118c693ccb4d758770133ccd97b545d32c3eb061da33b01e8a2d96
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.10


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-610

## TL;DR

Changing Main Git Branch retroactively relabels all historical builds, losing context of which branch was actually the baseline when each build ran. In severe cases (Spaceship build 57), 79 out of 106 stories completely disappear from the UI because auto-approved snapshots become invisible in preview mode.

## Acceptance Criteria

- Each build stores which mainBranch was active when it was created (new field: build.mainBranch)
- isFeatureBranch computation in closeBuildAndGetData uses build.mainBranch instead of project.mainBranch
- isFeatureBranch computation in frontend (BuildScreen, ProjectScreen) uses build.mainBranch instead of project.mainBranch
- Auto-approve and isActive decisions at close time use the stored build.mainBranch
- ProjectScreen build list shows a visual separator between consecutive builds when the stored mainBranch differs
- Existing builds without build.mainBranch fall back to project.mainBranch (deploy is safe with zero DB changes - identical behavior to current code)
- After deploy: manually set build.mainBranch=storyship on build 57 (projectKey=b5uzG_zg🔗1, index=57) to fix the 79 hidden stories

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
