### PR TITLE
feat: Move SDK compatibility check out of React render to eliminat…

### DIFF
--- a/packages/react-native-storybook/src/checkSdkCompatibility.ts
+++ b/packages/react-native-storybook/src/checkSdkCompatibility.ts
@@ -3,7 +3,7 @@ import SherloModule from './SherloModule';
 
 const ERROR_CODE = 'ERROR_SDK_COMPATIBILITY';
 
-async function checkSdkCompatibility(): Promise<void> {
+function checkSdkCompatibility(): boolean {
   const requiredMinNativeVersion = REQUIRED_MIN_NATIVE_VERSION;
 
   const nativeVersion = SherloModule.getNativeVersion();
@@ -19,8 +19,10 @@ async function checkSdkCompatibility(): Promise<void> {
         : `Sherlo native version ${nativeVersion} is below the required minimum ${requiredMinNativeVersion}. Please rebuild the app.`;
 
     SherloModule.sendNativeError(ERROR_CODE, message, { jsVersion, nativeVersion: nativeVersion ?? null });
-    throw new Error(message);
+    return false;
   }
+
+  return true;
 }
 
 export default checkSdkCompatibility;

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement } from 'react';
 import SherloModule from '../SherloModule';
 import checkSdkCompatibility from '../checkSdkCompatibility';
 import { StorybookParams, StorybookView } from '../types';
@@ -6,6 +6,11 @@ import { TestingMode } from './components';
 import { getStorybookComponent } from './helpers';
 import { useHideSplashScreen } from './hooks';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+let isSdkCompatible = true;
+if (SherloModule.getMode() === 'testing') {
+  isSdkCompatible = checkSdkCompatibility();
+}
 
 function getStorybook(view: StorybookView, params?: StorybookParams): () => ReactElement {
   const mode = SherloModule.getMode();
@@ -36,17 +41,8 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
 
     const mode = SherloModule.getMode();
 
-    const [compatibilityChecked, setCompatibilityChecked] = useState(false);
-
-    useEffect(() => {
-      if (mode !== 'testing') return;
-      checkSdkCompatibility()
-        .then(() => setCompatibilityChecked(true))
-        .catch(() => { /* native error sent, app stays blank intentionally */ });
-    }, [mode]);
-
     if (mode === 'testing') {
-      if (!compatibilityChecked) return null as unknown as ReactElement;
+      if (!isSdkCompatible) return null as unknown as ReactElement;
 
       return (
         <SafeAreaProvider>


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1258

## TL;DR

In @sherlo/react-native-storybook 1.6.3, `checkSdkCompatibility` was added inside getStorybook's render function as a `useState` + `useEffect` block with a `return null` early bail until the check resolves. This introduces a throwaway first render that shifts the timing of story mount relative to Android's IME/focus state, triggering a non-deterministic gray rectangle artifact (NavigationBar0 rendered with a light-appearance scrim) in screenshots. Investigation across 4 affected stories (b=60 OTP, b=62 banner, b=63 consumable sheet, b=4 p=4 bottomsheet) confirmed the rectangle only appears when `SOFT_INPUT_IS_FORWARD_NAVIGATION` is set on the app window, which the added render delay can race into. Downgrading Feeld to 1.5.6 fixed the bug; bisection on 1.5.6 + forward-ported 1.6.3 changes isolated the SDK compat check as the sole cause. Move the check to module-load time (synchronous, runs once at import) with a module-level boolean flag that the render function reads synchronously. Preserves the 'blank app on incompatibility' behavior (critical: runner's protocol.sherlo polling only reads the last line; if the app writes other events after NATIVE_ERROR they would mask it) while removing the render delay.

## Acceptance Criteria

- checkSdkCompatibility runs synchronously at module load time inside getStorybook.tsx (not inside useEffect)
- No useState / useEffect / async/await is used for the SDK compatibility check in getStorybook
- If SDK is incompatible, SherloModule.sendNativeError is called once at module load to write NATIVE_ERROR to protocol.sherlo
- If SDK is incompatible, getStorybook render returns null (blank app) synchronously on the first render — no throwaway render, no subsequent protocol events written
- If SDK is compatible, getStorybook renders TestingMode on first render with no delay (no throwaway render)
- Integration tests covering ERROR_SDK_COMPATIBILITY still pass — runner still detects the native error via protocol.sherlo
- Android screenshot test across the Feeld app (or equivalent reference app with TextInputs and bottomsheets) shows zero gray rectangle artifacts across 20 consecutive runs

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
