### PR TITLE
feat: Scroll detection picks wrong ScrollView and stitching breaks…

### DIFF
--- a/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
+++ b/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
@@ -184,32 +184,38 @@ public class SherloModuleCore {
     private static final float NUDGE_PX = 3.0f;
     private static final float MIN_SCROLL_RANGE_RATIO = 0.20f; // Minimum 20% of viewport height
 
+    // Locked scroll view from isScrollable(), reused by scrollToCheckpoint()
+    private View lockedScrollView = null;
+
     /**
      * Detects if the currently visible screen can be vertically scrolled for long-screenshot capture.
-     * Uses read-only view inspection: finds a primary scroll container, checks scroll metrics,
-     * and validates with a small programmatic nudge that is immediately restored.
+     * Resolves with a map: {scrollable: boolean, scrollViewFrame?: {x, y, width, height}} in physical pixels.
      *
      * @param activity The current activity
-     * @param promise Promise to resolve with boolean (true if scrollable, false otherwise)
+     * @param promise Promise to resolve with the result map
      */
     public void isScrollable(Activity activity, Promise promise) {
         if (activity == null) {
             if (SCROLL_DEBUG) {
                 Log.d(TAG, "isScrollable: No activity");
             }
-            promise.resolve(false);
+            WritableMap noResult = Arguments.createMap();
+            noResult.putBoolean("scrollable", false);
+            promise.resolve(noResult);
             return;
         }
 
         activity.runOnUiThread(() -> {
             try {
-                boolean result = detectScrollableView(activity);
+                WritableMap result = detectScrollableView(activity);
                 promise.resolve(result);
             } catch (Exception e) {
                 if (SCROLL_DEBUG) {
                     Log.e(TAG, "isScrollable exception", e);
                 }
-                promise.resolve(false);
+                WritableMap noResult = Arguments.createMap();
+                noResult.putBoolean("scrollable", false);
+                promise.resolve(noResult);
             }
         });
     }
@@ -225,7 +231,7 @@ public class SherloModuleCore {
      */
     public void scrollToCheckpoint(Activity activity, double index, double offset, double maxIndex, Promise promise) {
         if (activity == null) {
-            promise.resolve(createScrollResult(true, 0, 0, 0, 0));
+            promise.resolve(createScrollResult(true, 0, 0, 0, 0, null));
             return;
         }
 
@@ -237,29 +243,20 @@ public class SherloModuleCore {
                 if (SCROLL_DEBUG) {
                     Log.e(TAG, "scrollToCheckpoint exception", e);
                 }
-                promise.resolve(createScrollResult(true, 0, 0, 0, 0));
+                promise.resolve(createScrollResult(true, 0, 0, 0, 0, null));
             }
         });
     }
 
     private WritableMap performScrollToCheckpoint(Activity activity, int index, int offsetPx, int maxIndex) {
-        View decorView = activity.getWindow().getDecorView();
-        if (decorView == null) {
-            return createScrollResult(true, 0, 0, 0, 0);
-        }
+        // 1. Use locked scroll view from isScrollable() - no re-detection
+        View candidate = lockedScrollView;
 
-        // 1. Select Candidate
-        // Reuse the logic from isScrollable
-        View candidate = findScrollableViewViaProbe(decorView);
-        if (candidate == null) {
-            candidate = findLargestVisibleScrollableView(decorView);
-        }
-
-        if (candidate == null) {
+        if (candidate == null || candidate.getWindowToken() == null) {
             if (SCROLL_DEBUG) {
-                Log.d(TAG, "scrollToCheckpoint: No candidate found");
+                Log.d(TAG, "scrollToCheckpoint: No locked candidate found");
             }
-            return createScrollResult(true, 0, 0, 0, 0);
+            return createScrollResult(true, 0, 0, 0, 0, null);
         }
 
         // Suppress scroll indicators for the duration of testing
@@ -268,29 +265,17 @@ public class SherloModuleCore {
 
         // 2. Compute Metrics
         int viewportPx = candidate.getHeight();
-        
-        // Use reflection to fail gracefully if protected method fails
+
         int range = getScrollRangeViaReflection(candidate);
-        
-        // If reflection failed, try fallback or just return what we have
         if (range <= 0) {
-             // Fallback: assume some content logic or just return basic
-             // If we can't get range, we can't reliably scroll to max
-             if (SCROLL_DEBUG) {
-                 Log.d(TAG, "scrollToCheckpoint: Could not determine scroll range");
-             }
-             // We can still try to scroll if we have a target
+            if (SCROLL_DEBUG) {
+                Log.d(TAG, "scrollToCheckpoint: Could not determine scroll range");
+            }
         }
-        
-        // extent is viewport height usually
-        int extent = getScrollExtentViaReflection(candidate); 
-        // Note: computeVerticalScrollExtent is also protected
+
+        int extent = getScrollExtentViaReflection(candidate);
         if (extent <= 0) extent = viewportPx;
-        
-        // Max offset logic for Android: 
-        // range - extent = max scrollable offset
-        // If range is invalid, maybe we assume it's large?
-        // Let's rely on range from reflection.
+
         int maxOffsetPx = Math.max(0, range - extent);
         int minOffsetPx = 0;
 
@@ -305,58 +290,47 @@ public class SherloModuleCore {
         } else {
             targetPx = minOffsetPx + (clampedIndex * offsetPx);
         }
-        
-        // Clamp target
-        // If range was invalid (<=0), we might not want to clamp heavily or assume 0?
-        // If maxOffsetPx is 0, we can't scroll.
+
         int clampedPx = Math.max(minOffsetPx, Math.min(maxOffsetPx, targetPx));
-        
+
         // 4. Apply Scroll
         int currentOffset = getScrollOffsetViaReflection(candidate);
         int delta = clampedPx - currentOffset;
-        
+
         if (SCROLL_DEBUG) {
             Log.d(TAG, "scrollToCheckpoint: index=" + clampedIndex + ", target=" + targetPx + ", clamped=" + clampedPx + ", current=" + currentOffset + ", delta=" + delta);
         }
-        
+
         if (Math.abs(delta) > 0) {
             scrollViewBy(candidate, delta);
-            
-            // In a real scenario, we might want to wait for layout/scroll to settle.
-            // But requirement says apply immediately.
-            // Android scrollBy might be async in terms of UI update cycle, 
-            // but reading back immediately usually gives the "target" or "current" depending on impl.
-            // Let's read back.
         }
-        
+
         // 5. Read Back
         int actualOffsetPx = getScrollOffsetViaReflection(candidate);
-        
+
         // 6. Detect Bottom
         boolean reachedBottom = false;
         if (actualOffsetPx >= maxOffsetPx - EPSILON) {
             reachedBottom = true;
         }
         if (maxOffsetPx <= EPSILON) {
-            reachedBottom = true; // Not scrollable
-        }
-        
-        // Also if we tried to scroll down but offset didn't change, we might be stuck
-        if (delta > 0 && Math.abs(actualOffsetPx - currentOffset) < 1) {
-             // We tried to move but couldn't. Treat as bottom?
-             // Maybe. But strictly maxOffset check is safer.
+            reachedBottom = true;
         }
 
-        return createScrollResult(reachedBottom, clampedIndex, actualOffsetPx, viewportPx, range);
+        WritableMap frame = getScrollViewFrameInPixels(candidate);
+        return createScrollResult(reachedBottom, clampedIndex, actualOffsetPx, viewportPx, range, frame);
     }
 
-    private WritableMap createScrollResult(boolean reachedBottom, int appliedIndex, int appliedOffsetPx, int viewportPx, int contentPx) {
+    private WritableMap createScrollResult(boolean reachedBottom, int appliedIndex, int appliedOffsetPx, int viewportPx, int contentPx, WritableMap scrollViewFrame) {
         WritableMap map = Arguments.createMap();
         map.putBoolean("reachedBottom", reachedBottom);
         map.putInt("appliedIndex", appliedIndex);
         map.putInt("appliedOffsetPx", appliedOffsetPx);
         map.putInt("viewportPx", viewportPx);
         map.putInt("contentPx", contentPx);
+        if (scrollViewFrame != null) {
+            map.putMap("scrollViewFrame", scrollViewFrame);
+        }
         return map;
     }
 
@@ -377,179 +351,135 @@ public class SherloModuleCore {
     }
 
     /**
-     * Main detection logic for scrollable views.
+     * Main detection logic for scrollable views. Returns map with scrollable + optional scrollViewFrame.
      */
-    private boolean detectScrollableView(Activity activity) {
+    private WritableMap detectScrollableView(Activity activity) {
         View decorView = activity.getWindow().getDecorView();
+        WritableMap noResult = Arguments.createMap();
+        noResult.putBoolean("scrollable", false);
+
         if (decorView == null) {
             if (SCROLL_DEBUG) {
                 Log.d(TAG, "isScrollable: No decor view");
             }
-            return false;
+            return noResult;
         }
 
-        // Try probe-based detection first
-        View candidate = findScrollableViewViaProbe(decorView);
-        String selectionMethod = "probe-deepest";
+        // Reset lock for each new story detection
+        lockedScrollView = null;
 
-        // Fallback to largest visible scrollable view
-        if (candidate == null) {
-            candidate = findLargestVisibleScrollableView(decorView);
-            selectionMethod = "fallback-largest";
-        }
+        // BFS from root to find the best user-facing scrollable view
+        View candidate = findBestScrollViewBFS(decorView);
 
         if (candidate == null) {
             if (SCROLL_DEBUG) {
                 Log.d(TAG, "isScrollable: No scrollable candidate found");
             }
-            return false;
+            return noResult;
         }
 
         if (SCROLL_DEBUG) {
-            Log.d(TAG, "isScrollable: Candidate found via " + selectionMethod + ", class: " + candidate.getClass().getSimpleName());
+            Log.d(TAG, "isScrollable: Candidate found via BFS, class: " + candidate.getClass().getSimpleName());
         }
 
         // Suppress scroll indicators for the duration of testing
         candidate.setVerticalScrollBarEnabled(false);
         candidate.setHorizontalScrollBarEnabled(false);
 
-        // Metric-based scrollability check
-        if (isScrollableByMetrics(candidate)) {
+        boolean scrollable = isScrollableByMetrics(candidate);
+
+        if (!scrollable) {
+            scrollable = validateWithNudge(candidate);
             if (SCROLL_DEBUG) {
-                Log.d(TAG, "isScrollable: Metric check passed, skipping nudge validation to prevent transient scroll indicators.");
+                Log.d(TAG, "isScrollable: Nudge validation result: " + scrollable);
             }
+        } else {
+            if (SCROLL_DEBUG) {
+                Log.d(TAG, "isScrollable: Metric check passed");
+            }
+        }
+
+        if (!scrollable) {
+            return noResult;
+        }
+
+        // Lock the candidate for reuse in scrollToCheckpoint()
+        lockedScrollView = candidate;
+
+        WritableMap frame = getScrollViewFrameInPixels(candidate);
+        WritableMap result = Arguments.createMap();
+        result.putBoolean("scrollable", true);
+        result.putMap("scrollViewFrame", frame);
+        return result;
+    }
+
+    /**
+     * BFS traversal from root to find the largest user-facing vertically-scrollable view.
+     * Filters out framework-internal views and views covering < 10% of screen.
+     */
+    private View findBestScrollViewBFS(View root) {
+        int screenWidth = root.getWidth();
+        int screenHeight = root.getHeight();
+        int screenArea = screenWidth * screenHeight;
+        int minArea = screenArea / 10; // 10% threshold
+
+        View bestCandidate = null;
+        int bestArea = 0;
+
+        java.util.LinkedList<View> queue = new java.util.LinkedList<>();
+        queue.add(root);
+
+        while (!queue.isEmpty()) {
+            View view = queue.poll();
+
+            if (view.canScrollVertically(1) || view.canScrollVertically(-1)) {
+                if (view.getVisibility() == View.VISIBLE && !isFrameworkInternalScrollView(view)) {
+                    android.graphics.Rect rect = new android.graphics.Rect();
+                    if (view.getGlobalVisibleRect(rect)) {
+                        int area = rect.width() * rect.height();
+                        if (area >= minArea && isScrollableByMetrics(view) && area > bestArea) {
+                            bestArea = area;
+                            bestCandidate = view;
+                        }
+                    }
+                }
+            }
+
+            if (view instanceof android.view.ViewGroup) {
+                android.view.ViewGroup group = (android.view.ViewGroup) view;
+                for (int i = 0; i < group.getChildCount(); i++) {
+                    queue.add(group.getChildAt(i));
+                }
+            }
+        }
+
+        return bestCandidate;
+    }
+
+    /**
+     * Returns true if the view is a framework-internal view that should not be used as a scroll target.
+     */
+    private boolean isFrameworkInternalScrollView(View view) {
+        String className = view.getClass().getName();
+        // Android internal framework classes
+        if (className.startsWith("com.android.internal.")) {
             return true;
         }
-
-        // Fallback: Control validation: nudge and restore
-        // Only do this if metrics were inconclusive (e.g. reflection failed)
-        boolean nudgeResult = validateWithNudge(candidate);
-        if (SCROLL_DEBUG) {
-            Log.d(TAG, "isScrollable: Nudge validation result: " + nudgeResult);
-        }
-
-        return nudgeResult;
+        return false;
     }
 
     /**
-     * Find scrollable view using coordinate probe + deepest view at point.
+     * Returns the scroll view's frame in physical pixels (global screen coordinates).
      */
-    private View findScrollableViewViaProbe(View root) {
-        int rootWidth = root.getWidth();
-        int rootHeight = root.getHeight();
-
-        // Probe point: 50% width, 55% height (slightly below center to avoid nav headers)
-        int probeX = (int) (rootWidth * 0.5f);
-        int probeY = (int) (rootHeight * 0.55f);
-
-        View deepest = findDeepestViewAt(root, probeX, probeY);
-        if (deepest == null) {
-            // Try secondary probe at 70% height
-            probeY = (int) (rootHeight * 0.70f);
-            deepest = findDeepestViewAt(root, probeX, probeY);
-        }
-
-        if (deepest == null) {
-            return null;
-        }
-
-        // Walk up parent chain to find scrollable view
-        View current = deepest;
-        while (current != null) {
-            if (current.canScrollVertically(1) || current.canScrollVertically(-1)) {
-                return current;
-            }
-            if (current.getParent() instanceof View) {
-                current = (View) current.getParent();
-            } else {
-                break;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Find the deepest view at the given coordinates.
-     */
-    private View findDeepestViewAt(View parent, int x, int y) {
-        if (!(parent instanceof android.view.ViewGroup)) {
-            android.graphics.Rect rect = new android.graphics.Rect();
-            if (parent.getGlobalVisibleRect(rect) && rect.contains(x, y)) {
-                return parent;
-            }
-            return null;
-        }
-
-        android.view.ViewGroup group = (android.view.ViewGroup) parent;
-        
-        // Traverse children in reverse order (top-most first)
-        for (int i = group.getChildCount() - 1; i >= 0; i--) {
-            View child = group.getChildAt(i);
-            if (child.getVisibility() != View.VISIBLE) {
-                continue;
-            }
-
-            android.graphics.Rect rect = new android.graphics.Rect();
-            if (child.getGlobalVisibleRect(rect) && rect.contains(x, y)) {
-                View found = findDeepestViewAt(child, x, y);
-                if (found != null) {
-                    return found;
-                }
-                return child;
-            }
-        }
-
-        android.graphics.Rect parentRect = new android.graphics.Rect();
-        if (parent.getGlobalVisibleRect(parentRect) && parentRect.contains(x, y)) {
-            return parent;
-        }
-
-        return null;
-    }
-
-    /**
-     * Fallback: Find the largest visible scrollable view in the hierarchy.
-     */
-    private View findLargestVisibleScrollableView(View root) {
-        final View[] bestCandidate = {null};
-        final int[] bestArea = {0};
-
-        traverseViewHierarchy(root, view -> {
-            if (!(view.canScrollVertically(1) || view.canScrollVertically(-1))) {
-                return;
-            }
-
-            if (view.getVisibility() != View.VISIBLE) {
-                return;
-            }
-
-            android.graphics.Rect rect = new android.graphics.Rect();
-            if (!view.getGlobalVisibleRect(rect)) {
-                return;
-            }
-
-            int area = rect.width() * rect.height();
-            if (area > bestArea[0]) {
-                bestArea[0] = area;
-                bestCandidate[0] = view;
-            }
-        });
-
-        return bestCandidate[0];
-    }
-
-    /**
-     * Traverse view hierarchy recursively.
-     */
-    private void traverseViewHierarchy(View view, java.util.function.Consumer<View> visitor) {
-        visitor.accept(view);
-        if (view instanceof android.view.ViewGroup) {
-            android.view.ViewGroup group = (android.view.ViewGroup) view;
-            for (int i = 0; i < group.getChildCount(); i++) {
-                traverseViewHierarchy(group.getChildAt(i), visitor);
-            }
-        }
+    private WritableMap getScrollViewFrameInPixels(View view) {
+        android.graphics.Rect rect = new android.graphics.Rect();
+        view.getGlobalVisibleRect(rect);
+        WritableMap frame = Arguments.createMap();
+        frame.putInt("x", rect.left);
+        frame.putInt("y", rect.top);
+        frame.putInt("width", rect.width());
+        frame.putInt("height", rect.height());
+        return frame;
     }
 
     /**

--- a/packages/react-native-storybook/ios/SherloModuleCore.m
+++ b/packages/react-native-storybook/ios/SherloModuleCore.m
@@ -219,78 +219,88 @@ static FileSystemHelper *fileSystemHelper;
 // Debug flag for logging scroll detection
 static BOOL const SCROLL_DEBUG = YES;
 
+// Locked scroll view from isScrollable(), reused by scrollToCheckpoint()
+static UIScrollView *lockedScrollView = nil;
+
 /**
  * Detects if the currently visible screen has a vertically scrollable view suitable for long-screenshot capture.
+ * Resolves with a dictionary: {scrollable: BOOL, scrollViewFrame?: {x, y, width, height}} in physical pixels.
  */
 - (void)isScrollable:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
-            BOOL result = [self detectScrollableView];
-            resolve(@(result));
+            NSDictionary *result = [self detectScrollableView];
+            resolve(result);
         } @catch (NSException *exception) {
             if (SCROLL_DEBUG) {
                 NSLog(@"[%@] isScrollable exception: %@", LOG_TAG, exception);
             }
-            resolve(@(NO));
+            resolve(@{@"scrollable": @(NO)});
         }
     });
 }
 
 /**
- * Main detection logic for scrollable views.
+ * Main detection logic for scrollable views. Returns a result dict with scrollable + optional frame.
  */
-- (BOOL)detectScrollableView {
-    // Constants
+- (NSDictionary *)detectScrollableView {
     const CGFloat EPSILON = 4.0;
     const CGFloat NUDGE_PX = 3.0;
-    const CGFloat MIN_SCROLL_RANGE_RATIO = 0.20; // Minimum 20% of viewport height
+    const CGFloat MIN_SCROLL_RANGE_RATIO = 0.20;
 
-    // Get key window
+    // Reset lock for each new story detection
+    lockedScrollView = nil;
+
     UIWindow *keyWindow = [self getKeyWindow];
     if (!keyWindow) {
         if (SCROLL_DEBUG) {
             NSLog(@"[%@] isScrollable: No key window found", LOG_TAG);
         }
-        return NO;
+        return @{@"scrollable": @(NO)};
     }
 
-    // Try probe-based detection first
-    UIScrollView *candidate = [self findScrollViewViaProbe:keyWindow];
-    NSString *selectionMethod = @"probe-hitTest";
-
-    // Fallback to largest visible scroll view
-    if (!candidate) {
-        candidate = [self findLargestVisibleScrollView:keyWindow];
-        selectionMethod = @"fallback-largest";
-    }
+    // BFS from root to find the best user-facing scrollable view
+    UIScrollView *candidate = [self findBestScrollViewBFS:keyWindow];
 
     if (!candidate) {
         if (SCROLL_DEBUG) {
             NSLog(@"[%@] isScrollable: No scroll view candidate found", LOG_TAG);
         }
-        return NO;
+        return @{@"scrollable": @(NO)};
     }
 
     if (SCROLL_DEBUG) {
-        NSLog(@"[%@] isScrollable: Candidate found via %@, class: %@",
-              LOG_TAG, selectionMethod, NSStringFromClass([candidate class]));
+        NSLog(@"[%@] isScrollable: Candidate found via BFS, class: %@",
+              LOG_TAG, NSStringFromClass([candidate class]));
     }
 
     // Metric-based scrollability check
-    if ([self isScrollableByMetrics:candidate epsilon:EPSILON minRangeRatio:MIN_SCROLL_RANGE_RATIO]) {
+    BOOL scrollable = [self isScrollableByMetrics:candidate epsilon:EPSILON minRangeRatio:MIN_SCROLL_RANGE_RATIO];
+
+    if (!scrollable) {
+        // Fallback: nudge and restore
+        scrollable = [self validateWithNudge:candidate nudgePx:NUDGE_PX];
         if (SCROLL_DEBUG) {
-            NSLog(@"[%@] isScrollable: Metric check passed, skipping nudge validation to prevent transient scroll indicators.", LOG_TAG);
+            NSLog(@"[%@] isScrollable: Nudge validation result: %@", LOG_TAG, scrollable ? @"YES" : @"NO");
         }
-        return YES;
+    } else {
+        if (SCROLL_DEBUG) {
+            NSLog(@"[%@] isScrollable: Metric check passed", LOG_TAG);
+        }
     }
 
-    // Fallback: Control validation: nudge and restore
-    BOOL nudgeResult = [self validateWithNudge:candidate nudgePx:NUDGE_PX];
-    if (SCROLL_DEBUG) {
-        NSLog(@"[%@] isScrollable: Nudge validation result: %@", LOG_TAG, nudgeResult ? @"YES" : @"NO");
+    if (!scrollable) {
+        return @{@"scrollable": @(NO)};
     }
 
-    return nudgeResult;
+    // Lock the candidate for reuse in scrollToCheckpoint()
+    lockedScrollView = candidate;
+
+    NSDictionary *frame = [self getScrollViewFrameInPhysicalPixels:candidate window:keyWindow];
+    return @{
+        @"scrollable": @(YES),
+        @"scrollViewFrame": frame,
+    };
 }
 
 /**
@@ -316,98 +326,89 @@ static BOOL const SCROLL_DEBUG = YES;
 }
 
 /**
- * Find scroll view using coordinate probe + hitTest.
+ * BFS traversal from root to find the largest user-facing vertically-scrollable UIScrollView.
+ * Filters out framework-internal views (private _-prefixed classes) and views covering < 10% of screen.
  */
-- (UIScrollView *)findScrollViewViaProbe:(UIWindow *)window {
-    // Probe point: 50% width, 55% height (slightly below center to avoid nav headers)
-    CGPoint probePoint = CGPointMake(
-        window.bounds.size.width * 0.5,
-        window.bounds.size.height * 0.55
-    );
+- (UIScrollView *)findBestScrollViewBFS:(UIWindow *)window {
+    CGFloat screenArea = window.bounds.size.width * window.bounds.size.height;
+    CGFloat minArea = screenArea * 0.10;
 
-    UIView *hitView = [window hitTest:probePoint withEvent:nil];
-    if (!hitView) {
-        // Try secondary probe at 70% height
-        probePoint.y = window.bounds.size.height * 0.70;
-        hitView = [window hitTest:probePoint withEvent:nil];
-    }
+    UIScrollView *bestCandidate = nil;
+    CGFloat bestArea = 0;
 
-    if (!hitView) {
-        return nil;
-    }
+    NSMutableArray<UIView *> *queue = [NSMutableArray array];
+    UIView *root = window.rootViewController.view ?: window;
+    [queue addObject:root];
 
-    // Walk up superview chain to find vertically scrollable UIScrollView
-    UIView *current = hitView;
-    while (current) {
-        if ([current isKindOfClass:[UIScrollView class]]) {
-            UIScrollView *sv = (UIScrollView *)current;
-            // Use a very low threshold (epsilon) for candidate selection,
-            // as we just want to know if it's the right "kind" of scroll view.
-            if ([self isScrollableByMetrics:sv epsilon:1.0 minRangeRatio:0.01]) {
-                return sv;
+    while (queue.count > 0) {
+        UIView *view = queue[0];
+        [queue removeObjectAtIndex:0];
+
+        if ([view isKindOfClass:[UIScrollView class]]) {
+            UIScrollView *sv = (UIScrollView *)view;
+
+            BOOL isCandidate = YES;
+
+            // Must be visible, scroll-enabled, and in window
+            if (sv.hidden || sv.alpha < 0.01 || !sv.isScrollEnabled || !sv.window) {
+                isCandidate = NO;
+            }
+
+            // Filter framework-internal scroll views (Apple private classes start with '_')
+            if (isCandidate && [self isFrameworkInternalScrollView:sv]) {
+                isCandidate = NO;
+            }
+
+            if (isCandidate) {
+                CGRect frameInWindow = [sv convertRect:sv.bounds toView:window];
+                CGRect visible = CGRectIntersection(frameInWindow, window.bounds);
+
+                if (!CGRectIsNull(visible) && !CGRectIsEmpty(visible)) {
+                    CGFloat area = visible.size.width * visible.size.height;
+
+                    // Filter views covering less than 10% of screen
+                    if (area >= minArea && [self isScrollableByMetrics:sv epsilon:1.0 minRangeRatio:0.01]) {
+                        if (area > bestArea) {
+                            bestArea = area;
+                            bestCandidate = sv;
+                        }
+                    }
+                }
             }
         }
-        current = current.superview;
+
+        for (UIView *subview in view.subviews) {
+            [queue addObject:subview];
+        }
     }
-
-    return nil;
-}
-
-/**
- * Fallback: Find the largest visible UIScrollView in the hierarchy.
- */
-- (UIScrollView *)findLargestVisibleScrollView:(UIWindow *)window {
-    UIView *rootView = window.rootViewController.view;
-    if (!rootView) {
-        return nil;
-    }
-
-    __block UIScrollView *bestCandidate = nil;
-    __block CGFloat bestArea = 0;
-
-    [self traverseViewHierarchy:rootView block:^(UIView *view) {
-        if (![view isKindOfClass:[UIScrollView class]]) {
-            return;
-        }
-
-        UIScrollView *scrollView = (UIScrollView *)view;
-
-        // Check basic visibility
-        if (scrollView.hidden || scrollView.alpha < 0.01 || !scrollView.isScrollEnabled || !scrollView.window) {
-            return;
-        }
-
-        // Must be vertically scrollable to be a candidate for long screenshots
-        if (![self isScrollableByMetrics:scrollView epsilon:1.0 minRangeRatio:0.01]) {
-            return;
-        }
-
-        // Calculate visible intersection area
-        CGRect frameInWindow = [scrollView convertRect:scrollView.bounds toView:window];
-        CGRect intersection = CGRectIntersection(frameInWindow, window.bounds);
-
-        if (CGRectIsNull(intersection) || CGRectIsEmpty(intersection)) {
-            return;
-        }
-
-        CGFloat area = intersection.size.width * intersection.size.height;
-        if (area > bestArea) {
-            bestArea = area;
-            bestCandidate = scrollView;
-        }
-    }];
 
     return bestCandidate;
 }
 
 /**
- * Recursive hierarchy traversal.
+ * Returns YES if the scroll view is a framework-internal view that should not be used as a scroll target.
  */
-- (void)traverseViewHierarchy:(UIView *)view block:(void(^)(UIView *))block {
-    block(view);
-    for (UIView *subview in view.subviews) {
-        [self traverseViewHierarchy:subview block:block];
+- (BOOL)isFrameworkInternalScrollView:(UIScrollView *)scrollView {
+    NSString *className = NSStringFromClass([scrollView class]);
+    // Apple private classes use underscore prefix
+    if ([className hasPrefix:@"_"]) {
+        return YES;
     }
+    return NO;
+}
+
+/**
+ * Returns the scroll view's frame in physical pixels relative to the window origin.
+ */
+- (NSDictionary *)getScrollViewFrameInPhysicalPixels:(UIScrollView *)scrollView window:(UIWindow *)window {
+    CGFloat scale = [UIScreen mainScreen].scale;
+    CGRect frameInWindow = [scrollView convertRect:scrollView.bounds toView:window];
+    return @{
+        @"x": @(frameInWindow.origin.x * scale),
+        @"y": @(frameInWindow.origin.y * scale),
+        @"width": @(frameInWindow.size.width * scale),
+        @"height": @(frameInWindow.size.height * scale),
+    };
 }
 
 /**
@@ -538,20 +539,12 @@ static BOOL const SCROLL_DEBUG = YES;
 }
 
 - (NSDictionary *)performScrollToCheckpoint:(NSInteger)index offset:(double)offsetPx maxIndex:(NSInteger)maxIndex {
-    // 1. Select Candidate (reuse logic)
-    UIWindow *keyWindow = [self getKeyWindow];
-    UIScrollView *candidate = nil;
-    
-    if (keyWindow) {
-        candidate = [self findScrollViewViaProbe:keyWindow];
-        if (!candidate) {
-            candidate = [self findLargestVisibleScrollView:keyWindow];
-        }
-    }
-    
-    if (!candidate) {
+    // 1. Use locked scroll view from isScrollable() - no re-detection
+    UIScrollView *candidate = lockedScrollView;
+
+    if (!candidate || !candidate.window) {
         if (SCROLL_DEBUG) {
-            NSLog(@"[%@] scrollToCheckpoint: No candidate found", LOG_TAG);
+            NSLog(@"[%@] scrollToCheckpoint: No locked candidate found", LOG_TAG);
         }
         return @{
             @"reachedBottom": @(YES),
@@ -561,6 +554,8 @@ static BOOL const SCROLL_DEBUG = YES;
             @"contentPx": @(0)
         };
     }
+
+    UIWindow *keyWindow = [self getKeyWindow];
     
     // 2. Compute Metrics
     CGFloat scale = [UIScreen mainScreen].scale;
@@ -631,12 +626,15 @@ static BOOL const SCROLL_DEBUG = YES;
     // Also if we requested an index > 0 but couldn't move past previous checkpoint, 
     // it implies stuck or bottom. But strictly check bounds here.
     
+    NSDictionary *scrollViewFrame = [self getScrollViewFrameInPhysicalPixels:candidate window:keyWindow];
+
     return @{
         @"reachedBottom": @(reachedBottom),
         @"appliedIndex": @(clampedIndex),
         @"appliedOffsetPx": @(scrolledDistancePx), // Return relative scrolled distance
         @"viewportPx": @(viewportPt * scale),
-        @"contentPx": @(contentPt * scale)
+        @"contentPx": @(contentPt * scale),
+        @"scrollViewFrame": scrollViewFrame,
     };
 }
 

--- a/packages/react-native-storybook/src/SherloModule.ts
+++ b/packages/react-native-storybook/src/SherloModule.ts
@@ -31,7 +31,10 @@ type SherloModule = {
     threshold: number,
     includeAA: boolean
   ) => Promise<boolean>;
-  isScrollable: () => Promise<boolean>;
+  isScrollable: () => Promise<{
+    scrollable: boolean;
+    scrollViewFrame?: { x: number; y: number; width: number; height: number };
+  }>;
   scrollToCheckpoint: (
     index: number,
     offset: number,
@@ -42,6 +45,7 @@ type SherloModule = {
     appliedOffsetPx: number;
     viewportPx: number;
     contentPx: number;
+    scrollViewFrame?: { x: number; y: number; width: number; height: number };
   }>;
 };
 
@@ -179,7 +183,7 @@ function createDummySherloModule(): SherloModule {
     readFile: async () => '',
     openStorybook: () => {},
     toggleStorybook: () => {},
-    isScrollable: async () => false,
+    isScrollable: async () => ({ scrollable: false }),
     scrollToCheckpoint: async () => ({
       reachedBottom: true,
       appliedIndex: 0,

--- a/packages/react-native-storybook/src/__tests__/protocolTypes.test.ts
+++ b/packages/react-native-storybook/src/__tests__/protocolTypes.test.ts
@@ -73,9 +73,10 @@ describe('Protocol message construction', () => {
         isStable: true,
         requestId: 'req-123',
         hasNetworkImage: true,
-        isScrollable: false,
-        isAtEnd: true,
+        isScrollable: true,
+        isAtEnd: false,
         scrollOffset: 0,
+        scrollViewFrame: { x: 0, y: 100, width: 390, height: 700 },
         safeAreaMetadata: {
           shouldAddSafeArea: true,
           insetBottom: 102,
@@ -89,9 +90,10 @@ describe('Protocol message construction', () => {
       expect(msg.hasError).toBe(false);
       expect(msg.isStable).toBe(true);
       expect(msg.hasNetworkImage).toBe(true);
-      expect(msg.isScrollable).toBe(false);
-      expect(msg.isAtEnd).toBe(true);
+      expect(msg.isScrollable).toBe(true);
+      expect(msg.isAtEnd).toBe(false);
       expect(msg.scrollOffset).toBe(0);
+      expect(msg.scrollViewFrame).toEqual({ x: 0, y: 100, width: 390, height: 700 });
       expect(msg.safeAreaMetadata).toBeDefined();
     });
 

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
@@ -92,6 +92,7 @@ function useTestStory({
         let finalInspectorData = inspectorData;
         let hasNetworkImage = false;
         let isScrollable = false;
+        let scrollViewFrame: { x: number; y: number; width: number; height: number } | undefined;
         let safeAreaMetadata;
 
         if (!containsError) {
@@ -106,12 +107,15 @@ function useTestStory({
           }
 
           // Detect if the screen is scrollable for long-screenshot capture
-          isScrollable = await SherloModule.isScrollable().catch((error) => {
+          const scrollableResult = await SherloModule.isScrollable().catch((error) => {
             RunnerBridge.log('error checking if scrollable', { error: error.message });
-            return false;
+            return { scrollable: false, scrollViewFrame: undefined };
           });
 
-          RunnerBridge.log('checked if scrollable', { isScrollable });
+          isScrollable = scrollableResult.scrollable;
+          scrollViewFrame = scrollableResult.scrollViewFrame;
+
+          RunnerBridge.log('checked if scrollable', { isScrollable, scrollViewFrame });
 
           safeAreaMetadata = {
             shouldAddSafeArea: !nextSnapshot.parameters?.noSafeArea,
@@ -151,6 +155,7 @@ function useTestStory({
           hasNetworkImage,
           isAtEnd,
           scrollOffset: currentScrollOffset,
+          scrollViewFrame,
         });
 
         // Loop if runner requests more scrolling
@@ -240,11 +245,12 @@ function useTestStory({
             inspectorData: JSON.stringify(finalInspectorData),
             isStable: true, // We restabilized
             isScrollable,
-            requestId: currentRequestId, 
+            requestId: currentRequestId,
             safeAreaMetadata,
             hasNetworkImage,
             isAtEnd,
             scrollOffset: currentScrollOffset,
+            scrollViewFrame,
           });
         }
       } catch (error) {

--- a/packages/react-native-storybook/src/helpers/RunnerBridge/types.ts
+++ b/packages/react-native-storybook/src/helpers/RunnerBridge/types.ts
@@ -54,6 +54,7 @@ export type AppProtocolItem =
       isScrollable?: boolean;
       isAtEnd?: boolean;
       scrollOffset?: number;
+      scrollViewFrame?: { x: number; y: number; width: number; height: number };
       safeAreaMetadata?: {
         shouldAddSafeArea: boolean;
         insetBottom: number;

--- a/packages/react-native-storybook/src/specs/NativeSherloModule.ts
+++ b/packages/react-native-storybook/src/specs/NativeSherloModule.ts
@@ -17,7 +17,10 @@ export interface Spec extends TurboModule {
     threshold: number,
     includeAA: boolean
   ) => Promise<boolean>;
-  isScrollable: () => Promise<boolean>;
+  isScrollable: () => Promise<{
+    scrollable: boolean;
+    scrollViewFrame?: { x: number; y: number; width: number; height: number };
+  }>;
   scrollToCheckpoint: (
     index: number,
     offset: number,
@@ -28,6 +31,7 @@ export interface Spec extends TurboModule {
     appliedOffsetPx: number;
     viewportPx: number;
     contentPx: number;
+    scrollViewFrame?: { x: number; y: number; width: number; height: number };
   }>;
   getSherloConstants: () => {};
 }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1018

## TL;DR

The scrolling screenshot system always selects the innermost ScrollView (via a probe at a fixed screen coordinate) and stitches using hardcoded 25%/50%/25% viewport splits. For nested ScrollViews, the wrong view is captured — users see the inner scroll content instead of the main content scroll. For ScrollViews that occupy only part of the screen (e.g., inside a bottom sheet with a sticky footer), the crop regions don't align with the actual scrollable area, producing broken stitched images where static elements like footers are sliced and repeated. Additionally, scrollToCheckpoint re-probes on every call, so it can switch targets mid-capture. There is no test coverage for partial-screen scroll layouts.

## Acceptance Criteria

- Scroll detection selects the shallowest (outermost) scrollable view in the tree on both iOS and Android, not the innermost
- The detected scroll target is stable across all scroll checkpoint calls within a single story capture session — no target switching mid-capture
- isScrollable() and scrollToCheckpoint() return the ScrollView's screen-space frame (x, y, width, height in pixels) on both platforms
- REQUEST_SNAPSHOT protocol message includes scrollViewFrame field
- Runner stitching uses scrollViewFrame to define static top, scrollable band, and static bottom regions instead of hardcoded 25%/50%/25% splits
- A new test story exists in sherlo-tester integrated-app variants: a full-screen dimmed backdrop with a bottom sheet (~50-60% of screen), containing a ScrollView with enough content for 2-3 scroll captures, and a sticky footer button outside the ScrollView at the bottom of the sheet
- The bottom sheet test story produces a correctly stitched long screenshot where the backdrop appears once at top, scroll content is fully captured, and the sticky footer appears once at bottom

## Additional Context

## Current Architecture

### Detection (native module)

The app has a native module (`SherloModule`) with two key methods:

- `isScrollable()` — detects if there's a scrollable view on screen
- `scrollToCheckpoint(index, offsetPx, maxIndex)` — scrolls to a position and returns metrics

Detection works by doing a `hitTest` at a fixed screen coordinate (50% width, 55% height), finding the deepest view at that point, then walking UP the view hierarchy (superview chain on iOS, `getParent()` chain on Android) and picking the **first** UIScrollView/scrollable View it encounters — always the **innermost** one.

The probe has a fallback: if no scrollable ancestor is found at the probe point, it traverses the entire view hierarchy and picks the **largest visible scrollable view** by pixel area.

`scrollToCheckpoint` is stateless — it re-runs the probe logic every call, so it can switch to a different ScrollView mid-capture.

**Relevant native files:**

- iOS: `SherloModuleCore.m` — methods `detectScrollableView`, `findScrollViewViaProbe:`, `findLargestVisibleScrollView:`, `isScrollableByMetrics:`, `validateWithNudge:`
- Android: `SherloModuleCore.java` — methods `findScrollableViewViaProbe`, `findDeepestViewAt()`, scroll detection via `canScrollVertically()` and reflection into `computeVerticalScrollRange/Extent/Offset`

### What is a "story"?

A story is a single Storybook component rendered in isolation. Sherlo iterates through stories one at a time — for each story, it calls `isScrollable()` once, then if scrollable, enters a scroll loop calling `scrollToCheckpoint()` repeatedly. The story capture session ends when the runner signals done.

### Scrollability validation

iOS metric check: `scrollRange = contentSize.height + adjustedContentInset(top+bottom) - bounds.height`. Passes if `scrollRange > 4pt` AND `scrollRange >= 20% of viewport height`. Fallback: nudge validation — programmatically scroll 3px, check if offset changed >= 1pt, restore.

Android: `canScrollVertically(1) || canScrollVertically(-1)`. Reflection into protected `computeVerticalScrollRange()`, `computeVerticalScrollExtent()`, `computeVerticalScrollOffset()`. Falls back to boolean `canScrollVertically()` if reflection fails.

### Stitching (runner)

The runner receives full-viewport screenshots at each scroll position with metadata (`viewportPx`, `contentPx`, `appliedOffsetPx`). It stitches using hardcoded 25%/50%/25% top/middle/bottom splits:

- First part: top 25% + middle 50%
- Middle parts: middle 50% only
- Last part: middle 50% + bottom 25%

This assumes the ScrollView fills the entire viewport.

### Protocol

Orchestrated in `useTestStory.tsx`. App sends `REQUEST_SNAPSHOT` to runner via `RunnerBridge.send()` with fields: `isScrollable`, `isAtEnd`, `scrollOffset`, `inspectorData`, stability info. Runner responds with `ACK_SCROLL_REQUEST` (containing `scrollIndex`, `offsetPx`) or `ACK_REQUEST_SNAPSHOT` (done).

## What to Change

### Part 1: BFS-based detection (iOS + Android native)

Remove probe-based detection entirely:

- iOS: Remove `findScrollViewViaProbe:` and `findLargestVisibleScrollView:`
- Android: Remove `findScrollableViewViaProbe` and `findDeepestViewAt()`

Replace with BFS traversal from root:

1. Start from root view (`keyWindow.rootViewController.view` on iOS, `activity.getWindow().getDecorView()` on Android)
2. Traverse children level by level (BFS = shallowest-first)
3. Check each view with existing validation (metrics check + nudge fallback)
4. Filter out framework-internal scroll views: skip views with visible area < 10% of screen, skip known system classes (e.g., UINavigationController internal scroll views, UIInputSetHostView, Android's DecorView internal scrollers)
5. First passing view wins (outermost)
6. Tie-break at same depth: largest visible area

Lock the target: store native view reference from `isScrollable()`, reuse in `scrollToCheckpoint()`, clear on next `isScrollable()` call (which happens when the next story is loaded).

### Part 2: Dynamic scroll region

Native: both `isScrollable()` and `scrollToCheckpoint()` return `scrollViewFrame: { x, y, width, height }` in physical pixels.

- iOS: `convertRect:toView:nil` * `UIScreen.mainScreen.scale`
- Android: `getLocationOnScreen()` + `getWidth()`/`getHeight()`

Protocol: `REQUEST_SNAPSHOT` includes `scrollViewFrame`.

Runner stitching:

- Static top = pixels 0 to scrollViewFrame.y (captured once from first screenshot)
- Scrollable band = pixels scrollViewFrame.y to scrollViewFrame.y+height (cropped from each screenshot, stitched)
- Static bottom = pixels below scrollViewFrame.y+height (captured once from last screenshot)

Example: 1000px screen, bottom sheet ScrollView at y=400 height=500, sticky footer at y=900 height=100:

- Static top: 0-400px (dark backdrop) — once
- Scrollable band: 400-900px — stitched from each scroll capture
- Static bottom: 900-1000px (Confirm button) — once

### Part 3: Test story in sherlo-tester

Add a story to integrated-app variants rendering:

1. Full-screen dark/dimmed backdrop
2. Bottom sheet covering bottom ~50-60% of screen with rounded top corners
3. Inside sheet: header (icon + title), ScrollView with enough text/list content for 2-3 scroll captures
4. Sticky footer at bottom of sheet, OUTSIDE the ScrollView (e.g., a prominent button with padding)

This validates: correct detection of the inner ScrollView, correct static region preservation, sticky footer appears once in final image.

## Technical Notes

- Horizontal scrolling remains unsupported (vertical only)
- Max scroll index guardrail (50) and MAX_SCROLL_PARTS (~20) unchanged
- Nudge validation should be preserved as final check after BFS finds a candidate
- iOS uses points internally, converts to pixels for protocol; Android works in raw pixels. scrollViewFrame is always in physical pixels.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
