### PR TITLE
feat: Suppress Android scroll indicators during screenshot capture

### DIFF
--- a/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
+++ b/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
@@ -262,6 +262,10 @@ public class SherloModuleCore {
             return createScrollResult(true, 0, 0, 0, 0);
         }
 
+        // Suppress scroll indicators for the duration of testing
+        candidate.setVerticalScrollBarEnabled(false);
+        candidate.setHorizontalScrollBarEnabled(false);
+
         // 2. Compute Metrics
         int viewportPx = candidate.getHeight();
         
@@ -404,6 +408,10 @@ public class SherloModuleCore {
         if (SCROLL_DEBUG) {
             Log.d(TAG, "isScrollable: Candidate found via " + selectionMethod + ", class: " + candidate.getClass().getSimpleName());
         }
+
+        // Suppress scroll indicators for the duration of testing
+        candidate.setVerticalScrollBarEnabled(false);
+        candidate.setHorizontalScrollBarEnabled(false);
 
         // Metric-based scrollability check
         if (isScrollableByMetrics(candidate)) {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-982

## TL;DR

Android's native scroll bars flash during programmatic scrollBy() calls in scrollToCheckpoint and the isScrollable nudge fallback, causing scroll indicators to appear in captured screenshots. Disable scroll bars on the candidate view before any scroll operations on Android. iOS is unaffected (setContentOffset:animated:NO doesn't trigger indicators).

## Acceptance Criteria

- Scroll indicators (vertical + horizontal) are disabled on the Android scroll candidate immediately after it's found, before any scroll operations — in both isScrollable and performScrollToCheckpoint
- No save/restore of previous state needed
- No changes to iOS code
- Scroll indicator is not visible in screenshots of scrollable stories (verified on a Pixel device)

## Additional Context

### Context

Investigation of Build 132 (project ui.spaceship, team Spaceship) on `pixel.7.pro-13-light-en_US` shows a visible scroll indicator in the screenshot for `shared-etoro-link-spaceship-account-view--tcs-deviceHeight`.

The SDK already has a smart metric-first approach in `isScrollable` to avoid triggering indicators, but:

- The nudge fallback path has no suppression
- `scrollToCheckpoint` (used for long-screenshot stitching) has zero indicator suppression

### Fix locations

- `SherloModuleCore.java` — `performScrollToCheckpoint()` (~line 253): disable indicators on candidate after finding it
- `SherloModuleCore.java` — `isScrollable()` (~line 416): disable indicators on candidate after finding it

Use `candidate.setVerticalScrollBarEnabled(false)` and `candidate.setHorizontalScrollBarEnabled(false)` — these are `android.view.View` methods, no reflection needed.

### Risk note

`setVerticalScrollBarEnabled(false)` calls `resolvePadding()` internally. This only causes layout shift if scrollbar style is `insideInset` (not the default). React Native uses overlay scrollbars, so no padding change expected. Call it early so Android has a full frame to settle before screenshot capture.

### Scope

This only affects Sherlo's testing mode (`SherloModuleCore`). Normal Storybook browsing is unaffected — these native methods are never called outside testing.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
