### PR TITLE
feat: Reproduce Android text shift bug in sherlo-tester

### DIFF
--- a/.github/workflows/release_to_test.yml
+++ b/.github/workflows/release_to_test.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build packages
         run: yarn build
+        env:
+          NX_SKIP_NX_CACHE: true
 
       - name: Prepare and publish to GitHub Packages
         run: |

--- a/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
+++ b/packages/react-native-storybook/android/src/main/java/io/sherlo/storybookreactnative/SherloModuleCore.java
@@ -12,7 +12,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
-
 // Java Utility and IO Imports
 import java.util.HashMap;
 import java.util.Map;

--- a/packages/react-native-storybook/android/src/newarch/java/io/sherlo/storybookreactnative/SherloModule.java
+++ b/packages/react-native-storybook/android/src/newarch/java/io/sherlo/storybookreactnative/SherloModule.java
@@ -156,4 +156,5 @@ public class SherloModule extends NativeSherloModuleSpec {
         Activity activity = getCurrentActivity();
         moduleCore.scrollToCheckpoint(activity, index, offset, maxIndex, promise);
     }
+
 } 

--- a/packages/react-native-storybook/android/src/oldarch/java/io/sherlo/storybookreactnative/SherloModule.java
+++ b/packages/react-native-storybook/android/src/oldarch/java/io/sherlo/storybookreactnative/SherloModule.java
@@ -158,4 +158,5 @@ public class SherloModule extends ReactContextBaseJavaModule {
         Activity activity = getCurrentActivity();
         moduleCore.scrollToCheckpoint(activity, index, offset, maxIndex, promise);
     }
+
 }

--- a/packages/react-native-storybook/ios/SherloModuleCore.m
+++ b/packages/react-native-storybook/ios/SherloModuleCore.m
@@ -638,4 +638,4 @@ static UIScrollView *lockedScrollView = nil;
     };
 }
 
-@end 
+@end

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/Storybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/Storybook.tsx
@@ -5,10 +5,8 @@ import { VERIFICATION_TEST_ID } from '../../../constants';
 import { StorybookParams, StorybookView } from '../../../types';
 import { getStorybookComponent, isStorybook7 } from '../../helpers';
 import { RunnerBridge } from '../../../helpers';
-import { useRef, useState, useEffect } from 'react';
+import { useRef } from 'react';
 import SherloModule from '../../../SherloModule';
