### PR TITLE
feat: Fix sherlo testing apps lockfile drift and harden release wo…

### DIFF
--- a/.github/workflows/release-sherlo-packages.yml
+++ b/.github/workflows/release-sherlo-packages.yml
@@ -112,6 +112,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Wait for npm registry propagation
+        run: |
+          TIMEOUT=600
+          INTERVAL=15
+          ELAPSED=0
+          echo "Waiting for sherlo@$NEW_VERSION_NUMBER and @sherlo/react-native-storybook@$NEW_VERSION_NUMBER on npm..."
+          while true; do
+            SHERLO_OK=$(npm view sherlo@$NEW_VERSION_NUMBER version 2>/dev/null)
+            SDK_OK=$(npm view @sherlo/react-native-storybook@$NEW_VERSION_NUMBER version 2>/dev/null)
+            if [ -n "$SHERLO_OK" ] && [ -n "$SDK_OK" ]; then
+              echo "Both packages available: sherlo@$SHERLO_OK, @sherlo/react-native-storybook@$SDK_OK"
+              break
+            fi
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "ERROR: Timed out after ${TIMEOUT}s waiting for npm propagation."
+              echo "  sherlo@$NEW_VERSION_NUMBER: ${SHERLO_OK:-not found}"
+              echo "  @sherlo/react-native-storybook@$NEW_VERSION_NUMBER: ${SDK_OK:-not found}"
+              exit 1
+            fi
+            echo "Not yet available (${ELAPSED}s elapsed). Retrying in ${INTERVAL}s..."
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          
       - name: Update lock files in examples and test directories
         run: |
           for dir in examples/standard examples/eas-update examples/eas-cloud-build; do

--- a/examples/eas-cloud-build/yarn.lock
+++ b/examples/eas-cloud-build/yarn.lock
@@ -2165,21 +2165,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sherlo/react-native-storybook@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "@sherlo/react-native-storybook@npm:1.6.3"
+"@sherlo/react-native-storybook@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "@sherlo/react-native-storybook@npm:1.6.4-alpha.1"
   dependencies:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.3"
+    sherlo: "npm:^1.6.4-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"
     react: "*"
     react-native: ">=0.64.0"
     react-native-safe-area-context: "*"
-  checksum: 10/56e16151df844100ee81633c17fb3bcb4757a0ff3a312657e50815f55269db30e166b8661f129a488dc80f705dd3dcd58e8ff37ec63954aed2bd65caf23f31b7
+  checksum: 10/697fdd8558c26c513019379353fb722c1210944e6a0e056c575bf394729dede61fbc58980a4a310896b4178a375eb4e7d6dba04a2e9c2bb1b016047a511a2055
   languageName: node
   linkType: hard
 
@@ -6846,7 +6846,7 @@ __metadata:
   dependencies:
     "@gorhom/bottom-sheet": "npm:^5.2.8"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
-    "@sherlo/react-native-storybook": "npm:^1.6.3"
+    "@sherlo/react-native-storybook": "npm:^1.6.4-alpha.1"
     "@storybook/react-native": "npm:^10.2.1"
     "@types/react": "npm:~19.1.10"
     expo: "npm:54.0.31"
@@ -6862,12 +6862,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"sherlo@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "sherlo@npm:1.6.3"
+"sherlo@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "sherlo@npm:1.6.4-alpha.1"
   bin:
     sherlo: cli.js
-  checksum: 10/367038e118a435aa914526855ab3a28f2f0e71eece762ac1cd028b49d9779f1fe061c5d484884ff9572bf33b4d25111e9dcf8e7dd71a6267c14f4c5c24baa09b
+  checksum: 10/332bc6175404c8112b856d2820dcc4c5daa8c077f17d7af0c1f4e34995999bde65d2637bea701cde580ffeaadb2f367c77570e4f5a5ac72cccfa9e09091fe0da
   languageName: node
   linkType: hard
 

--- a/examples/eas-update/yarn.lock
+++ b/examples/eas-update/yarn.lock
@@ -2165,21 +2165,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sherlo/react-native-storybook@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "@sherlo/react-native-storybook@npm:1.6.3"
+"@sherlo/react-native-storybook@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "@sherlo/react-native-storybook@npm:1.6.4-alpha.1"
   dependencies:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.3"
+    sherlo: "npm:^1.6.4-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"
     react: "*"
     react-native: ">=0.64.0"
     react-native-safe-area-context: "*"
-  checksum: 10/56e16151df844100ee81633c17fb3bcb4757a0ff3a312657e50815f55269db30e166b8661f129a488dc80f705dd3dcd58e8ff37ec63954aed2bd65caf23f31b7
+  checksum: 10/697fdd8558c26c513019379353fb722c1210944e6a0e056c575bf394729dede61fbc58980a4a310896b4178a375eb4e7d6dba04a2e9c2bb1b016047a511a2055
   languageName: node
   linkType: hard
 
@@ -7004,7 +7004,7 @@ __metadata:
   dependencies:
     "@gorhom/bottom-sheet": "npm:^5.2.8"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
-    "@sherlo/react-native-storybook": "npm:^1.6.3"
+    "@sherlo/react-native-storybook": "npm:^1.6.4-alpha.1"
     "@storybook/react-native": "npm:^10.2.1"
     "@types/react": "npm:~19.1.10"
     expo: "npm:54.0.31"
