### PR TITLE
feat: Moving element detection broken for scrollable stories

### DIFF
--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
@@ -167,6 +167,8 @@ function useTestStory({
             currentRequestId = nextRequestId;
           }
 
+          let isStableAfterScroll = true;
+
           if (scrollIndex > 0) {
              // Scroll to target
              const scrollResult = await SherloModule.scrollToCheckpoint(
@@ -177,7 +179,7 @@ function useTestStory({
                RunnerBridge.log('error scrolling to checkpoint', { error: error.message });
                throw error;
              });
-             
+
              // Check if we reached bottom locally
              if (scrollResult.reachedBottom) {
                 RunnerBridge.log('reached bottom locally during scroll');
@@ -185,7 +187,7 @@ function useTestStory({
              }
 
              // Stabilize
-             const isStableAfterScroll = await SherloModule.stabilize(
+             isStableAfterScroll = await SherloModule.stabilize(
                 config.stabilization.requiredMatches,
                 config.stabilization.minScreenshotsCount,
                 config.stabilization.intervalMs,
@@ -197,7 +199,7 @@ function useTestStory({
                 RunnerBridge.log('error stabilizing after scroll', { error: error.message });
                 throw error;
               });
-              
+
               if (!isStableAfterScroll) {
                  RunnerBridge.log('warning: UI not stable after scroll');
               }
@@ -243,7 +245,7 @@ function useTestStory({
             action: 'REQUEST_SNAPSHOT',
             hasError: containsError,
             inspectorData: JSON.stringify(finalInspectorData),
-            isStable: true, // We restabilized
+            isStable: isStableAfterScroll,
             isScrollable,
             requestId: currentRequestId,
             safeAreaMetadata,


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1078

Fix Bug A: forwards actual isStableAfterScroll result in REQUEST_SNAPSHOT for scroll parts 1+ instead of hardcoding true. Moving elements below the fold are now correctly detected.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
