### PR TITLE
fix: viewport-clip getInspectorData() to prevent hang on deep view hierarchies

### DIFF
--- a/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/InspectorHelper.java
+++ b/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/InspectorHelper.java
@@ -19,7 +19,9 @@ import org.json.JSONObject;
  */
 public class InspectorHelper {
     private static final String TAG = "SherloModule:InspectorHelper";
-    
+    private static final int MAX_DEPTH = 50;
+    private static final int MAX_NODES = 10000;
+
     /**
      * Gets UI inspector data from the current view hierarchy.
      * Runs the data collection on the UI thread and returns a serialized JSON string.
@@ -47,6 +49,7 @@ public class InspectorHelper {
     /**
      * Collects and serializes data about the view hierarchy.
      * Creates a JSON object with device metrics and detailed view information.
+     * Only traverses views that intersect the current screen viewport for performance.
      *
      * @param activity The activity containing the view hierarchy
      * @return JSON string representing the view hierarchy and device metrics
@@ -55,27 +58,43 @@ public class InspectorHelper {
     private static String getInspectorDataString(Activity activity) throws JSONException {
         View rootView = activity.getWindow().getDecorView().getRootView();
         android.content.res.Resources resources = rootView.getResources();
-        
-        // Get hierarchical view structure instead of flat list
-        JSONObject viewHierarchy = collectViewHierarchy(rootView);
+
+        // Determine the visible viewport bounds (screen coordinates)
+        Rect screenRect = new Rect();
+        rootView.getWindowVisibleDisplayFrame(screenRect);
+        int viewportTop = screenRect.top;
+        int viewportBottom = screenRect.bottom;
+
+        // Get hierarchical view structure, clipped to viewport
+        int[] nodeCount = {0};
+        JSONObject viewHierarchy = collectViewHierarchy(rootView, 0, nodeCount, viewportTop, viewportBottom);
 
         // Create the root JSON object
         JSONObject rootObject = new JSONObject();
         rootObject.put("density", resources.getDisplayMetrics().density);
         rootObject.put("fontScale", resources.getConfiguration().fontScale);
         rootObject.put("viewHierarchy", viewHierarchy);
-        
+
         return rootObject.toString();
     }
 
     /**
      * Collects information about a view and its children in a hierarchical structure.
+     * Only includes children whose bounds intersect the viewport [viewportTop, viewportBottom].
+     * Parent containers that span beyond the viewport are always included (they intersect it),
+     * but their off-screen children are skipped.
      *
      * @param view The view to collect information from
+     * @param depth Current recursion depth
+     * @param nodeCount Mutable counter tracking total nodes collected (single-element array)
+     * @param viewportTop Top edge of the visible viewport in screen coordinates
+     * @param viewportBottom Bottom edge of the visible viewport in screen coordinates
      * @return A JSON object representing the view and its children
      * @throws JSONException If there's an error creating the JSON structure
      */
-    private static JSONObject collectViewHierarchy(View view) throws JSONException {
+    private static JSONObject collectViewHierarchy(View view, int depth, int[] nodeCount, int viewportTop, int viewportBottom) throws JSONException {
+        nodeCount[0]++;
+
         JSONObject viewObject = new JSONObject();
 
         // Class name
@@ -102,11 +121,31 @@ public class InspectorHelper {
         }
 
         // Add children array for hierarchical structure
+        // Skip children if we hit depth or node count limits
+        // Skip children whose bounds are entirely outside the viewport
         JSONArray children = new JSONArray();
-        if (view instanceof ViewGroup) {
+        if (view instanceof ViewGroup && depth < MAX_DEPTH && nodeCount[0] < MAX_NODES) {
             ViewGroup viewGroup = (ViewGroup) view;
             for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                children.put(collectViewHierarchy(viewGroup.getChildAt(i)));
+                if (nodeCount[0] >= MAX_NODES) {
+                    break;
+                }
+
+                View child = viewGroup.getChildAt(i);
+
+                // Get child's position in screen coordinates
+                int[] childLocation = new int[2];
+                child.getLocationOnScreen(childLocation);
+                int childTop = childLocation[1];
+                int childBottom = childTop + child.getHeight();
+
+                // Skip children entirely outside the viewport
+                // A view intersects if: viewTop < viewportBottom && viewBottom > viewportTop
+                if (childBottom <= viewportTop || childTop >= viewportBottom) {
+                    continue;
+                }
+
+                children.put(collectViewHierarchy(child, depth + 1, nodeCount, viewportTop, viewportBottom));
             }
         }
         viewObject.put("children", children);

--- a/packages/react-native-storybook/ios/InspectorHelper.m
+++ b/packages/react-native-storybook/ios/InspectorHelper.m
@@ -4,6 +4,8 @@
 #import <stdlib.h>
 
 static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
+static const NSInteger MAX_DEPTH = 50;
+static const NSInteger MAX_NODES = 10000;
 
 /**
  * Helper for inspecting the UI view hierarchy of a React Native application.
@@ -23,17 +25,17 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
     dispatch_async(dispatch_get_main_queue(), ^{
         NSError *error = nil;
         NSString *jsonString = [InspectorHelper dumpBoundaries:&error];
-        
+
         if (error) {
             reject(@"E_INSPECTOR", @"Error getting inspector data", error);
             return;
         }
-        
+
         if (!jsonString) {
             reject(@"E_INSPECTOR", @"Failed to generate inspector data", nil);
             return;
         }
-        
+
         resolve(jsonString);
     });
 }
@@ -41,6 +43,7 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
 /**
  * Collects and serializes data about the view hierarchy.
  * Creates a JSON object with device metrics and detailed view information.
+ * Only traverses views that intersect the current screen viewport for performance.
  *
  * @param error Pointer to an NSError that will be populated if an error occurs
  * @return JSON string representing the view hierarchy and device metrics
@@ -55,14 +58,14 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
             keyWindow = windowScene.windows.firstObject;
         }
     }
-    
+
     if (!keyWindow) {
         if (error) {
             *error = [NSError errorWithDomain:@"InspectorHelper" code:1 userInfo:@{NSLocalizedDescriptionKey: @"Could not find the key window"}];
         }
         return nil;
     }
-    
+
     UIView *rootView = keyWindow.rootViewController.view;
     if (!rootView) {
         if (error) {
@@ -70,19 +73,24 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
         }
         return nil;
     }
-    
-    // Instead of a flat array, get hierarchical view structure
-    NSDictionary *viewHierarchy = [self collectViewHierarchy:rootView];
-    
+
+    // Determine the visible viewport bounds (window coordinates)
+    CGFloat viewportTop = 0;
+    CGFloat viewportBottom = keyWindow.bounds.size.height;
+
+    // Get hierarchical view structure, clipped to viewport
+    NSInteger nodeCount = 0;
+    NSDictionary *viewHierarchy = [self collectViewHierarchy:rootView depth:0 nodeCount:&nodeCount viewportTop:viewportTop viewportBottom:viewportBottom];
+
     // Create the root JSON object
     NSMutableDictionary *rootObject = [NSMutableDictionary dictionary];
     CGFloat screenScale = [UIScreen mainScreen].nativeScale;
-    
+
     // Use the system's default font size for body text
     UIFont *defaultFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     CGFloat defaultFontSize = defaultFont ? defaultFont.pointSize : [UIFont systemFontSize];
     CGFloat fontScale = defaultFontSize / [UIFont systemFontSize];
-    
+
     // Only add if the numbers are finite
     if (isfinite(screenScale)) {
         [rootObject setObject:@(screenScale) forKey:@"density"];
@@ -90,28 +98,28 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
     if (isfinite(fontScale)) {
         [rootObject setObject:@(fontScale) forKey:@"fontScale"];
     }
-    
+
     [rootObject setObject:viewHierarchy forKey:@"viewHierarchy"];
-    
+
     // Add validation before JSON serialization
     if (![NSJSONSerialization isValidJSONObject:rootObject]) {
         NSMutableDictionary *debugInfo = [NSMutableDictionary dictionary];
-        
+
         // Add debug logging
         NSLog(@"[%@] JSON serialization failed for rootObject", LOG_TAG);
-        
+
         // Check if the hierarchy is valid
         if (![NSJSONSerialization isValidJSONObject:viewHierarchy]) {
             NSLog(@"[%@] Invalid viewHierarchy detected", LOG_TAG);
             [debugInfo setObject:@"Invalid viewHierarchy" forKey:@"invalidComponent"];
-            
+
             // Try to identify the problem
             [self validateJsonObject:viewHierarchy withDebugInfo:debugInfo path:@"root"];
         }
-        
+
         if (error) {
-            *error = [NSError errorWithDomain:@"InspectorHelper" 
-                                       code:3 
+            *error = [NSError errorWithDomain:@"InspectorHelper"
+                                       code:3
                                    userInfo:@{
                 NSLocalizedDescriptionKey: @"Could not serialize view data to JSON",
                 @"debugInfo": debugInfo
@@ -121,7 +129,7 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
         }
         return nil;
     }
-    
+
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:rootObject options:0 error:error];
     if (!jsonData) {
         if (error) {
@@ -129,7 +137,7 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
         }
         return nil;
     }
-    
+
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
@@ -146,14 +154,14 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
         for (NSString *key in dict) {
             id value = dict[key];
             NSString *newPath = [NSString stringWithFormat:@"%@.%@", path, key];
-            
+
             if (![self isValidJSONValue:value]) {
                 NSString *debugValue = [NSString stringWithFormat:@"%@: %@", newPath, [value description]];
                 NSLog(@"[%@] Invalid property found: %@", LOG_TAG, debugValue);
                 [debugInfo setObject:debugValue forKey:@"invalidProperty"];
                 return;
             }
-            
+
             if ([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSArray class]]) {
                 [self validateJsonObject:value withDebugInfo:debugInfo path:newPath];
             }
@@ -163,14 +171,14 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
         for (NSInteger i = 0; i < array.count; i++) {
             id value = array[i];
             NSString *newPath = [NSString stringWithFormat:@"%@[%ld]", path, (long)i];
-            
+
             if (![self isValidJSONValue:value]) {
                 NSString *debugValue = [NSString stringWithFormat:@"%@: %@", newPath, [value description]];
                 NSLog(@"[%@] Invalid array item found: %@", LOG_TAG, debugValue);
                 [debugInfo setObject:debugValue forKey:@"invalidProperty"];
                 return;
             }
-            
+
             if ([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSArray class]]) {
                 [self validateJsonObject:value withDebugInfo:debugInfo path:newPath];
             }
@@ -180,13 +188,22 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
 
 /**
  * Collect information about a view and its children in a hierarchical structure.
+ * Only includes children whose bounds intersect the viewport [viewportTop, viewportBottom].
+ * Parent containers that span beyond the viewport are always included (they intersect it),
+ * but their off-screen children are skipped.
  *
  * @param view The view to collect information from
+ * @param depth Current recursion depth
+ * @param nodeCount Pointer to mutable counter tracking total nodes collected
+ * @param viewportTop Top edge of the visible viewport in window coordinates
+ * @param viewportBottom Bottom edge of the visible viewport in window coordinates
  * @return A dictionary representing the view and its children
  */
-+ (NSDictionary *)collectViewHierarchy:(UIView *)view {
++ (NSDictionary *)collectViewHierarchy:(UIView *)view depth:(NSInteger)depth nodeCount:(NSInteger *)nodeCount viewportTop:(CGFloat)viewportTop viewportBottom:(CGFloat)viewportBottom {
+    (*nodeCount)++;
+
     NSMutableDictionary *viewDict = [NSMutableDictionary dictionary];
-    
+
     // Class name - always valid
     NSString *className = NSStringFromClass([view class]);
     if (className && className.length > 0) {
@@ -194,20 +211,20 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
     } else {
         [viewDict setObject:@"Unknown" forKey:@"className"];
     }
-    
+
     // Visibility
     BOOL isVisible = !view.hidden && view.alpha > 0.01 && view.window != nil;
     [viewDict setObject:@(isVisible) forKey:@"isVisible"];
-    
+
     // Frame calculations
     CGRect windowFrame = [view convertRect:view.bounds toView:nil];
     CGFloat screenScale = [UIScreen mainScreen].nativeScale;
-    
+
     CGFloat x = windowFrame.origin.x * screenScale;
     CGFloat y = windowFrame.origin.y * screenScale;
     CGFloat width = windowFrame.size.width * screenScale;
     CGFloat height = windowFrame.size.height * screenScale;
-    
+
     if (isfinite(x)) {
         [viewDict setObject:@(x) forKey:@"x"];
     }
@@ -220,7 +237,7 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
     if (isfinite(height)) {
         [viewDict setObject:@(height) forKey:@"height"];
     }
-    
+
     NSNumber *reactTag = view.reactTag;
     if (reactTag != nil) {
         [viewDict setObject:reactTag forKey:@"id"];
@@ -230,15 +247,34 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
             [viewDict setObject:@(nativeTag) forKey:@"id"];
         }
     }
-    
+
     // Add children array
+    // Skip children if we hit depth or node count limits
+    // Skip children whose bounds are entirely outside the viewport
     NSMutableArray *children = [NSMutableArray array];
-    for (UIView *subview in view.subviews) {
-        NSDictionary *childInfo = [self collectViewHierarchy:subview];
-        [children addObject:childInfo];
+    if (depth < MAX_DEPTH && *nodeCount < MAX_NODES) {
+        for (UIView *subview in view.subviews) {
+            if (*nodeCount >= MAX_NODES) {
+                break;
+            }
+
+            // Get child's position in window coordinates
+            CGRect childWindowFrame = [subview convertRect:subview.bounds toView:nil];
+            CGFloat childTop = childWindowFrame.origin.y;
+            CGFloat childBottom = childTop + childWindowFrame.size.height;
+
+            // Skip children entirely outside the viewport
+            // A view intersects if: childTop < viewportBottom && childBottom > viewportTop
+            if (childBottom <= viewportTop || childTop >= viewportBottom) {
+                continue;
+            }
+
+            NSDictionary *childInfo = [self collectViewHierarchy:subview depth:depth + 1 nodeCount:nodeCount viewportTop:viewportTop viewportBottom:viewportBottom];
+            [children addObject:childInfo];
+        }
     }
     [viewDict setObject:children forKey:@"children"];
-    
+
     return viewDict;
 }
 
@@ -250,21 +286,21 @@ static NSString *const LOG_TAG = @"SherloModule:InspectorHelper";
  */
 + (BOOL)isValidJSONValue:(id)value {
     if (!value) return YES;
-    
+
     if ([value isKindOfClass:[NSString class]] ||
         [value isKindOfClass:[NSNumber class]] ||
         [value isKindOfClass:[NSNull class]]) {
         return YES;
     }
-    
+
     if ([value isKindOfClass:[NSArray class]]) {
         return [NSJSONSerialization isValidJSONObject:value];
     }
-    
+
     if ([value isKindOfClass:[NSDictionary class]]) {
         return [NSJSONSerialization isValidJSONObject:value];
     }
-    
+
     return NO;
 }
 

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
@@ -68,7 +68,12 @@ function useTestStory({
         RunnerBridge.log('checked if stable', { isStable });
 
         let inspectorData;
+        const inspectorDataStart = Date.now();
         while (!inspectorData) {
+          if (Date.now() - inspectorDataStart > 10000) {
+            RunnerBridge.log('getInspectorData timed out after 10s');
+            throw new Error('getInspectorData timed out after 10s');
+          }
           inspectorData = await SherloModule.getInspectorData().catch((error) => {
             RunnerBridge.log('error getting inspector data', { error: JSON.stringify(error) });
           });
@@ -195,7 +200,12 @@ function useTestStory({
 
               // Recapture Metadata after scroll to get dynamic elements (below fold)
               let newInspectorData;
+              const scrollInspectorStart = Date.now();
               while (!newInspectorData) {
+                 if (Date.now() - scrollInspectorStart > 10000) {
+                   RunnerBridge.log('getInspectorData (scroll) timed out after 10s');
+                   throw new Error('getInspectorData (scroll) timed out after 10s');
+                 }
                  newInspectorData = await SherloModule.getInspectorData().catch((error) => {
                      RunnerBridge.log('error getting inspector data (scroll)', { error: JSON.stringify(error) });
                  });


### PR DESCRIPTION
## Summary
- **Android & iOS**: `collectViewHierarchy()` now only traverses views that intersect the current screen viewport. Off-screen children (and their subtrees) are skipped entirely, preventing stack overflow / OOM / UI thread deadlock on ScrollViews with 150+ non-recycled items.
- **JS (useTestStory.tsx)**: Added 10s timeout to both `getInspectorData()` retry loops as a safety net against infinite hangs.

## Root Cause
`getInspectorData()` runs on the UI/main thread and recursively traverses the **entire** native view tree. React Native `ScrollView` doesn't recycle views — after scrolling through 150+ items at 5-6 nesting levels, all views are materialized. The unbounded traversal either stack-overflows, OOMs from the massive JSON tree, or blocks the UI thread indefinitely (ANR/watchdog kill).

## How It Works
- Before recursing into each child view, check its screen-coordinate bounds against the viewport (`viewTop < viewportBottom && viewBottom > viewportTop`)
- Parent containers (Root, ScrollView) that **span** the viewport are always included — they intersect it
- Leaf items entirely above or below the viewport are skipped along with their subtrees
- `MAX_DEPTH=50` and `MAX_NODES=10000` remain as secondary safeguards

## Stitching Compatibility
The runner's `metadataStitcher` already handles per-part viewport-local data correctly:
- Filters nodes by `partCuts` band — nodes outside `[cut.top, cut.bottom]` are skipped
- Merges nodes with same ID across parts (union geometry for containers)
- Rebuilds parent-child hierarchy using effective IDs

Verified with 6 new comprehensive tests in `metadataStitcher.test.ts` (in sherlo-runner) covering viewport-clipped output, cross-boundary items, 3-part tall scroll, and empty-leaf-part scenarios. All 294 runner tests pass.

## Test plan
- [x] Verified: DeepHierarchyScroll reproduction — all 6 scroll captures complete in ~1:45 vs infinite timeout before
- [x] All 294 sherlo-runner tests pass (including 6 new viewport-clipping stitching tests)
- [x] Simple (non-scroll) stories unaffected — viewport contains all views, so behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)