### PR TITLE
feat: Fix dev-regression CI: strip portal deps that break standalo…

### DIFF
--- a/.github/workflows/release_to_dev.yml
+++ b/.github/workflows/release_to_dev.yml
@@ -1,0 +1,42 @@
+name: Release to Dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+
+jobs:
+  release-to-dev:
+    runs-on: ubuntu-latest
+    concurrency: release-to-dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download Sherlo packages
+        run: ./scripts/init-env.sh
+        env:
+          CLIENT_STAGE: dev
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Set dev prerelease version
+        run: |
+          VERSION=$(node -p "require('./lerna.json').version")
+          npx lerna version ${VERSION}-dev.${GITHUB_RUN_ID} --yes --no-git-tag-version --no-push
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Publish to npm with dev tag
+        run: npx lerna publish from-package --no-private --yes --dist-tag dev --no-git-reset
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_to_test.yml
+++ b/.github/workflows/release_to_test.yml
@@ -1,0 +1,39 @@
+name: Release to Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-to-test:
+    runs-on: ubuntu-latest
+    concurrency: release-to-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download Sherlo packages
+        run: ./scripts/init-env.sh
+        env:
+          CLIENT_STAGE: test
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Set test prerelease version
+        run: |
+          VERSION=$(node -p "require('./lerna.json').version")
+          npx lerna version ${VERSION}-test.${GITHUB_RUN_ID} --yes --no-git-tag-version --no-push
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Publish to npm with test tag
+        run: npx lerna publish from-package --no-private --yes --dist-tag test --no-git-reset
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/src/commands/init/dependencies/installSherlo.ts
+++ b/packages/cli/src/commands/init/dependencies/installSherlo.ts
@@ -34,9 +34,12 @@ async function installSherlo(sessionId: string | null): Promise<void> {
   // When SHERLO_SDK_PATH is set (e.g. by sherlo-tester), install from local source
   // via portal link instead of npm.
   const localSdkPath = process.env.SHERLO_SDK_PATH;
+  const sdkVersion = process.env.SHERLO_SDK_VERSION;
   const packageSpec = localSdkPath
     ? `${SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME}@portal:${localSdkPath}`
-    : SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME;
+    : sdkVersion
+      ? `${SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME}@${sdkVersion}`
+      : SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME;
 
   const packageManager = (await detect())?.name ?? 'npm';
   const resolvedCommand = resolveCommand(


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-792

## TL;DR

The dev-regression GitHub Actions workflow fails at `yarn install` because package.json has 7 portal dependencies (`portal:../sherlo-api/...`) requiring the sherlo-api sibling repo. In CI only sherlo-tester is checked out. E2E tests do NOT use any @sherlo/* packages — they interact only via browser and CLI subprocess. Strip portal deps from package.json in CI before yarn install.

## Acceptance Criteria

- `yarn install` succeeds in the dev-regression CI workflow without sherlo-api sibling repo
- Portal deps are stripped from package.json ONLY in CI (local development unchanged)
- The dev-regression workflow completes install and proceeds to test execution
- E2E tests run correctly without @sherlo/* packages installed
- Local `yarn install` with portal deps continues to work unchanged

## Additional Context

## Root Cause

The dev-regression.yml workflow (from SHERLO-788) fails at yarn install with error: @sherlo/admin-client@portal:../sherlo-api/packages/clients/admin: Manifest not found

package.json has 7 portal dependencies pointing to ../sherlo-api/packages/... (@sherlo/admin-client, @sherlo/api-types, @sherlo/app-client, @sherlo/common-client, @sherlo/runner-client, @sherlo/sdk-client, @sherlo/shared). In CI only sherlo-tester is checked out. sherlo-api does not exist.

## Why Stripping Is Safe

Thorough analysis confirmed E2E tests do NOT import any @sherlo/* packages:

1. E2E test suites (e2e/suites/) have zero imports from @sherlo/*
2. E2E utilities (e2e/utils/) use raw fetch() for GraphQL, not client libraries
3. CLI/infra code (cli/, infra/) does not import @sherlo/* packages
4. Only integration/ tests and apps/ fixture templates use @sherlo/* packages
5. The dev-regression workflow only runs yarn tester test which touches e2e/ code paths
6. tsconfig.json includes integration/**/*.ts but tsx runs on-demand (no pre-compilation), so missing types won't cause errors for unused code

## Implementation (1 File)

### File: .github/workflows/dev-regression.yml

Add a step BEFORE yarn install that strips portal deps from package.json. Use node (available after setup-node) to parse package.json, delete all dependency entries whose value starts with portal:, and write it back. The step should use node -e with fs.readFileSync/writeFileSync to read package.json, iterate Object.entries(pkg.dependencies), delete any where String(v).startsWith('portal:'), then write back with JSON.stringify(pkg, null, 2). This runs after checkout and setup-node but before yarn install.

## What NOT to Change

- Do NOT modify package.json permanently, portal deps must remain for local development
- Do NOT download S3 packages, E2E tests don't need @sherlo/* at all
- Do NOT change tsconfig.json or any test code
- Do NOT modify any other workflow or infra file

## Verification

1. Trigger the dev-regression workflow manually from GitHub Actions
2. Verify yarn install succeeds without sherlo-api
3. Verify yarn tester env setup dev completes
4. Verify E2E tests start executing (even if they fail for env reasons, install must pass)
5. Verify local yarn install still works with portal deps

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
