### PR TITLE
feat: CI builds fail — yarn.lock out of sync with published sherlo…

### DIFF
--- a/testing/expo/yarn.lock
+++ b/testing/expo/yarn.lock
@@ -2419,7 +2419,7 @@ __metadata:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.1"
+    sherlo: "npm:^1.6.2-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"

--- a/testing/react-native/yarn.lock
+++ b/testing/react-native/yarn.lock
@@ -4145,7 +4145,7 @@ __metadata:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.1"
+    sherlo: "npm:^1.6.2-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-987

## TL;DR

The 'Sherlo Builds' CI workflow fails on both iOS and Android at the 'Install project dependencies' step. Yarn runs with --immutable in CI, and the lockfile in the sherlo repo (apps/expo-development, apps/rn-development) still pins sherlo@^1.6.1 while the npm registry now resolves the ^1.6.1 range to 1.6.2-alpha.1 (a new pre-release was published). The lockfile diff shows the mismatch and Yarn exits with YN0028. Fix: run yarn install locally to regenerate the lockfile and commit it.

## Acceptance Criteria

- yarn.lock in the sherlo repo reflects the currently published sherlo package version (1.6.2-alpha.1) so that yarn install --immutable passes without modifications
- CI 'Sherlo Builds' workflow completes the 'Install project dependencies' step successfully on both iOS and Android jobs

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
