### PR TITLE
feat: Step 1.5: SEO Quick Wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <br />
 
 <p align="center">
-  <a href="https://sherlo.io/">
+  <a href="https://sherlo.io/" title="Sherlo - Visual Testing for React Native Storybook">
     <picture>
       <source media="(prefers-color-scheme: dark) and (max-width: 500px)" srcset="/assets/logo-dark.svg" width="140">
       <source media="(prefers-color-scheme: dark)" srcset="/assets/logo-dark.svg" width="176">
       <source media="(max-width: 500px)" srcset="/assets/logo-light.svg" width="140">
-      <img src="/assets/logo-light.svg" alt="Sherlo logo" width="176" />
+      <img src="/assets/logo-light.svg" alt="Sherlo - Visual Testing for React Native Storybook" width="176" />
     </picture>
   </a>
 </p>
@@ -20,7 +20,7 @@
     <source media="(prefers-color-scheme: dark) and (max-width: 500px)" srcset="/assets/hero-mobile-dark.gif" width="436">
     <source media="(max-width: 500px)" srcset="/assets/hero-mobile-light.gif" width="436">
     <source media="(prefers-color-scheme: dark)" srcset="/assets/hero-desktop-dark.gif" width="560">
-    <img src="/assets/hero-desktop-light.gif" alt="Conceptual visualization of Sherlo's workflow showing how visual testing and review process works" width="560" />
+    <img src="/assets/hero-desktop-light.gif" alt="Animated demo of Sherlo running visual regression tests on a React Native Storybook" width="560" />
   </picture>
 </div>
 
@@ -28,7 +28,7 @@
 
 Test your UI on iOS and Android automatically in the cloud. Built for React Native Storybook.
 
