### PR TITLE
feat: CLI init triggers false 'has not finished' warnings and lose…

### DIFF
--- a/packages/cli/src/commands/init/config/config.ts
+++ b/packages/cli/src/commands/init/config/config.ts
@@ -32,7 +32,7 @@ async function config({ sessionId, token }: { sessionId: string | null; token?: 
   } catch (error) {
     await trackProgress({
       event: EVENT,
-      params: { status: 'failed', error: (error as Error).message },
+      params: { status: 'failed', error },
       sessionId,
     });
     throw error;

--- a/packages/cli/src/commands/init/config/config.ts
+++ b/packages/cli/src/commands/init/config/config.ts
@@ -10,24 +10,33 @@ async function config({ sessionId, token }: { sessionId: string | null; token?: 
 
   let configValue, hasAddedDefaultDevices, action;
 
-  if (!hasConfigFile()) {
-    ({ createdConfig: configValue, hasAddedDefaultDevices } = await createConfig(token));
+  try {
+    if (!hasConfigFile()) {
+      ({ createdConfig: configValue, hasAddedDefaultDevices } = await createConfig(token));
 
-    action = 'created';
-  } else {
-    ({ updatedConfig: configValue, hasAddedDefaultDevices } = await updateConfig(token));
+      action = 'created';
+    } else {
+      ({ updatedConfig: configValue, hasAddedDefaultDevices } = await updateConfig(token));
 
-    action = 'updated';
+      action = 'updated';
+    }
+
+    const configWithoutToken = { ...configValue };
+    delete configWithoutToken.token;
+
+    await trackProgress({
+      event: EVENT,
+      params: { action, configWithoutToken },
+      sessionId,
+    });
+  } catch (error) {
+    await trackProgress({
+      event: EVENT,
+      params: { status: 'failed', error: (error as Error).message },
+      sessionId,
+    });
+    throw error;
   }
-
-  const configWithoutToken = { ...configValue };
-  delete configWithoutToken.token;
-
-  await trackProgress({
-    event: EVENT,
-    params: { action, configWithoutToken },
-    sessionId,
-  });
 
   if (hasAddedDefaultDevices) {
     console.log();

--- a/packages/cli/src/commands/init/dependencies/dependencies.ts
+++ b/packages/cli/src/commands/init/dependencies/dependencies.ts
@@ -1,19 +1,34 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { getCwd } from '../../../helpers';
-import { printTitle } from '../helpers';
-import { IOS_DIR } from './constants';
+import { printTitle, trackProgress } from '../helpers';
+import { EVENT, IOS_DIR } from './constants';
 import installPods from './installPods';
 import installSherlo from './installSherlo';
 
 async function dependencies({ sessionId }: { sessionId: string | null }) {
   printTitle('💾 Dependencies');
 
-  await installSherlo(sessionId);
+  try {
+    await installSherlo();
 
-  if (iosDirectoryWithPodfileExists()) {
-    await installPods(sessionId);
+    if (iosDirectoryWithPodfileExists()) {
+      await installPods();
+    }
+  } catch (error) {
+    await trackProgress({
+      event: EVENT,
+      params: { status: 'failed', error },
+      sessionId,
+    });
+    throw error;
   }
+
+  await trackProgress({
+    event: EVENT,
+    params: { status: 'success' },
+    sessionId,
+  });
 }
 
 export default dependencies;

--- a/packages/cli/src/commands/init/dependencies/installPods.ts
+++ b/packages/cli/src/commands/init/dependencies/installPods.ts
@@ -2,13 +2,10 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { FULL_INIT_COMMAND } from '../../../constants';
 import { getCwd, runShellCommand, throwError } from '../../../helpers';
-import { trackProgress } from '../helpers';
-import { EVENT, IOS_DIR } from './constants';
+import { IOS_DIR } from './constants';
 
-async function installPods(sessionId: string | null): Promise<void> {
+async function installPods(): Promise<void> {
   const spinner = ora('Installing Pods').start();
-
-  const event = `${EVENT}:installPods`;
 
   const command = `cd ${IOS_DIR} && pod install`;
 
@@ -22,12 +19,6 @@ async function installPods(sessionId: string | null): Promise<void> {
 
     console.log();
 
-    await trackProgress({
-      event,
-      params: { status: 'failed', error: (error as Error).message },
-      sessionId,
-    });
-
     throwError({
       message:
         'Failed to install Pods automatically\n' +
@@ -36,18 +27,12 @@ async function installPods(sessionId: string | null): Promise<void> {
         chalk.cyan(`  ${command}\n`) +
         '\n' +
         chalk.reset('Then re-run:\n') +
-        chalk.cyan(`  ${FULL_INIT_COMMAND}\n`),
+        chalk.cyan(`  ${FULL_INIT_COMMAND}`),
       errorToReport: error,
     });
   }
 
   spinner.succeed('Installed Pods');
-
-  await trackProgress({
-    event,
-    params: { status: 'success' },
-    sessionId,
-  });
 }
 
 export default installPods;

--- a/packages/cli/src/commands/init/dependencies/installPods.ts
+++ b/packages/cli/src/commands/init/dependencies/installPods.ts
@@ -24,7 +24,7 @@ async function installPods(sessionId: string | null): Promise<void> {
 
     await trackProgress({
       event,
-      params: { status: 'failed:command_error' },
+      params: { status: 'failed', error: (error as Error).message },
       sessionId,
     });
 

--- a/packages/cli/src/commands/init/dependencies/installSherlo.ts
+++ b/packages/cli/src/commands/init/dependencies/installSherlo.ts
@@ -45,10 +45,7 @@ async function installSherlo(sessionId: string | null): Promise<void> {
   const resolvedCommand = resolveCommand(
     packageManager,
     'add',
-    [
-      isSherloAlreadyInDevDependencies ? '-D' : null,
-      packageSpec,
-    ].filter(Boolean) as string[]
+    [isSherloAlreadyInDevDependencies ? '-D' : null, packageSpec].filter(Boolean) as string[]
   );
 
   if (!resolvedCommand) {
@@ -67,8 +64,9 @@ async function installSherlo(sessionId: string | null): Promise<void> {
 
   try {
     await runShellCommand({
-      command: `YARN_ENABLE_IMMUTABLE_INSTALLS=false ${commandToRun}`,
+      command: commandToRun,
       projectRoot: getCwd(),
+      env: packageManager === 'yarn' ? { YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' } : undefined,
     });
   } catch (error) {
     spinner.fail();
@@ -80,16 +78,6 @@ async function installSherlo(sessionId: string | null): Promise<void> {
       params: { status: 'failed', error: (error as Error).message },
       sessionId,
     });
-
-    // Log full error for debugging
-    if (error instanceof Error) {
-      console.error('[DEBUG installSherlo]', {
-        message: error.message,
-        stdout: (error as any).stdout,
-        stderr: (error as any).stderr,
-        code: (error as any).code,
-      });
-    }
 
     throwError({
       message:

--- a/packages/cli/src/commands/init/dependencies/installSherlo.ts
+++ b/packages/cli/src/commands/init/dependencies/installSherlo.ts
@@ -77,7 +77,7 @@ async function installSherlo(sessionId: string | null): Promise<void> {
 
     await trackProgress({
       event,
-      params: { status: 'failed:command_error' },
+      params: { status: 'failed', error: (error as Error).message },
       sessionId,
     });
 

--- a/packages/cli/src/commands/init/dependencies/installSherlo.ts
+++ b/packages/cli/src/commands/init/dependencies/installSherlo.ts
@@ -5,13 +5,9 @@ import { detect, resolveCommand } from 'package-manager-detector';
 import { join } from 'path';
 import { FULL_INIT_COMMAND, SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../../constants';
 import { getCwd, getErrorWithCustomMessage, runShellCommand, throwError } from '../../../helpers';
-import { trackProgress } from '../helpers';
-import { EVENT } from './constants';
 
-async function installSherlo(sessionId: string | null): Promise<void> {
+async function installSherlo(): Promise<void> {
   const spinner = ora('Installing Sherlo').start();
-
-  const event = `${EVENT}:installSherlo`;
 
   let packageJson;
   const packageJsonPath = join(getCwd(), 'package.json');
@@ -73,12 +69,6 @@ async function installSherlo(sessionId: string | null): Promise<void> {
 
     console.log();
 
-    await trackProgress({
-      event,
-      params: { status: 'failed', error: (error as Error).message },
-      sessionId,
-    });
-
     throwError({
       message:
         'Failed to install Sherlo automatically\n' +
@@ -87,18 +77,12 @@ async function installSherlo(sessionId: string | null): Promise<void> {
         chalk.cyan(`  ${commandToRun}\n`) +
         '\n' +
         chalk.reset('Then re-run:\n') +
-        chalk.cyan(`  ${FULL_INIT_COMMAND}\n`),
+        chalk.cyan(`  ${FULL_INIT_COMMAND}`),
       errorToReport: error,
     });
   }
 
   spinner.succeed('Installed Sherlo');
-
-  await trackProgress({
-    event,
-    params: { status: 'success' },
-    sessionId,
-  });
 }
 
 export default installSherlo;

--- a/packages/cli/src/commands/init/helpers/trackProgress.ts
+++ b/packages/cli/src/commands/init/helpers/trackProgress.ts
@@ -19,7 +19,7 @@ async function trackProgress({
   const { apiToken, projectIndex, teamId } = token ? getTokenParts(token) : {};
 
   const stringifiedParams = JSON.stringify(params ?? {}, (_, value) =>
-    typeof value === 'string' ? stripAnsi(value) : value
+    typeof value === 'string' ? stripAnsi(value).trim() : value
   );
 
   return sdkClient({ authToken: apiToken })

--- a/packages/cli/src/commands/init/helpers/trackProgress.ts
+++ b/packages/cli/src/commands/init/helpers/trackProgress.ts
@@ -1,5 +1,5 @@
 import sdkClient from '@sherlo/sdk-client';
-import { getTokenParts, reporting } from '../../../helpers';
+import { getTokenParts, reporting, stripAnsi } from '../../../helpers';
 
 async function trackProgress({
   event,
@@ -18,10 +18,14 @@ async function trackProgress({
 }): Promise<{ sessionId: string | null }> {
   const { apiToken, projectIndex, teamId } = token ? getTokenParts(token) : {};
 
+  const stringifiedParams = JSON.stringify(params ?? {}, (_, value) =>
+    typeof value === 'string' ? stripAnsi(value) : value
+  );
+
   return sdkClient({ authToken: apiToken })
     .trackCliInit({
       event,
-      stringifiedParams: JSON.stringify(params ?? {}),
+      stringifiedParams,
       hasStarted,
       hasFinished,
       sessionId,

--- a/packages/cli/src/commands/init/helpers/trackProgress.ts
+++ b/packages/cli/src/commands/init/helpers/trackProgress.ts
@@ -18,6 +18,15 @@ async function trackProgress({
 }): Promise<{ sessionId: string | null }> {
   const { apiToken, projectIndex, teamId } = token ? getTokenParts(token) : {};
 
+  if (params && params.error instanceof Error) {
+    const errorObj = params.error as Error & { cause?: unknown };
+    params = {
+      ...params,
+      error: errorObj.message,
+      ...(errorObj.cause ? { cause: errorObj.cause } : {}),
+    };
+  }
+
   const stringifiedParams = JSON.stringify(params ?? {}, (_, value) =>
     typeof value === 'string' ? stripAnsi(value).trim() : value
   );

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -20,8 +20,6 @@ async function init({ token }: Options<THIS_COMMAND>) {
 
   printSherloIntro();
 
-  console.log('Initializing Sherlo in your project...');
-
   await requirements({ token, sessionId });
 
   await dependencies({ sessionId });

--- a/packages/cli/src/commands/init/requirements/requirements.ts
+++ b/packages/cli/src/commands/init/requirements/requirements.ts
@@ -1,7 +1,9 @@
 import ora from 'ora';
+import chalk from 'chalk';
 import {
   APP_DOMAIN,
   EXPO_PACKAGE_NAME,
+  FULL_INIT_COMMAND,
   REACT_NATIVE_PACKAGE_NAME,
   STORYBOOK_REACT_NATIVE_PACKAGE_NAME,
   TOKEN_OPTION,
@@ -26,6 +28,8 @@ async function requirements({ token, sessionId }: { token?: string; sessionId: s
     });
     throw error;
   }
+
+  console.log('Initializing Sherlo in your project...');
 
   printTitle('✅ Requirements', 15);
 
@@ -73,12 +77,14 @@ async function validateRequirements(token?: string): Promise<void> {
         message:
           `Invalid \`--${TOKEN_OPTION}\`. Make sure you copied it correctly or generate a new one at ` +
           printLink(APP_DOMAIN),
+        below:
+          '\n' +
+          chalk.reset('Then re-run:\n') +
+          chalk.cyan(`  ${FULL_INIT_COMMAND}`),
         errorToReport: new Error('Invalid token: ' + token),
       });
     }
   } catch (error) {
-    console.log();
-
     throw error;
   }
 }

--- a/packages/cli/src/commands/init/requirements/requirements.ts
+++ b/packages/cli/src/commands/init/requirements/requirements.ts
@@ -6,11 +6,7 @@ import {
   STORYBOOK_REACT_NATIVE_PACKAGE_NAME,
   TOKEN_OPTION,
 } from '../../../constants';
-import {
-  isValidToken,
-  printLink,
-  throwError,
-} from '../../../helpers';
+import { isValidToken, printLink, throwError } from '../../../helpers';
 import { printMessage, printTitle, trackProgress } from '../helpers';
 import { EVENT } from './constants';
 import getPackageVersion from './getPackageVersion';

--- a/packages/cli/src/commands/init/requirements/requirements.ts
+++ b/packages/cli/src/commands/init/requirements/requirements.ts
@@ -21,7 +21,7 @@ async function requirements({ token, sessionId }: { token?: string; sessionId: s
   } catch (error) {
     await trackProgress({
       event: EVENT,
-      params: { status: 'failed', error: (error as Error).message },
+      params: { status: 'failed', error },
       sessionId,
     });
     throw error;

--- a/packages/cli/src/commands/init/requirements/requirements.ts
+++ b/packages/cli/src/commands/init/requirements/requirements.ts
@@ -75,7 +75,9 @@ async function validateRequirements(token?: string): Promise<void> {
     if (token && !isValidToken(token)) {
       throwError({
         message:
-          `Invalid \`--${TOKEN_OPTION}\`. Make sure you copied it correctly or generate a new one at ` +
+          `Invalid \`--${TOKEN_OPTION}\` value\n` +
+          '\n' +
+          chalk.reset('Make sure you copied it correctly or generate a new one at ') +
           printLink(APP_DOMAIN),
         below:
           '\n' +

--- a/packages/cli/src/commands/init/requirements/requirements.ts
+++ b/packages/cli/src/commands/init/requirements/requirements.ts
@@ -20,7 +20,16 @@ import validateHasStorybook from './validateHasStorybook';
 import validateProjectContext from './validateProjectContext';
 
 async function requirements({ token, sessionId }: { token?: string; sessionId: string | null }) {
-  await validateRequirements(token);
+  try {
+    await validateRequirements(token);
+  } catch (error) {
+    await trackProgress({
+      event: EVENT,
+      params: { status: 'failed', error: (error as Error).message },
+      sessionId,
+    });
+    throw error;
+  }
 
   printTitle('✅ Requirements', 15);
 

--- a/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/getPackageErrorMessage.ts
+++ b/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/getPackageErrorMessage.ts
@@ -16,9 +16,9 @@ function getPackageErrorMessage(params: Params) {
   }
 
   return (
-    `\`${params.packageName}\` version \`${params.versions.current}\` is not supported (requires ≥\`${params.versions.min}\`)\n` +
+    `\`${params.packageName}\` version ${params.versions.current} is not supported (requires ≥${params.versions.min})\n` +
     '\n' +
-    chalk.reset(`Please upgrade \`${params.packageName}\` to version \`${params.versions.min}\` or higher`)
+    chalk.reset(`Please upgrade \`${params.packageName}\` to version ${params.versions.min} or higher`)
   );
 }
 

--- a/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/getPackageErrorMessage.ts
+++ b/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/getPackageErrorMessage.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 type Params =
   | (BaseParams & { type: 'missing' })
   | (BaseParams & { type: 'version'; versions: { current: string; min: string } });
@@ -7,16 +9,16 @@ type BaseParams = { packageName: string };
 function getPackageErrorMessage(params: Params) {
   if (params.type === 'missing') {
     return (
-      `\`${params.packageName}\` package is not installed` +
-      '\n\n' +
-      `Please install \`${params.packageName}\` using your package manager`
+      `\`${params.packageName}\` package is not installed\n` +
+      '\n' +
+      chalk.reset(`Please install \`${params.packageName}\` using your package manager`)
     );
   }
 
   return (
-    `\`${params.packageName}\` version \`${params.versions.current}\` is not supported (requires ≥\`${params.versions.min}\`)` +
-    '\n\n' +
-    `Please upgrade \`${params.packageName}\` to version \`${params.versions.min}\` or higher`
+    `\`${params.packageName}\` version \`${params.versions.current}\` is not supported (requires ≥\`${params.versions.min}\`)\n` +
+    '\n' +
+    chalk.reset(`Please upgrade \`${params.packageName}\` to version \`${params.versions.min}\` or higher`)
   );
 }
 

--- a/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/validatePackageRequirement.ts
+++ b/packages/cli/src/commands/init/requirements/validateCorePackagesVersions/validatePackageRequirement.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+import { FULL_INIT_COMMAND } from '../../../../constants';
 import { isPackageVersionCompatible, throwError } from '../../../../helpers';
 import getPackageVersion from '../getPackageVersion';
 import getPackageErrorMessage from './getPackageErrorMessage';
@@ -7,12 +9,18 @@ function validatePackageRequirement(requirement: PackageRequirement) {
   const { packageName, minVersion } = requirement;
   const version = getPackageVersion(packageName);
 
+  const below =
+    '\n' +
+    chalk.reset('Then re-run:\n') +
+    chalk.cyan(`  ${FULL_INIT_COMMAND}`);
+
   if (!version) {
     throwError({
       message: getPackageErrorMessage({
         packageName,
         type: 'missing',
       }),
+      below,
     });
   }
 
@@ -32,6 +40,7 @@ function validatePackageRequirement(requirement: PackageRequirement) {
           min: minVersion,
         },
       }),
+      below,
     });
   }
 

--- a/packages/cli/src/commands/init/requirements/validateHasReactNative.ts
+++ b/packages/cli/src/commands/init/requirements/validateHasReactNative.ts
@@ -1,4 +1,5 @@
-import { REACT_NATIVE_PACKAGE_NAME } from '../../../constants';
+import chalk from 'chalk';
+import { FULL_INIT_COMMAND, REACT_NATIVE_PACKAGE_NAME } from '../../../constants';
 import { throwError } from '../../../helpers';
 import findPackageJsonPaths from './findPackageJsonPaths';
 import hasDependency from './hasDependency';
@@ -12,11 +13,13 @@ async function validateHasReactNative(): Promise<void> {
 
   if (!hasReactNative) {
     throwError({
-      message: (
-        `\`${REACT_NATIVE_PACKAGE_NAME}\` package is not installed` +
-        '\n\n' +
-        `Please install \`${REACT_NATIVE_PACKAGE_NAME}\` using your package manager`
-      ),
+      message:
+        `\`${REACT_NATIVE_PACKAGE_NAME}\` package is not installed\n` +
+        '\n' +
+        chalk.reset('Please install it using your package manager\n') +
+        '\n' +
+        chalk.reset('Then re-run:\n') +
+        chalk.cyan(`  ${FULL_INIT_COMMAND}`),
     });
   }
 }

--- a/packages/cli/src/commands/init/requirements/validateHasStorybook.ts
+++ b/packages/cli/src/commands/init/requirements/validateHasStorybook.ts
@@ -1,4 +1,5 @@
-import { STORYBOOK_REACT_NATIVE_PACKAGE_NAME } from '../../../constants';
+import chalk from 'chalk';
+import { FULL_INIT_COMMAND, STORYBOOK_REACT_NATIVE_PACKAGE_NAME } from '../../../constants';
 import { throwError } from '../../../helpers';
 import findPackageJsonPaths from './findPackageJsonPaths';
 import hasDependency from './hasDependency';
@@ -14,6 +15,10 @@ async function validateHasStorybook(): Promise<void> {
     throwError({
       message: 'Set up Storybook before initializing Sherlo',
       learnMoreLink: 'https://github.com/storybookjs/react-native',
+      below:
+        '\n' +
+        chalk.reset('Then re-run:\n') +
+        chalk.cyan(`  ${FULL_INIT_COMMAND}`),
     });
   }
 }

--- a/packages/cli/src/commands/init/storybookComponent/updateStorybookComponent.ts
+++ b/packages/cli/src/commands/init/storybookComponent/updateStorybookComponent.ts
@@ -8,7 +8,17 @@ import updateStorybookFiles from './updateStorybookFiles';
 async function updateStorybookComponent(
   sessionId: string | null
 ): Promise<{ hasUpdatedStorybookComponent: boolean }> {
-  const storybookFiles = await getStorybookFiles();
+  let storybookFiles;
+  try {
+    storybookFiles = await getStorybookFiles();
+  } catch (error) {
+    await trackProgress({
+      event: EVENT,
+      params: { status: 'failed', error: (error as Error).message },
+      sessionId,
+    });
+    throw error;
+  }
 
   const alreadyUpdatedFilePaths = storybookFiles
     .filter(({ isUpdated }) => isUpdated)
@@ -26,7 +36,16 @@ async function updateStorybookComponent(
     .map(({ filePath }) => filePath);
 
   if (notUpdatedFilePaths.length > 0) {
-    await updateStorybookFiles(notUpdatedFilePaths);
+    try {
+      await updateStorybookFiles(notUpdatedFilePaths);
+    } catch (error) {
+      await trackProgress({
+        event: EVENT,
+        params: { status: 'failed', error: (error as Error).message },
+        sessionId,
+      });
+      throw error;
+    }
 
     notUpdatedFilePaths.forEach((filePath) => {
       printMessage({

--- a/packages/cli/src/commands/init/storybookComponent/updateStorybookComponent.ts
+++ b/packages/cli/src/commands/init/storybookComponent/updateStorybookComponent.ts
@@ -14,7 +14,7 @@ async function updateStorybookComponent(
   } catch (error) {
     await trackProgress({
       event: EVENT,
-      params: { status: 'failed', error: (error as Error).message },
+      params: { status: 'failed', error },
       sessionId,
     });
     throw error;
@@ -41,7 +41,7 @@ async function updateStorybookComponent(
     } catch (error) {
       await trackProgress({
         event: EVENT,
-        params: { status: 'failed', error: (error as Error).message },
+        params: { status: 'failed', error },
         sessionId,
       });
       throw error;

--- a/packages/cli/src/commands/init/testing/testing.ts
+++ b/packages/cli/src/commands/init/testing/testing.ts
@@ -32,6 +32,7 @@ async function testing(sessionId: string | null): Promise<void> {
   await trackProgress({
     event: EVENT,
     params: { seen: true },
+    hasFinished: true,
     sessionId,
   });
 }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -66,7 +66,7 @@ export const TEST_STANDARD_COMMAND = 'test:standard';
 export const TEST_EAS_UPDATE_COMMAND = 'test:eas-update';
 export const TEST_EAS_CLOUD_BUILD_COMMAND = 'test:eas-cloud-build';
 export const EAS_BUILD_ON_COMPLETE_COMMAND = 'eas-build-on-complete';
-export const FULL_INIT_COMMAND = 'npx sherlo@latest init';
+export const FULL_INIT_COMMAND = 'npx sherlo init';
 
 /* OPTIONS */
 

--- a/packages/cli/src/helpers/runShellCommand/executeCommand.ts
+++ b/packages/cli/src/helpers/runShellCommand/executeCommand.ts
@@ -7,10 +7,12 @@ function executeCommand({
   command,
   projectRoot,
   encoding,
+  env,
 }: {
   command: string;
   projectRoot: string;
   encoding: 'utf8' | 'buffer';
+  env?: NodeJS.ProcessEnv;
 }): Promise<string | Buffer> {
   return new Promise((resolve, reject) => {
     const options: {
@@ -21,7 +23,7 @@ function executeCommand({
     } = {
       cwd: projectRoot,
       maxBuffer: 1 * 1024 * 1024 * 1024, // 1GB max buffer - very safe limit
-      env: { ...process.env, FORCE_COLOR: 'true' },
+      env: { ...process.env, FORCE_COLOR: 'true', ...env },
     };
 
     // Set encoding only if it's 'utf8', for 'buffer' we don't set it to get Buffer output

--- a/packages/cli/src/helpers/runShellCommand/runShellCommand.ts
+++ b/packages/cli/src/helpers/runShellCommand/runShellCommand.ts
@@ -5,6 +5,7 @@ interface Options {
   command: string;
   projectRoot: string;
   encoding?: 'utf8' | 'buffer';
+  env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -18,9 +19,10 @@ async function runShellCommand({
   command,
   projectRoot,
   encoding = 'utf8',
+  env,
 }: Options): Promise<string | Buffer> {
   try {
-    return await executeCommand({ command, projectRoot, encoding });
+    return await executeCommand({ command, projectRoot, encoding, env });
   } catch (error) {
     if (
       error instanceof Error &&
@@ -32,6 +34,7 @@ async function runShellCommand({
         command,
         projectRoot,
         encoding,
+        env,
       });
     }
 

--- a/packages/cli/src/helpers/runShellCommand/tryToFixPermissionAndRetryOnce.ts
+++ b/packages/cli/src/helpers/runShellCommand/tryToFixPermissionAndRetryOnce.ts
@@ -11,11 +11,13 @@ async function tryToFixPermissionAndRetryOnce({
   command,
   projectRoot,
   encoding,
+  env,
 }: {
   error: Error & { stderr?: string };
   command: string;
   projectRoot: string;
   encoding: 'utf8' | 'buffer';
+  env?: NodeJS.ProcessEnv;
 }): Promise<string | Buffer> {
   const filePath = extractFilePath(error.stderr || '');
 
@@ -27,7 +29,7 @@ async function tryToFixPermissionAndRetryOnce({
       throw error;
     }
 
-    return await executeCommand({ command, projectRoot, encoding });
+    return await executeCommand({ command, projectRoot, encoding, env });
   }
 
   // If we couldn't extract a valid path, throw the original error

--- a/packages/cli/src/helpers/throwError.ts
+++ b/packages/cli/src/helpers/throwError.ts
@@ -23,8 +23,14 @@ type ErrorType = 'default' | 'auth' | 'unexpected';
 function throwError(params: Params): never {
   reportError(params);
 
-  const error: Error & { skipReporting?: boolean } = new Error(getErrorMessage(params));
+  const error: Error & { skipReporting?: boolean; cause?: Error } = new Error(getErrorMessage(params));
   error.skipReporting = true; // Error has been already reported above
+
+  if (params.type === 'unexpected') {
+    error.cause = params.error;
+  } else if ('errorToReport' in params && params.errorToReport) {
+    error.cause = params.errorToReport;
+  }
 
   throw error;
 }

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -11,7 +11,7 @@ Main package for [Sherlo](https://github.com/sherlo-io/sherlo) - Visual Testing 
 ### 1. Initialize Sherlo
 
 ```bash
-npx sherlo@latest init
+npx sherlo init
 ```
 
 This will automatically install `@sherlo/react-native-storybook` and configure your project.

--- a/testing/expo/package.json
+++ b/testing/expo/package.json
@@ -64,7 +64,7 @@
     "@storybook/addon-ondevice-backgrounds": "^9.1.2",
     "@storybook/addon-ondevice-controls": "^9.1.2",
     "@storybook/addon-ondevice-notes": "^9.1.2",
-    "@storybook/react-native": "999.0.0",
+    "@storybook/react-native": "^9.1.2",
     "@types/lodash": "^4",
     "babel-loader": "^8.2.3",
     "burnt": "^0.13.0",

--- a/testing/expo/package.json
+++ b/testing/expo/package.json
@@ -64,7 +64,7 @@
     "@storybook/addon-ondevice-backgrounds": "^9.1.2",
     "@storybook/addon-ondevice-controls": "^9.1.2",
     "@storybook/addon-ondevice-notes": "^9.1.2",
-    "@storybook/react-native": "^9.1.2",
+    "@storybook/react-native": "999.0.0",
     "@types/lodash": "^4",
     "babel-loader": "^8.2.3",
     "burnt": "^0.13.0",


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-938

Fixes false CLI Init has not finished Slack warnings and adds structured error tracking with cause chain. Unified try-catch pattern across all init steps, auto-extract error message and cause in trackProgress, strip ANSI codes, YARN_ENABLE_IMMUTABLE_INSTALLS via env option, added Then re-run hints to all errors, moved Initializing message after requirements, improved error formatting. 19 files changed, all error paths manually tested.

## Test Plan

All error paths manually verified: no package.json, monorepo root, missing react-native, missing storybook, old version, invalid token, yarn add fail, pod install fail, storybook component not found, config read fail, happy path
