### PR TITLE
feat: Add --diagnostics CLI flag for per-snapshot debug data colle…

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -73,6 +73,7 @@ export const FULL_INIT_COMMAND = 'npx sherlo init';
 export const ANDROID_OPTION = 'android';
 export const BRANCH_OPTION = 'branch';
 export const CONFIG_OPTION = 'config';
+export const DIAGNOSTICS_OPTION = 'diagnostics';
 export const EAS_ANDROID_URL_OPTION = 'easAndroidUrl';
 export const EAS_BUILD_SCRIPT_NAME_OPTION = 'easBuildScriptName';
 // export const EAS_UPDATE_JSON_OUTPUT_OPTION = 'easUpdateJsonOutput';

--- a/packages/cli/src/helpers/getBuildRunConfig.ts
+++ b/packages/cli/src/helpers/getBuildRunConfig.ts
@@ -10,8 +10,8 @@ function getBuildRunConfig({
   commandParams: CommandParams;
   binaryS3Keys?: { android?: string; ios?: string };
   easUpdateData?: EasUpdateData;
-}): BuildRun<'withS3KeyNoDebug'>['config'] {
-  const { devices, include, exclude } = commandParams;
+}): BuildRun<'withS3KeyNoDebug'>['config'] & { diagnostics?: string[] } {
+  const { devices, include, exclude, diagnostics } = commandParams;
 
   const androidDevices = getPlatformDevices(devices, 'android');
   const iosDevices = getPlatformDevices(devices, 'ios');
@@ -36,6 +36,7 @@ function getBuildRunConfig({
             s3Key: binaryS3Keys?.ios || ASYNC_UPLOAD_S3_KEY_PLACEHOLDER,
           }
         : undefined,
+    ...(diagnostics !== undefined ? { diagnostics } : {}),
   };
 }
 