@@ -7022,12 +7022,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"sherlo@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "sherlo@npm:1.6.3"
+"sherlo@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "sherlo@npm:1.6.4-alpha.1"
   bin:
     sherlo: cli.js
-  checksum: 10/367038e118a435aa914526855ab3a28f2f0e71eece762ac1cd028b49d9779f1fe061c5d484884ff9572bf33b4d25111e9dcf8e7dd71a6267c14f4c5c24baa09b
+  checksum: 10/332bc6175404c8112b856d2820dcc4c5daa8c077f17d7af0c1f4e34995999bde65d2637bea701cde580ffeaadb2f367c77570e4f5a5ac72cccfa9e09091fe0da
   languageName: node
   linkType: hard
 

--- a/examples/standard/yarn.lock
+++ b/examples/standard/yarn.lock
@@ -2165,21 +2165,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sherlo/react-native-storybook@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "@sherlo/react-native-storybook@npm:1.6.3"
+"@sherlo/react-native-storybook@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "@sherlo/react-native-storybook@npm:1.6.4-alpha.1"
   dependencies:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.3"
+    sherlo: "npm:^1.6.4-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"
     react: "*"
     react-native: ">=0.64.0"
     react-native-safe-area-context: "*"
-  checksum: 10/56e16151df844100ee81633c17fb3bcb4757a0ff3a312657e50815f55269db30e166b8661f129a488dc80f705dd3dcd58e8ff37ec63954aed2bd65caf23f31b7
+  checksum: 10/697fdd8558c26c513019379353fb722c1210944e6a0e056c575bf394729dede61fbc58980a4a310896b4178a375eb4e7d6dba04a2e9c2bb1b016047a511a2055
   languageName: node
   linkType: hard
 
@@ -6846,7 +6846,7 @@ __metadata:
   dependencies:
     "@gorhom/bottom-sheet": "npm:^5.2.8"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
-    "@sherlo/react-native-storybook": "npm:^1.6.3"
+    "@sherlo/react-native-storybook": "npm:^1.6.4-alpha.1"
     "@storybook/react-native": "npm:^10.2.1"
     "@types/react": "npm:~19.1.10"
     expo: "npm:54.0.31"
@@ -6862,12 +6862,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"sherlo@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "sherlo@npm:1.6.3"
+"sherlo@npm:^1.6.4-alpha.1":
+  version: 1.6.4-alpha.1
+  resolution: "sherlo@npm:1.6.4-alpha.1"
   bin:
     sherlo: cli.js
-  checksum: 10/367038e118a435aa914526855ab3a28f2f0e71eece762ac1cd028b49d9779f1fe061c5d484884ff9572bf33b4d25111e9dcf8e7dd71a6267c14f4c5c24baa09b
+  checksum: 10/332bc6175404c8112b856d2820dcc4c5daa8c077f17d7af0c1f4e34995999bde65d2637bea701cde580ffeaadb2f367c77570e4f5a5ac72cccfa9e09091fe0da
   languageName: node
   linkType: hard
 

--- a/testing/expo/yarn.lock
+++ b/testing/expo/yarn.lock
@@ -2419,7 +2419,7 @@ __metadata:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.3"
+    sherlo: "npm:^1.6.4-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"

--- a/testing/react-native/yarn.lock
+++ b/testing/react-native/yarn.lock
@@ -4145,7 +4145,7 @@ __metadata:
     base-64: "npm:1.0.0"
     deepmerge: "npm:4.3.1"
     its-fine: "npm:2.0.0"
-    sherlo: "npm:^1.6.3"
+    sherlo: "npm:^1.6.4-alpha.1"
     utf8: "npm:3.0.0"
   peerDependencies:
     "@storybook/react-native": ">=7.6.11"


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1335

## TL;DR

Two issues, one root cause. (1) The 'Sherlo Testing' workflow fails on every run because testing app yarn.lock files in sherlo-io/sherlo reference sherlo@^1.6.3 while their package.json files reference ^1.6.4-alpha.1. Failing run: https://github.com/sherlo-io/sherlo/actions/runs/25290852088. (2) Root cause: release run https://github.com/sherlo-io/sherlo/actions/runs/24522933496 bumped versions and published to npm, but its 'Update lock files in examples and test directories' step failed with `YN0082: No candidates found` because the install runs seconds after npm publish, before registry propagation. The 'Commit and push updated lock files' follow-up was skipped, leaving testing apps with drifted lockfiles. Fix both: regenerate the lockfiles now, and harden the release step so it waits for the published versions to be resolvable on npm before installing.

## Acceptance Criteria

- All testing app yarn.lock files in sherlo-io/sherlo (examples/standard, examples/eas-update, examples/eas-cloud-build, testing/expo, testing/react-native — confirm full list against the release workflow definition) reference the currently published sherlo SDK version
- `yarn install --immutable` succeeds in every testing app workspace
- 'Sherlo Testing' workflow passes end-to-end (all jobs green) on main after the lockfile-fix PR merges
- Release workflow's lockfile-update step waits for the just-published versions to be resolvable on npm before running `yarn install` (poll `npm view sherlo@<NEW_VERSION>` and `npm view @sherlo/react-native-storybook@<NEW_VERSION>` with timeout/backoff, fail the step loudly if not available within a reasonable window). This eliminates the propagation race that broke run 24522933496.
- Hardening is verified by triggering an alpha release and confirming both the lockfile-update step and the 'Commit and push updated lock files' step complete successfully

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