-
-const FONT_GRACE_PERIOD_MS = 300;
 
 /**
  * We applied styles based on how they are defined in the link below to ensure that user's stories
@@ -31,12 +29,6 @@ function Storybook({
 }) {
   const insets = useSafeAreaInsets();
   const reportedSherloJSLoaded = useRef(false);
-
-  const [gracePeriodOver, setGracePeriodOver] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setGracePeriodOver(true), FONT_GRACE_PERIOD_MS);
-    return () => clearTimeout(timer);
-  }, []);
 
   const StorybookComponent = getStorybookComponent({
     view,
@@ -85,7 +77,7 @@ function Storybook({
   return (
     <View testID={VERIFICATION_TEST_ID} style={style}>
       <View style={{ flex: 1, overflow: 'hidden' }}>
-        {gracePeriodOver ? <StorybookComponent /> : null}
+        <StorybookComponent />
       </View>
     </View>
   );

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/Storybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/Storybook.tsx
@@ -5,8 +5,10 @@ import { VERIFICATION_TEST_ID } from '../../../constants';
 import { StorybookParams, StorybookView } from '../../../types';
 import { getStorybookComponent, isStorybook7 } from '../../helpers';
 import { RunnerBridge } from '../../../helpers';
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import SherloModule from '../../../SherloModule';
+
+const FONT_GRACE_PERIOD_MS = 300;
 
 /**
  * We applied styles based on how they are defined in the link below to ensure that user's stories
@@ -29,6 +31,12 @@ function Storybook({
 }) {
   const insets = useSafeAreaInsets();
   const reportedSherloJSLoaded = useRef(false);
+
+  const [gracePeriodOver, setGracePeriodOver] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setGracePeriodOver(true), FONT_GRACE_PERIOD_MS);
+    return () => clearTimeout(timer);
+  }, []);
 
   const StorybookComponent = getStorybookComponent({
     view,
@@ -77,7 +85,7 @@ function Storybook({
   return (
     <View testID={VERIFICATION_TEST_ID} style={style}>
       <View style={{ flex: 1, overflow: 'hidden' }}>
-        <StorybookComponent />
+        {gracePeriodOver ? <StorybookComponent /> : null}
       </View>
     </View>
   );

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -13,7 +13,7 @@ const APP_START_TIME = Date.now();
 
 const DEFAULT_INITIAL_RENDER_DELAY_MS = 1000;
 
-const INITIAL_RENDER_DELAY_ENABLED = false;
+const INITIAL_RENDER_DELAY_ENABLED = true;
 
 // Outermost decorator that delays story rendering in testing mode.
 // Prevents race conditions where stories render before async setup

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -13,6 +13,8 @@ const APP_START_TIME = Date.now();
 
 const FONT_GRACE_PERIOD_MS = 1000;
 
+const FONT_GRACE_ENABLED = false;
+
 // Outermost decorator (added last) that delays story rendering until fonts
 // are registered. On Android, TextMeasureCache caches Roboto fallback metrics
 // if story text renders before custom fonts are registered — this prevents that.
@@ -35,7 +37,7 @@ function SherloFontGraceDecorator(Story: StoryFn) {
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
   const mode = SherloModule.getMode();
 
-  if (mode === 'testing') {
+  if (mode === 'testing' && FONT_GRACE_ENABLED) {
     const originalGetProjectAnnotations = view._preview.getProjectAnnotations.bind(
       view._preview
     );

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -11,10 +11,6 @@ import type { StoryFn } from '@storybook/react';
 // not from when the decorator first runs.
 const APP_START_TIME = Date.now();
 
-const DEFAULT_INITIAL_RENDER_DELAY_MS = 1000;
-
-const INITIAL_RENDER_DELAY_ENABLED = true;
-
 // Outermost decorator that delays story rendering in testing mode.
 // Prevents race conditions where stories render before async setup
 // (e.g. custom font registration) completes.
@@ -37,25 +33,25 @@ function SherloInitialRenderDelayDecorator(Story: StoryFn, delayMs: number) {
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
   const mode = SherloModule.getMode();
 
-  if (mode === 'testing' && INITIAL_RENDER_DELAY_ENABLED) {
-    const delayMs =
-      SherloModule.getConfig().initialStoryRenderDelayMs ?? DEFAULT_INITIAL_RENDER_DELAY_MS;
-
-    const originalGetProjectAnnotations = view._preview.getProjectAnnotations.bind(
-      view._preview
-    );
-    view._preview.onGetProjectAnnotationsChanged({
-      getProjectAnnotations: async () => {
-        const annotations = await originalGetProjectAnnotations();
-        return {
-          ...annotations,
-          decorators: [
-            ...(annotations.decorators ?? []),
-            (Story: StoryFn) => SherloInitialRenderDelayDecorator(Story, delayMs),
-          ],
-        };
-      },
-    });
+  if (mode === 'testing') {
+    const delayMs = SherloModule.getConfig().initialStoryRenderDelayMs;
+    if (delayMs !== undefined) {
+      const originalGetProjectAnnotations = view._preview.getProjectAnnotations.bind(
+        view._preview
+      );
+      view._preview.onGetProjectAnnotationsChanged({
+        getProjectAnnotations: async () => {
+          const annotations = await originalGetProjectAnnotations();
+          return {
+            ...annotations,
+            decorators: [
+              ...(annotations.decorators ?? []),
+              (Story: StoryFn) => SherloInitialRenderDelayDecorator(Story, delayMs),
+            ],
+          };
+        },
+      });
+    }
   }
 
   return () => {

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,12 +1,55 @@
-import { ReactElement } from 'react';
+import { ReactElement, useState, useEffect, createElement } from 'react';
 import SherloModule from '../SherloModule';
 import { StorybookParams, StorybookView } from '../types';
 import { TestingMode } from './components';
 import { getStorybookComponent } from './helpers';
 import { useHideSplashScreen } from './hooks';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import type { StoryFn } from '@storybook/react';
+
+// Captured at module load time so the 1s grace is measured from app boot,
+// not from when the decorator first runs.
+const APP_START_TIME = Date.now();
+
+const FONT_GRACE_PERIOD_MS = 1000;
+
+// Outermost decorator (added last) that delays story rendering until fonts
+// are registered. On Android, TextMeasureCache caches Roboto fallback metrics
+// if story text renders before custom fonts are registered — this prevents that.
+function SherloFontGraceDecorator(Story: StoryFn) {
+  const elapsed = Date.now() - APP_START_TIME;
+  const [ready, setReady] = useState(elapsed >= FONT_GRACE_PERIOD_MS);
+
+  useEffect(() => {
+    if (!ready) {
+      const remaining = FONT_GRACE_PERIOD_MS - (Date.now() - APP_START_TIME);
+      const timer = setTimeout(() => setReady(true), Math.max(0, remaining));
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  if (!ready) return null;
+  return createElement(Story, {});
+}
 
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
+  const mode = SherloModule.getMode();
+
+  if (mode === 'testing') {
+    const originalGetProjectAnnotations = view._preview.getProjectAnnotations.bind(
+      view._preview
+    );
+    view._preview.onGetProjectAnnotationsChanged({
+      getProjectAnnotations: async () => {
+        const annotations = await originalGetProjectAnnotations();
+        return {
+          ...annotations,
+          decorators: [...(annotations.decorators ?? []), SherloFontGraceDecorator],
+        };
+      },
+    });
+  }
+
   return () => {
     useHideSplashScreen();
 

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,34 +1,10 @@
-import { ReactElement, useState, useEffect, createElement } from 'react';
+import { ReactElement } from 'react';
 import SherloModule from '../SherloModule';
 import { StorybookParams, StorybookView } from '../types';
 import { TestingMode } from './components';
 import { getStorybookComponent } from './helpers';
 import { useHideSplashScreen } from './hooks';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import type { StoryFn } from '@storybook/react';
-
-// Captured at module load time so the delay is measured from app boot,
-// not from when the decorator first runs.
-const APP_START_TIME = Date.now();
-
-// Outermost decorator that delays story rendering in testing mode.
-// Prevents race conditions where stories render before async setup
-// (e.g. custom font registration) completes.
-function SherloInitialRenderDelayDecorator(Story: StoryFn, delayMs: number) {
-  const elapsed = Date.now() - APP_START_TIME;
-  const [ready, setReady] = useState(elapsed >= delayMs);
-
-  useEffect(() => {
-    if (!ready) {
-      const remaining = delayMs - (Date.now() - APP_START_TIME);
-      const timer = setTimeout(() => setReady(true), Math.max(0, remaining));
-      return () => clearTimeout(timer);
-    }
-  }, []);
-
-  if (!ready) return null;
-  return createElement(Story, {});
-}
 
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
   const mode = SherloModule.getMode();
@@ -44,9 +20,9 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
           const annotations = await originalGetProjectAnnotations();
           return {
             ...annotations,
-            decorators: [
-              ...(annotations.decorators ?? []),
-              (Story: StoryFn) => SherloInitialRenderDelayDecorator(Story, delayMs),
+            loaders: [
+              ...(annotations.loaders ?? []),
+              async () => { await new Promise(r => setTimeout(r, delayMs)); },
             ],
           };
         },

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -7,24 +7,24 @@ import { useHideSplashScreen } from './hooks';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import type { StoryFn } from '@storybook/react';
 
-// Captured at module load time so the 1s grace is measured from app boot,
+// Captured at module load time so the delay is measured from app boot,
 // not from when the decorator first runs.
 const APP_START_TIME = Date.now();
 
-const FONT_GRACE_PERIOD_MS = 1000;
+const DEFAULT_INITIAL_RENDER_DELAY_MS = 1000;
 
-const FONT_GRACE_ENABLED = false;
+const INITIAL_RENDER_DELAY_ENABLED = false;
 
-// Outermost decorator (added last) that delays story rendering until fonts
-// are registered. On Android, TextMeasureCache caches Roboto fallback metrics
-// if story text renders before custom fonts are registered — this prevents that.
-function SherloFontGraceDecorator(Story: StoryFn) {
+// Outermost decorator that delays story rendering in testing mode.
+// Prevents race conditions where stories render before async setup
+// (e.g. custom font registration) completes.
+function SherloInitialRenderDelayDecorator(Story: StoryFn, delayMs: number) {
   const elapsed = Date.now() - APP_START_TIME;
-  const [ready, setReady] = useState(elapsed >= FONT_GRACE_PERIOD_MS);
+  const [ready, setReady] = useState(elapsed >= delayMs);
 
   useEffect(() => {
     if (!ready) {
-      const remaining = FONT_GRACE_PERIOD_MS - (Date.now() - APP_START_TIME);
+      const remaining = delayMs - (Date.now() - APP_START_TIME);
       const timer = setTimeout(() => setReady(true), Math.max(0, remaining));
       return () => clearTimeout(timer);
     }
@@ -37,7 +37,10 @@ function SherloFontGraceDecorator(Story: StoryFn) {
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
   const mode = SherloModule.getMode();
 
-  if (mode === 'testing' && FONT_GRACE_ENABLED) {
+  if (mode === 'testing' && INITIAL_RENDER_DELAY_ENABLED) {
+    const delayMs =
+      SherloModule.getConfig().initialStoryRenderDelayMs ?? DEFAULT_INITIAL_RENDER_DELAY_MS;
+
     const originalGetProjectAnnotations = view._preview.getProjectAnnotations.bind(
       view._preview
     );
@@ -46,7 +49,10 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
         const annotations = await originalGetProjectAnnotations();
         return {
           ...annotations,
-          decorators: [...(annotations.decorators ?? []), SherloFontGraceDecorator],
+          decorators: [
+            ...(annotations.decorators ?? []),
+            (Story: StoryFn) => SherloInitialRenderDelayDecorator(Story, delayMs),
+          ],
         };
       },
     });

--- a/packages/react-native-storybook/src/helpers/RunnerBridge/types.ts
+++ b/packages/react-native-storybook/src/helpers/RunnerBridge/types.ts
@@ -20,6 +20,7 @@ export type Config = {
   overrideMode?: 'default' | 'storybook' | 'testing';
   easUpdateDeeplink?: string;
   overrideLastState?: LastState;
+  initialStoryRenderDelayMs?: number;
 };
 
 export type LastState = {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-986

Fixes Android TextMeasureCache poisoning: when custom fonts haven't registered with ReactFontManager yet, the first text measurement caches Roboto metrics. Since TextMeasureCache has no invalidation when a font registers, every subsequent story that uses that font gets the wrong (truncated) layout.

**Root cause:** TextMeasureCache is an LRU cache keyed by full AttributedString (fontFamily + fontSize + weight + style). Created on first measurement, never invalidated when fonts register. Cold-boot AVDs start with empty font registries — stories render before ReactFontManager.setTypeface() completes.

**Fix:** Inject a Storybook loader that delays story rendering by initialStoryRenderDelayMs (sent by the runner). Storybook loaders are awaited before renderToCanvas, so the delay blocks the story AND all its decorators from rendering until fonts are registered.

Changes:
- getStorybook.tsx — injects a loader delay via onGetProjectAnnotationsChanged when initialStoryRenderDelayMs is set in config
- RunnerBridge/types.ts — adds initialStoryRenderDelayMs?: number to Config type

The runner (sherlo-runner PR #68) sets initialStoryRenderDelayMs: 1000 in the config it sends to the app on every test run.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