--- a/packages/cli/src/helpers/getValidatedCommandParams/getNormalizedOptions.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/getNormalizedOptions.ts
@@ -1,4 +1,4 @@
-import { INCLUDE_OPTION } from '../../constants';
+import { DIAGNOSTICS_OPTION, INCLUDE_OPTION } from '../../constants';
 import { Command, Options } from '../../types';
 
 function getNormalizedOptions<C extends Command>(
@@ -8,6 +8,10 @@ function getNormalizedOptions<C extends Command>(
 
   if (typeof options[INCLUDE_OPTION] === 'string') {
     normalizedOptions[INCLUDE_OPTION] = parseCommaSeparatedStringToArray(options[INCLUDE_OPTION]);
+  }
+
+  if (typeof options[DIAGNOSTICS_OPTION] === 'string') {
+    normalizedOptions[DIAGNOSTICS_OPTION] = parseCommaSeparatedStringToArray(options[DIAGNOSTICS_OPTION]);
   }
 
   return normalizedOptions;

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -17,6 +17,7 @@ import {
   CONTACT_EMAIL,
   DEFAULT_CONFIG_FILENAME,
   DEFAULT_PROJECT_ROOT,
+  DIAGNOSTICS_OPTION,
   DISCORD_URL,
   EAS_ANDROID_URL_OPTION,
   EAS_BUILD_ON_COMPLETE_COMMAND,
@@ -116,6 +117,10 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
     `--${CONFIG_OPTION} <path>`,
     `Path to the config file (default: ${DEFAULT_CONFIG_FILENAME})`,
   ],
+  [DIAGNOSTICS_OPTION]: [
+    `--${DIAGNOSTICS_OPTION} <names>`,
+    'Diagnostics to collect, comma-separated (e.g. androidWindowDump,stabilizationFrames)',
+  ],
   [EAS_ANDROID_URL_OPTION]: [
     `--${EAS_ANDROID_URL_OPTION} <url>`,
     'Direct Android EAS Update URL (bypasses expo config and eas-cli lookup)',
@@ -167,20 +172,24 @@ function addInitCommand(program: Command) {
 }
 
 function addTestCommand(program: Command) {
+  const devtoolsOptions = process.env.SHERLO_DEVTOOLS === '1' ? [DIAGNOSTICS_OPTION] : [];
+
   addCommand({
     program,
     command: TEST_COMMAND,
-    options: getTestCommonOptions('withPlatformPaths'),
+    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
     action: test,
   });
 }
 
 function addTestStandardCommand(program: Command) {
+  const devtoolsOptions = process.env.SHERLO_DEVTOOLS === '1' ? [DIAGNOSTICS_OPTION] : [];
+
   addCommand({
     program,
     command: TEST_STANDARD_COMMAND,
     oldCommand: 'local-builds',
-    options: getTestCommonOptions('withPlatformPaths'),
+    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
     action: testStandard,
   });
 }
@@ -188,7 +197,7 @@ function addTestStandardCommand(program: Command) {
 function addTestEasUpdateCommand(program: Command) {
   const devtoolsOptions =
     process.env.SHERLO_DEVTOOLS === '1'
-      ? [EAS_ANDROID_URL_OPTION, EAS_IOS_URL_OPTION, EAS_UPDATE_SLUG_OPTION]
+      ? [EAS_ANDROID_URL_OPTION, EAS_IOS_URL_OPTION, EAS_UPDATE_SLUG_OPTION, DIAGNOSTICS_OPTION]
       : [];
 
   addCommand({
@@ -201,6 +210,8 @@ function addTestEasUpdateCommand(program: Command) {
 }
 
 function addTestEasCloudBuildCommand(program: Command) {
+  const devtoolsOptions = process.env.SHERLO_DEVTOOLS === '1' ? [DIAGNOSTICS_OPTION] : [];
+
   addCommand({
     program,
     command: TEST_EAS_CLOUD_BUILD_COMMAND,
@@ -209,6 +220,7 @@ function addTestEasCloudBuildCommand(program: Command) {
       EAS_BUILD_SCRIPT_NAME_OPTION,
       WAIT_FOR_EAS_BUILD_OPTION,
       ...getTestCommonOptions('withoutPlatformPaths'),
+      ...devtoolsOptions,
     ],
     action: testEasCloudBuild,
   });

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,6 +4,7 @@ import {
   ANDROID_OPTION,
   BRANCH_OPTION,
   CONFIG_OPTION,
+  DIAGNOSTICS_OPTION,
   EAS_ANDROID_URL_OPTION,
   EAS_BUILD_ON_COMPLETE_COMMAND,
   EAS_BUILD_SCRIPT_NAME_OPTION,
@@ -70,6 +71,7 @@ type CommonOptions<M extends OptionsMode, F extends OptionsFormat> = {
   [MESSAGE_OPTION]?: string;
   [TOKEN_OPTION]?: string;
   [INCLUDE_OPTION]?: F extends 'raw' ? string : string[];
+  [DIAGNOSTICS_OPTION]?: F extends 'raw' ? string : string[];
 } & (M extends 'withDefaults'
   ? { [CONFIG_OPTION]: string; [PROJECT_ROOT_OPTION]: string }
   : { [CONFIG_OPTION]?: string; [PROJECT_ROOT_OPTION]?: string });


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1216

## TL;DR

When investigating non-deterministic screenshot issues (e.g. mystery gray rectangles, navigation bar artifacts), we have no way to capture what's actually on screen at the system level. Add a `--diagnostics` CLI flag (gated by `SHERLO_DEVTOOLS=1`) that flows through the existing `buildRunConfig` path to the runner, which then captures additional debug data per snapshot and saves it to local runner logs. First two diagnostic capabilities: `androidWindowDump` (uiautomator + SurfaceFlinger dump per snapshot) and `stabilizationFrames` (keep intermediate stabilization screenshots instead of discarding).

## Acceptance Criteria

- CLI accepts `--diagnostics <comma-separated-list>` option when `SHERLO_DEVTOOLS=1` is set; option is hidden otherwise
- `diagnostics` field flows through `getBuildRunConfig()` → `openBuild` GraphQL mutation → DynamoDB `BuildRun.config` → runner `buildRun.config.diagnostics`
- When `androidWindowDump` is enabled, runner saves `uiautomator dump` and `dumpsys SurfaceFlinger --list` output to local log directory per snapshot at capture time
- When `stabilizationFrames` is enabled, runner keeps intermediate stabilization screenshots in local log directory instead of discarding them
- Diagnostic files are saved alongside existing runner logs (local filesystem only, no S3 upload)
- Inspector department can access diagnostic files via existing SSH runner log access

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