-▶️ [Sherlo in 2 minutes](https://www.youtube.com/watch?v=RKP3zEgzyig)
+▶️ [Sherlo in 2 minutes](https://sherlo.io#video)
 
 ### How It Works
 
@@ -157,10 +157,10 @@ Join thousands of teams using Storybook – a tool that helps you develop and do
 <br />
 
 <div align="center">
-  <a href="https://sherlo.io">Website</a> • 
-  <a href="https://app.sherlo.io">App</a> • 
-  <a href="https://sherlo.io/docs">Docs</a> • 
-  <a href="./examples">Examples</a>
+  <a href="https://sherlo.io" title="Sherlo - Visual Testing for React Native Storybook">Website</a> • 
+  <a href="https://app.sherlo.io" title="Sherlo review app">App</a> • 
+  <a href="https://sherlo.io/docs" title="Sherlo documentation">Docs</a> • 
+  <a href="./examples" title="Sherlo examples">Examples</a>
 </div>
 
 <br />

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Test your UI on iOS and Android automatically in the cloud. Built for React Native Storybook.
 
-▶️ [Sherlo in 2 minutes](https://sherlo.io#video)
+▶️ [Sherlo in 2 minutes](https://sherlo.io/#video)
 
 ### How It Works
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Examples
 
-Ready-to-run React Native + Storybook [visual regression testing](https://sherlo.io) projects, each featuring:
+A collection of example apps with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook.
 
-- iOS and Android screenshot capture
+- Sherlo integration
 - GitHub Actions workflow
 
 <br />

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Examples
 
-Ready-to-run projects for different visual testing workflows, featuring:
+Ready-to-run React Native + Storybook [visual regression testing](https://sherlo.io) projects, each featuring:
 
-- Sherlo integration
+- iOS and Android screenshot capture
 - GitHub Actions workflow
 
 <br />

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,3 +1,9 @@
+# React Native Storybook screenshot testing with EAS Build – Sherlo example
+
+This example shows how to run [Sherlo](https://sherlo.io) screenshot tests on a React Native Storybook built with Expo EAS Cloud Build. Each cloud build produces a fresh iOS and Android binary. Sherlo captures every Storybook story, and visual regressions are detected automatically before the build is promoted.
+
+For the EAS Build integration guide, see the [Sherlo EAS Build docs](https://sherlo.io/docs/builds). For the underlying config format, see the [Sherlo config reference](https://sherlo.io/docs/config).
+
 # ☁️ EAS Cloud Build Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,8 +1,8 @@
 # ☁️ EAS Cloud Build Example • Sherlo
 
-React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing, built via EAS Cloud Build:
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook, built with EAS Cloud Build.
 
-- iOS and Android screenshot capture
+- Sherlo integration
 - GitHub Actions workflow
 
 <br />

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,9 +1,3 @@
-# React Native Storybook screenshot testing with EAS Build – Sherlo example
-
-This example shows how to run [Sherlo](https://sherlo.io) screenshot tests on a React Native Storybook built with Expo EAS Cloud Build. Each cloud build produces a fresh iOS and Android binary. Sherlo captures every Storybook story, and visual regressions are detected automatically before the build is promoted.
-
-For the EAS Build integration guide, see the [Sherlo EAS Build docs](https://sherlo.io/docs/builds). For the underlying config format, see the [Sherlo config reference](https://sherlo.io/docs/config).
-
 # ☁️ EAS Cloud Build Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,8 +1,8 @@
 # ☁️ EAS Cloud Build Example • Sherlo
 
-Minimal React Native + Storybook app with:
+React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing, built via EAS Cloud Build:
 
-- Sherlo integration
+- iOS and Android screenshot capture
 - GitHub Actions workflow
 
 <br />

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,9 +1,3 @@
-# React Native Storybook visual testing with EAS Update – Sherlo example
-
-This example shows how to run [Sherlo](https://sherlo.io) visual regression tests against a React Native Storybook delivered over Expo EAS Update. Every published EAS Update branch generates a new Sherlo snapshot batch, so visual regressions are caught before the update reaches production users.
-
-For the EAS Update setup walkthrough, see the [Sherlo EAS Update docs](https://sherlo.io/docs/testing?method=eas-update). For general EAS integration tips, see the [Sherlo builds docs](https://sherlo.io/docs/builds).
-
 # ⚡️ EAS Update Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,8 +1,8 @@
 # ⚡️ EAS Update Example • Sherlo
 
-Minimal React Native + Storybook app with:
+React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing, delivered via EAS Update:
 
-- Sherlo integration
+- iOS and Android screenshot capture
 - GitHub Actions workflow
 
 <br />

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,3 +1,9 @@
+# React Native Storybook visual testing with EAS Update – Sherlo example
+
+This example shows how to run [Sherlo](https://sherlo.io) visual regression tests against a React Native Storybook delivered over Expo EAS Update. Every published EAS Update branch generates a new Sherlo snapshot batch, so visual regressions are caught before the update reaches production users.
+
+For the EAS Update setup walkthrough, see the [Sherlo EAS Update docs](https://sherlo.io/docs/testing?method=eas-update). For general EAS integration tips, see the [Sherlo builds docs](https://sherlo.io/docs/builds).
+
 # ⚡️ EAS Update Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,8 +1,8 @@
 # ⚡️ EAS Update Example • Sherlo
 
-React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing, delivered via EAS Update:
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook, delivered via EAS Update.
 
-- iOS and Android screenshot capture
+- Sherlo integration
 - GitHub Actions workflow
 
 <br />

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,9 +1,3 @@
-# React Native Storybook visual regression testing – Sherlo standard example
-
-This example shows how to set up [Sherlo](https://sherlo.io) for visual regression testing of a React Native Storybook in a standard Expo or bare React Native project. Each commit captures screenshots of every story on iOS and Android, compares them against the baseline, and surfaces visual diffs for review.
-
-For the full setup guide, see the [Sherlo documentation](https://sherlo.io/docs). For details on the story configuration used here, see [Sherlo stories docs](https://sherlo.io/docs/stories/parameters).
-
 # 📦 Standard Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,8 +1,8 @@
 # 📦 Standard Example • Sherlo
 
-Minimal React Native + Storybook app with:
+React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing:
 
-- Sherlo integration
+- iOS and Android screenshot capture
 - GitHub Actions workflow
 
 <br />

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,3 +1,9 @@
+# React Native Storybook visual regression testing – Sherlo standard example
+
+This example shows how to set up [Sherlo](https://sherlo.io) for visual regression testing of a React Native Storybook in a standard Expo or bare React Native project. Each commit captures screenshots of every story on iOS and Android, compares them against the baseline, and surfaces visual diffs for review.
+
+For the full setup guide, see the [Sherlo documentation](https://sherlo.io/docs). For details on the story configuration used here, see [Sherlo stories docs](https://sherlo.io/docs/stories/parameters).
+
 # 📦 Standard Example • Sherlo
 
 Minimal React Native + Storybook app with:

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,8 +1,8 @@
 # 📦 Standard Example • Sherlo
 
-React Native + Storybook app with [Sherlo](https://sherlo.io) visual regression testing:
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook.
 
-- iOS and Android screenshot capture
+- Sherlo integration
 - GitHub Actions workflow
 
 <br />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # `sherlo`
 
-Command-line interface for [Sherlo](https://github.com/sherlo-io/sherlo) - Visual Testing for React Native Storybook.
+Command-line interface for [Sherlo](https://sherlo.io) - Visual Testing for React Native Storybook.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,6 +1,6 @@
 # `@sherlo/react-native-storybook`
 
-Main package for [Sherlo](https://github.com/sherlo-io/sherlo) - Visual Testing for React Native Storybook.
+Main package for [Sherlo](https://sherlo.io) - Visual Testing for React Native Storybook.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1204

## TL;DR

Cluster of independent SEO quick wins running in parallel to Steps 2-6 of SHERLO-1114. Recovers wasted link equity from high-DA GitHub/npm surfaces (main and package READMEs + 3 example READMEs currently linking to github.com instead of sherlo.io), creates an indexable GitHub org profile README, adds a #video anchor path from the main README to a new hash-aware landing page behavior, persists Google keyword-proximity research as reference doc in sherlo-marketing, and routes all public-facing copy through a content review.

## Acceptance Criteria

- All sherlo repository README and example-README changes in the developer subtask are delivered, and both npm packages (sherlo and @sherlo/react-native-storybook) are released with the updated READMEs so the fix propagates to npmjs.com and reactnative.directory
- New public GitHub repository sherlo-io/.github exists with profile/README.md, and https://github.com/sherlo-io renders the profile README prominently
- sherlo-marketing has a new reference doc at docs/seo-link-context-hierarchy.md covering Google keyword-proximity mechanics, and a follow-up audit document at .local-data/seo-link-proximity-review.md listing remaining links that would benefit from optimization (audit-only, no implementation in this ticket)
- sherlo-www landing page hides the fixed site header when window.location.hash is #video, and restores the header when the hash changes or is cleared
- Content department has reviewed all public-facing copy in this ticket and either approved it or delivered a list of required changes applied by the developer subtask before final merge
- Post-delivery verification: npm registry pages for sherlo and @sherlo/react-native-storybook render the updated README with sherlo.io link; github.com/sherlo-io renders the org profile README; sherlo.io#video hides the header in a browser manual test

## Additional Context

## Context

Triggered by the observation that our npm package READMEs link to github.com/sherlo-io instead of sherlo.io, wasting backlink equity from npmjs.com and reactnative.directory. A full SEO audit (developer/www/content/marketing depts + Brain-level web research) found additional quick-win items not covered by the SHERLO-1114 epic's existing Step 2-6 tickets.

## Why a separate ticket

The SEO Improvements epic has a sequential execution order (Steps 2-6). This ticket is Step 1.5 — it runs in parallel and does not block or depend on any other step. All items are independent markdown/copy/CSS changes with no architectural coupling.

## Scope boundaries — OUT OF SCOPE

- Hero H1 / visual prominence tradeoff on landing page (folded into SHERLO-1116 as a consider item)
- Schema upgrades on main layout.tsx (belongs to SHERLO-1116)
- Creating /blog, /pricing, /features, /expo-storybook pages (SHERLO-1116, SHERLO-1118)
- Product Hunt, AlternativeTo, awesome-list PRs (SHERLO-1117, SHERLO-1119)
- sherlo-www repo README (repo is private, no SEO impact)
- SHERLO-1115 follow-up gaps (docs intro desc length, Twitter cards, og:url, schema) — folded into SHERLO-1116
- Rewriting currently-suboptimal anchors in main sherlo/README.md lines 81 and 97 (Full documentation, Browse examples) — marketing dept audit output feeds a follow-up ticket, no implementation here

## Research sources

- developer dept audit of github.com/sherlo-io links in the SDK monorepo
- www dept audit of sherlo-www repo for meta/schema/heading/keyword gaps
- content dept audit of external backlinks, awesome lists, Product Hunt, directories
- marketing dept 5-part Search Console and GA4 baseline report (46 clicks, 2993 impressions, 90d)
- marketing dept hero GIF alt text + example README template recommendations
- Brain-level web research on Google anchor text and link context: Google Patent US8577893B1, BERT 2019 update, Reasonable Surfer model

All dept output was cross-referenced against the actual codebase before being included.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
