### PR TITLE
feat: Update testing apps and examples to v2 withStorybook integra…

### DIFF
--- a/examples/eas-cloud-build/.rnstorybook/index.ts
+++ b/examples/eas-cloud-build/.rnstorybook/index.ts
@@ -1,21 +1,9 @@
-/**
- * Sherlo-modified Storybook component
- *
- * Sherlo needs to control Storybook to switch between stories
- * This is done using getStorybook() wrapper instead of the standard view.getStorybookUI()
- *
- * Learn more: https://sherlo.io/docs/setup#storybook-component
- */
-
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getStorybook } from '@sherlo/react-native-storybook';
 import { view } from './storybook.requires';
 
-const StorybookUIRoot = getStorybook(view, {
+export default view.getStorybookUI({
   storage: {
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
 });
-
-export default StorybookUIRoot;

--- a/examples/eas-cloud-build/App.tsx
+++ b/examples/eas-cloud-build/App.tsx
@@ -7,7 +7,7 @@
  * Learn how: https://sherlo.io/docs/setup?storybook=integrated#storybook-access
  */
 
-import Storybook from './.rnstorybook'; // Modified for Sherlo
+import Storybook from './.rnstorybook';
 
 export default function App() {
   return <Storybook />;

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -135,7 +135,7 @@ _💡 First test won't show "changes" since there's nothing to compare against y
 ## 📁 Key Files
 
 - **[`App.tsx`](./App.tsx)** – Root component rendering Storybook for testing _([docs](https://sherlo.io/docs/setup#storybook-access))_
-- **[`.rnstorybook/index.ts`](./.rnstorybook/index.ts)** – Storybook component modified for Sherlo integration _([docs](https://sherlo.io/docs/setup#storybook-component))_
+- **[`metro.config.js`](./metro.config.js)** – Metro config wrapped with Sherlo's `withStorybook` _([docs](https://sherlo.io/docs/setup#metro-config))_
 - **[`sherlo.config.json`](./sherlo.config.json)** – Config file with testing devices _([docs](https://sherlo.io/docs/config))_
 - **[`.github/workflows/eas-cloud-build.yml`](./.github/workflows/eas-cloud-build.yml)** – CI workflow for automated testing process
 - **[`package.json`](./package.json)** – Dependencies and scripts for Sherlo integration

--- a/examples/eas-cloud-build/metro.config.js
+++ b/examples/eas-cloud-build/metro.config.js
@@ -3,7 +3,4 @@ const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config, {
-  enabled: true,
-  configPath: __dirname + '/.rnstorybook',
-});
+module.exports = withStorybook(config);

--- a/examples/eas-cloud-build/metro.config.js
+++ b/examples/eas-cloud-build/metro.config.js
@@ -1,3 +1,12 @@
+/**
+ * Sherlo Metro wrapper
+ *
+ * Wraps Metro to integrate Storybook so it can be toggled via the Dev Menu
+ * and controlled by Sherlo during cloud testing.
+ *
+ * Learn more: https://sherlo.io/docs/setup#metro-config
+ */
+
 const { getDefaultConfig } = require('expo/metro-config');
 const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 

--- a/examples/eas-cloud-build/metro.config.js
+++ b/examples/eas-cloud-build/metro.config.js
@@ -1,6 +1,9 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config);
+module.exports = withStorybook(config, {
+  enabled: true,
+  configPath: __dirname + '/.rnstorybook',
+});

--- a/examples/eas-cloud-build/package.json
+++ b/examples/eas-cloud-build/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.8",
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "@sherlo/react-native-storybook": "^1.6.4-alpha.1",
+    "@sherlo/react-native-storybook": "^2.0.0-alpha.1",
     "@storybook/react-native": "^10.2.1",
     "expo": "54.0.31",
     "react": "19.1.0",

--- a/examples/eas-update/.rnstorybook/index.ts
+++ b/examples/eas-update/.rnstorybook/index.ts
@@ -1,21 +1,9 @@
-/**
- * Sherlo-modified Storybook component
- *
- * Sherlo needs to control Storybook to switch between stories
- * This is done using getStorybook() wrapper instead of the standard view.getStorybookUI()
- *
- * Learn more: https://sherlo.io/docs/setup#storybook-component
- */
-
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getStorybook } from '@sherlo/react-native-storybook';
 import { view } from './storybook.requires';
 
-const StorybookUIRoot = getStorybook(view, {
+export default view.getStorybookUI({
   storage: {
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
 });
-
-export default StorybookUIRoot;

--- a/examples/eas-update/App.tsx
+++ b/examples/eas-update/App.tsx
@@ -7,7 +7,7 @@
  * Learn how: https://sherlo.io/docs/setup?storybook=integrated#storybook-access
  */
 
-import Storybook from './.rnstorybook'; // Modified for Sherlo
+import Storybook from './.rnstorybook';
 
 export default function App() {
   return <Storybook />;

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -163,7 +163,7 @@ _💡 First test won't show "changes" since there's nothing to compare against y
 ## 📁 Key Files
 
 - **[`App.tsx`](./App.tsx)** – Root component rendering Storybook for testing _([docs](https://sherlo.io/docs/setup#storybook-access))_
-- **[`.rnstorybook/index.ts`](./.rnstorybook/index.ts)** – Storybook component modified for Sherlo integration _([docs](https://sherlo.io/docs/setup#storybook-component))_
+- **[`metro.config.js`](./metro.config.js)** – Metro config wrapped with Sherlo's `withStorybook` _([docs](https://sherlo.io/docs/setup#metro-config))_
 - **[`sherlo.config.json`](./sherlo.config.json)** – Config file with testing devices _([docs](https://sherlo.io/docs/config))_
 - **[`.github/workflows/eas-update.yml`](./.github/workflows/eas-update.yml)** – CI workflow for automated testing process
 - **[`package.json`](./package.json)** – Dependencies and scripts for Sherlo integration

--- a/examples/eas-update/metro.config.js
+++ b/examples/eas-update/metro.config.js
@@ -3,7 +3,4 @@ const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config, {
-  enabled: true,
-  configPath: __dirname + '/.rnstorybook',
-});
+module.exports = withStorybook(config);

--- a/examples/eas-update/metro.config.js
+++ b/examples/eas-update/metro.config.js
@@ -1,3 +1,12 @@
+/**
+ * Sherlo Metro wrapper
+ *
+ * Wraps Metro to integrate Storybook so it can be toggled via the Dev Menu
+ * and controlled by Sherlo during cloud testing.
+ *
+ * Learn more: https://sherlo.io/docs/setup#metro-config
+ */
+
 const { getDefaultConfig } = require('expo/metro-config');
 const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 

--- a/examples/eas-update/metro.config.js
+++ b/examples/eas-update/metro.config.js
@@ -1,6 +1,9 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config);
+module.exports = withStorybook(config, {
+  enabled: true,
+  configPath: __dirname + '/.rnstorybook',
+});

--- a/examples/eas-update/package.json
+++ b/examples/eas-update/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.8",
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "@sherlo/react-native-storybook": "^1.6.4-alpha.1",
+    "@sherlo/react-native-storybook": "^2.0.0-alpha.1",
     "@storybook/react-native": "^10.2.1",
     "expo": "54.0.31",
     "expo-dev-client": "^6.0.20",

--- a/examples/standard/.rnstorybook/index.ts
+++ b/examples/standard/.rnstorybook/index.ts
@@ -1,21 +1,9 @@
-/**
- * Sherlo-modified Storybook component
- *
- * Sherlo needs to control Storybook to switch between stories
- * This is done using getStorybook() wrapper instead of the standard view.getStorybookUI()
- *
- * Learn more: https://sherlo.io/docs/setup#storybook-component
- */
-
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getStorybook } from '@sherlo/react-native-storybook';
 import { view } from './storybook.requires';
 
-const StorybookUIRoot = getStorybook(view, {
+export default view.getStorybookUI({
   storage: {
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
 });
-
-export default StorybookUIRoot;

--- a/examples/standard/App.tsx
+++ b/examples/standard/App.tsx
@@ -7,7 +7,7 @@
  * Learn how: https://sherlo.io/docs/setup?storybook=integrated#storybook-access
  */
 
-import Storybook from './.rnstorybook'; // Modified for Sherlo
+import Storybook from './.rnstorybook';
 
 export default function App() {
   return <Storybook />;

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -144,7 +144,7 @@ _💡 First test won't show "changes" since there's nothing to compare against y
 ## 📁 Key Files
 
 - **[`App.tsx`](./App.tsx)** – Root component rendering Storybook for testing _([docs](https://sherlo.io/docs/setup#storybook-access))_
-- **[`.rnstorybook/index.ts`](./.rnstorybook/index.ts)** – Storybook component modified for Sherlo integration _([docs](https://sherlo.io/docs/setup#storybook-component))_
+- **[`metro.config.js`](./metro.config.js)** – Metro config wrapped with Sherlo's `withStorybook` _([docs](https://sherlo.io/docs/setup#metro-config))_
 - **[`sherlo.config.json`](./sherlo.config.json)** – Config file with testing devices _([docs](https://sherlo.io/docs/config))_
 - **[`.github/workflows/standard.yml`](./.github/workflows/standard.yml)** – CI workflow for automated testing process
 - **[`package.json`](./package.json)** – Dependencies and scripts for Sherlo integration

--- a/examples/standard/metro.config.js
+++ b/examples/standard/metro.config.js
@@ -3,7 +3,4 @@ const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config, {
-  enabled: true,
-  configPath: __dirname + '/.rnstorybook',
-});
+module.exports = withStorybook(config);

--- a/examples/standard/metro.config.js
+++ b/examples/standard/metro.config.js
@@ -1,3 +1,12 @@
+/**
+ * Sherlo Metro wrapper
+ *
+ * Wraps Metro to integrate Storybook so it can be toggled via the Dev Menu
+ * and controlled by Sherlo during cloud testing.
+ *
+ * Learn more: https://sherlo.io/docs/setup#metro-config
+ */
+
 const { getDefaultConfig } = require('expo/metro-config');
 const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 

--- a/examples/standard/metro.config.js
+++ b/examples/standard/metro.config.js
@@ -1,6 +1,9 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withStorybook(config);
+module.exports = withStorybook(config, {
+  enabled: true,
+  configPath: __dirname + '/.rnstorybook',
+});

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.8",
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "@sherlo/react-native-storybook": "^1.6.4-alpha.1",
+    "@sherlo/react-native-storybook": "^2.0.0-alpha.1",
     "@storybook/react-native": "^10.2.1",
     "expo": "54.0.31",
     "react": "19.1.0",

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -67,21 +67,6 @@ import { Button } from 'react-native';
 
 ---
 
-### `addStorybookToDevMenu()`
-
-Add a "Toggle Storybook" option to the React Native Dev Menu.
-
-**Example:**
-
-```tsx
-import { addStorybookToDevMenu } from '@sherlo/react-native-storybook';
-
-// In your app initialization
-addStorybookToDevMenu();
-```
-
----
-
 ### `isRunningVisualTests`
 
 Boolean that indicates if Sherlo visual tests are currently running. Use this to disable animations, mock network data, or apply other deterministic behavior that helps produce consistent screenshots.

--- a/packages/react-native-storybook/metro/applySherloTransforms.js
+++ b/packages/react-native-storybook/metro/applySherloTransforms.js
@@ -134,8 +134,7 @@ function generateWrapper(wrapperPath, configPath) {
     '  // in that case real.start is not a function.\n' +
     "  if (typeof real.start !== 'function') {\n" +
     '    try {\n' +
-    "      var sherloInternal = require('@sherlo/react-native-storybook/dist/SherloModule');\n" +
-    "      var SherloModule = sherloInternal && sherloInternal.default ? sherloInternal.default : sherloInternal;\n" +
+    "      var SherloModule = require('@sherlo/react-native-storybook/dist/SherloModule').default;\n" +
     "      if (SherloModule && typeof SherloModule.getMode === 'function' && SherloModule.getMode() === 'testing') {\n" +
     "        SherloModule.sendNativeError(\n" +
     "          'ERROR_STORYBOOK_DISABLED',\n" +
@@ -150,10 +149,8 @@ function generateWrapper(wrapperPath, configPath) {
     '  // Lazy-require sherlo AFTER the re-exports above are already set up.\n' +
     '  // This breaks the circular dependency that would otherwise cause\n' +
     '  // isStorybook7 to be detected incorrectly (see comment above).\n' +
-    "  var getStorybookMod = require('@sherlo/react-native-storybook/dist/getStorybook');\n" +
-    "  var getStorybook = getStorybookMod && getStorybookMod.default ? getStorybookMod.default : getStorybookMod;\n" +
-    "  var addStorybookToDevMenuMod = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu');\n" +
-    "  var addStorybookToDevMenu = addStorybookToDevMenuMod && addStorybookToDevMenuMod.default ? addStorybookToDevMenuMod.default : addStorybookToDevMenuMod;\n" +
+    "  var getStorybook = require('@sherlo/react-native-storybook/dist/getStorybook').default;\n" +
+    "  var addStorybookToDevMenu = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu').default;\n" +
     '\n' +
     '  var view = real.start(config);\n' +
     '\n' +

--- a/packages/react-native-storybook/metro/applySherloTransforms.js
+++ b/packages/react-native-storybook/metro/applySherloTransforms.js
@@ -150,14 +150,15 @@ function generateWrapper(wrapperPath, configPath) {
     '  // Lazy-require sherlo AFTER the re-exports above are already set up.\n' +
     '  // This breaks the circular dependency that would otherwise cause\n' +
     '  // isStorybook7 to be detected incorrectly (see comment above).\n' +
-    "  var sherlo = require('@sherlo/react-native-storybook');\n" +
     "  var getStorybookMod = require('@sherlo/react-native-storybook/dist/getStorybook');\n" +
     "  var getStorybook = getStorybookMod && getStorybookMod.default ? getStorybookMod.default : getStorybookMod;\n" +
+    "  var addStorybookToDevMenuMod = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu');\n" +
+    "  var addStorybookToDevMenu = addStorybookToDevMenuMod && addStorybookToDevMenuMod.default ? addStorybookToDevMenuMod.default : addStorybookToDevMenuMod;\n" +
     '\n' +
     '  var view = real.start(config);\n' +
     '\n' +
     '  try {\n' +
-    '    sherlo.addStorybookToDevMenu();\n' +
+    '    addStorybookToDevMenu();\n' +
     '  } catch (e) {\n' +
     "    console.error('[sherlo withStorybook] addStorybookToDevMenu failed:', e);\n" +
     '  }\n' +

--- a/packages/react-native-storybook/src/__tests__/withStorybook.test.ts
+++ b/packages/react-native-storybook/src/__tests__/withStorybook.test.ts
@@ -235,17 +235,17 @@ describe('generated storybook-wrapper.js - content', () => {
     expect(wrapperContent).not.toMatch(topLevelSherloRequire);
   });
 
-  it('requires @sherlo/react-native-storybook lazily inside patchedStart', () => {
-    const lazyRequire = /[ \t]+var sherlo = require\('@sherlo\/react-native-storybook'\)/;
+  it('deep-requires addStorybookToDevMenu lazily inside patchedStart', () => {
+    const lazyRequire = /[ \t]+var addStorybookToDevMenuMod = require\('@sherlo\/react-native-storybook\/dist\/addStorybookToDevMenu'\)/;
     expect(wrapperContent).toMatch(lazyRequire);
   });
 
-  it('requires @sherlo/react-native-storybook AFTER the re-export loop', () => {
+  it('deep-requires addStorybookToDevMenu AFTER the re-export loop', () => {
     const reExportIdx = wrapperContent.indexOf('Object.keys(real).forEach');
-    const sherloRequireIdx = wrapperContent.indexOf("var sherlo = require('@sherlo/react-native-storybook')");
+    const devMenuRequireIdx = wrapperContent.indexOf("var addStorybookToDevMenuMod = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu')");
     expect(reExportIdx).toBeGreaterThan(-1);
-    expect(sherloRequireIdx).toBeGreaterThan(-1);
-    expect(sherloRequireIdx).toBeGreaterThan(reExportIdx);
+    expect(devMenuRequireIdx).toBeGreaterThan(-1);
+    expect(devMenuRequireIdx).toBeGreaterThan(reExportIdx);
   });
 
   it('passes params ?? {} to getStorybook so undefined params use Storybook defaults', () => {

--- a/packages/react-native-storybook/src/__tests__/withStorybook.test.ts
+++ b/packages/react-native-storybook/src/__tests__/withStorybook.test.ts
@@ -236,13 +236,13 @@ describe('generated storybook-wrapper.js - content', () => {
   });
 
   it('deep-requires addStorybookToDevMenu lazily inside patchedStart', () => {
-    const lazyRequire = /[ \t]+var addStorybookToDevMenuMod = require\('@sherlo\/react-native-storybook\/dist\/addStorybookToDevMenu'\)/;
+    const lazyRequire = /[ \t]+var addStorybookToDevMenu = require\('@sherlo\/react-native-storybook\/dist\/addStorybookToDevMenu'\)\.default/;
     expect(wrapperContent).toMatch(lazyRequire);
   });
 
   it('deep-requires addStorybookToDevMenu AFTER the re-export loop', () => {
     const reExportIdx = wrapperContent.indexOf('Object.keys(real).forEach');
-    const devMenuRequireIdx = wrapperContent.indexOf("var addStorybookToDevMenuMod = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu')");
+    const devMenuRequireIdx = wrapperContent.indexOf("var addStorybookToDevMenu = require('@sherlo/react-native-storybook/dist/addStorybookToDevMenu').default");
     expect(reExportIdx).toBeGreaterThan(-1);
     expect(devMenuRequireIdx).toBeGreaterThan(-1);
     expect(devMenuRequireIdx).toBeGreaterThan(reExportIdx);

--- a/packages/react-native-storybook/src/index.ts
+++ b/packages/react-native-storybook/src/index.ts
@@ -1,6 +1,5 @@
 import { normalizeStack } from './normalizeStack';
 
-export { default as addStorybookToDevMenu } from './addStorybookToDevMenu';
 export { default as isRunningVisualTests } from './isRunningVisualTests';
 export { default as isStorybookMode } from './isStorybookMode';
 export { default as openStorybook } from './openStorybook';
@@ -45,7 +44,9 @@ function patchAppRegistryWithBoundary(SherloModule: any): void {
         componentStack: '',
       };
       const entry = { action: 'JS_ERROR', timestamp: Date.now(), entity: 'app', data };
-      return Promise.resolve(SherloModule.appendFile('protocol.sherlo', JSON.stringify(entry) + '\n'))
+      return Promise.resolve(
+        SherloModule.appendFile('protocol.sherlo', JSON.stringify(entry) + '\n')
+      )
         .then(function () {})
         .catch(function () {});
     } catch (_) {
@@ -54,8 +55,13 @@ function patchAppRegistryWithBoundary(SherloModule: any): void {
   }
 
   function doReportFatalError(error: any): void {
-    if ((global as any).ErrorUtils && typeof (global as any).ErrorUtils.reportFatalError === 'function') {
-      try { (global as any).ErrorUtils.reportFatalError(error); } catch (_) {}
+    if (
+      (global as any).ErrorUtils &&
+      typeof (global as any).ErrorUtils.reportFatalError === 'function'
+    ) {
+      try {
+        (global as any).ErrorUtils.reportFatalError(error);
+      } catch (_) {}
     }
   }
 
@@ -78,12 +84,17 @@ function patchAppRegistryWithBoundary(SherloModule: any): void {
   };
 
   const origRegister = AR.registerComponent.bind(AR);
-  AR.registerComponent = function sherloRegisterComponent(appKey: string, componentProvider: () => any) {
+  AR.registerComponent = function sherloRegisterComponent(
+    appKey: string,
+    componentProvider: () => any
+  ) {
     return origRegister(appKey, () => {
       // When sherloAtRoot is enabled, substitute the root with the Storybook entry
       // loaded from the config path instead of calling the original componentProvider.
       let config: any;
-      try { config = SherloModule.getConfig(); } catch (_) {}
+      try {
+        config = SherloModule.getConfig();
+      } catch (_) {}
 
       if (config && config.sherloAtRoot === true) {
         const storybookMod = require('@storybook/react-native');
@@ -95,20 +106,28 @@ function patchAppRegistryWithBoundary(SherloModule: any): void {
         if (typeof loader !== 'function') {
           throw new Error(
             '[sherlo] sherloAtRoot requires configPath to be set in metro.config.js so the' +
-            ' Storybook entry can be bundled. Rebuild the app after adding configPath.'
+              ' Storybook entry can be bundled. Rebuild the app after adding configPath.'
           );
         }
         const storybookIndexMod = loader();
         const UserStorybookEntry = storybookIndexMod && storybookIndexMod.default;
         if (!UserStorybookEntry) {
           throw new Error(
-            '[sherlo] sherloAtRoot requires ' + configPath + '/index to default-export the Storybook UI component' +
-            ' (canonical Storybook RN template shape: see https://github.com/storybookjs/react-native template).' +
-            ' Got module with keys: [' + Object.keys(storybookIndexMod || {}).join(', ') + ']'
+            '[sherlo] sherloAtRoot requires ' +
+              configPath +
+              '/index to default-export the Storybook UI component' +
+              ' (canonical Storybook RN template shape: see https://github.com/storybookjs/react-native template).' +
+              ' Got module with keys: [' +
+              Object.keys(storybookIndexMod || {}).join(', ') +
+              ']'
           );
         }
         function SherloRootWrapperAtRoot(props: any) {
-          return React.createElement(SherloErrorBoundary, null, React.createElement(UserStorybookEntry, props));
+          return React.createElement(
+            SherloErrorBoundary,
+            null,
+            React.createElement(UserStorybookEntry, props)
+          );
         }
         (SherloRootWrapperAtRoot as any).displayName = 'SherloRoot(sherloAtRoot)';
         (SherloRootWrapperAtRoot as any)._sherloWrapped = true;
@@ -118,7 +137,11 @@ function patchAppRegistryWithBoundary(SherloModule: any): void {
       const Component = componentProvider();
       if (!Component || (Component as any)._sherloWrapped) return Component;
       function SherloRootWrapper(props: any) {
-        return React.createElement(SherloErrorBoundary, null, React.createElement(Component, props));
+        return React.createElement(
+          SherloErrorBoundary,
+          null,
+          React.createElement(Component, props)
+        );
       }
       (SherloRootWrapper as any).displayName =
         'SherloRoot(' + ((Component as any).displayName || (Component as any).name || appKey) + ')';

--- a/testing/expo/.rnstorybook/index.tsx
+++ b/testing/expo/.rnstorybook/index.tsx
@@ -1,12 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { getStorybook } from '@sherlo/react-native-storybook';
 import { view } from './storybook.requires';
 
-const Storybook = getStorybook(view, {
+export default view.getStorybookUI({
   storage: {
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
 });
-
-export default Storybook;

--- a/testing/expo/App.tsx
+++ b/testing/expo/App.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { isStorybookMode, addStorybookToDevMenu } from '@sherlo/react-native-storybook';
+import { isStorybookMode } from '@sherlo/react-native-storybook';
 import { StatusBar } from 'expo-status-bar';
 import Storybook from './.rnstorybook';
 import HomeScreen from './src/HomeScreen';
-
-addStorybookToDevMenu();
 
 function App() {
   if (isStorybookMode) {

--- a/testing/expo/metro.config.js
+++ b/testing/expo/metro.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { getDefaultConfig } = require('@expo/metro-config');
-const withStorybook = require('@storybook/react-native/metro/withStorybook');
+const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const resolvePath = (relativePath) => path.resolve(__dirname, relativePath);
 

--- a/testing/react-native/.storybook/index.tsx
+++ b/testing/react-native/.storybook/index.tsx
@@ -1,12 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {getStorybook} from '@sherlo/react-native-storybook';
 import {view} from './storybook.requires';
 
-const Storybook = getStorybook(view, {
+export default view.getStorybookUI({
   storage: {
     getItem: AsyncStorage.getItem,
     setItem: AsyncStorage.setItem,
   },
 });
-
-export default Storybook;

--- a/testing/react-native/App.tsx
+++ b/testing/react-native/App.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import {
-  isStorybookMode,
-  addStorybookToDevMenu,
-} from '@sherlo/react-native-storybook';
+import {isStorybookMode} from '@sherlo/react-native-storybook';
 import {StatusBar} from 'expo-status-bar';
 import Storybook from './.storybook';
 import HomeScreen from './src/HomeScreen';
-
-addStorybookToDevMenu();
 
 function App() {
   if (isStorybookMode) {

--- a/testing/react-native/metro.config.js
+++ b/testing/react-native/metro.config.js
@@ -1,22 +1,13 @@
 const path = require('path');
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
-const {generate} = require('@storybook/react-native/scripts/generate');
-
-generate({
-  // update ./.storybook to your storybook folder
-  configPath: path.resolve(__dirname, './.storybook'),
-});
+const withStorybook = require('@sherlo/react-native-storybook/withStorybook');
 
 const resolvePath = relativePath => path.resolve(__dirname, relativePath);
 
-// Tell Metro to *forcefully* resolve and watch source versions of shared packages
 const linkedModules = {
-  '@sherlo/react-native-storybook': resolvePath(
-    '../../packages/react-native-storybook/src',
-  ),
+  '@sherlo/react-native-storybook': resolvePath('../../packages/react-native-storybook/src'),
 };
 
-// Tell Metro to resolve these package names to their real source paths
 const extraNodeModules = new Proxy(
   {},
   {
@@ -28,8 +19,7 @@ const extraNodeModules = new Proxy(
 
 const defaultConfig = getDefaultConfig(__dirname);
 
-/** @type {import('@react-native/metro-config').MetroConfig} */
-const config = {
+const customConfig = mergeConfig(defaultConfig, {
   transformer: {
     unstable_allowRequireContext: true,
   },
@@ -38,6 +28,9 @@ const config = {
     sourceExts: [...defaultConfig.resolver.sourceExts, 'mjs'],
   },
   watchFolders: Object.values(linkedModules),
-};
+});
 
-module.exports = mergeConfig(defaultConfig, config);
+module.exports = withStorybook(customConfig, {
+  enabled: true,
+  configPath: path.resolve(__dirname, './.storybook'),
+});


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1348

## TL;DR

SDK v2.0.0-alpha.0 (PR #136 "withSherlo Metro Config Wrapper") removed `getStorybook` from the public package exports and switched the integration to a Metro-config wrapper plus AppRegistry root patching. Both testing apps (testing/expo, testing/react-native) and all three examples (standard, eas-update, eas-cloud-build) still use the deprecated `getStorybook(view, ...)` pattern and call the upstream `@storybook/react-native/metro/withStorybook` instead of `@sherlo/react-native-storybook/withStorybook`. When the SDK dist is rebuilt against the current source, these apps fail to boot Storybook (`getStorybook` is undefined), the runner never receives the START protocol message, and downstream the API's `closeBuild` path can trigger a DynamoDB 400 KB item-size error - the suspected root cause of build 49 (team ucyN_GCY, project 79) on dev env.

## Acceptance Criteria

- Neither `testing/expo/.rnstorybook/index.tsx` nor `testing/react-native/.storybook/index.tsx` imports `getStorybook` from `@sherlo/react-native-storybook`; each default-exports the Storybook UI directly from `view`.
- `testing/expo/metro.config.js` and `testing/react-native/metro.config.js` import `withStorybook` from `@sherlo/react-native-storybook/withStorybook` (no longer from `@storybook/react-native/metro/withStorybook`).
- All three examples (`examples/standard`, `examples/eas-update`, `examples/eas-cloud-build`) have their `.rnstorybook/index.ts` and `metro.config.js` updated to the same new pattern.
- Any README inside the `sherlo` repo that currently contains a `getStorybook(view, ...)` snippet or a `require('@storybook/react-native/metro/withStorybook')` snippet is updated to the new pattern. READMEs that do not contain those snippets are left untouched.
- After the migration, both `testing/expo` and `testing/react-native` boot successfully and complete a Sherlo test run end-to-end against dev env (the new build no longer fails with the `snapshotsCount=null` -> oversize `missingSnapshotsStatusData` chain seen in build 49).

## Additional Context

## Affected files (sherlo repo)

Testing apps:

- `testing/expo/.rnstorybook/index.tsx`
- `testing/expo/metro.config.js`
- `testing/react-native/.storybook/index.tsx`
- `testing/react-native/metro.config.js`

Examples:

- `examples/standard/.rnstorybook/index.ts`
- `examples/standard/metro.config.js`
- `examples/eas-update/.rnstorybook/index.ts`
- `examples/eas-update/metro.config.js`
- `examples/eas-cloud-build/.rnstorybook/index.ts`
- `examples/eas-cloud-build/metro.config.js`

## New canonical pattern

`metro.config.js`:

```js
const { getDefaultConfig } = require('@react-native/metro-config'); // or '@expo/metro-config' for expo apps
const withStorybook = require('@sherlo/react-native-storybook/withStorybook');

const defaultConfig = getDefaultConfig(__dirname);

module.exports = withStorybook(defaultConfig, {
  enabled: true,
  configPath: __dirname + '/.rnstorybook', // or '/.storybook' for testing/react-native
});
```

`.rnstorybook/index.ts(x)` (default-export the Storybook UI component directly from `view`):

```ts
import { view } from './storybook.requires';
export default view.getStorybookUI({ /* storage opts if needed */ });
```

Reference: `packages/react-native-storybook/README.md` (Metro Config + Changelog v2.0.0-alpha.1) and `sherlo-www/docs/docs/2_setup.mdx` (already documents the new pattern).

## Out of scope

- Public docs in sherlo-www (already migrated).
- Adding a `prepare` script to `packages/react-native-storybook` or rebuilding/republishing the SDK dist - separate concern.
- A sweeping README audit - only touch READMEs that contain stale `getStorybook(...)` snippets or stale `@storybook/react-native/metro/withStorybook` snippets.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
