### PR TITLE
feat: Brand migration: drop 'Storybook' from primary descriptor +…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <br />
 
 <p align="center">
-  <a href="https://sherlo.io/" title="Sherlo - Visual Testing for React Native Storybook">
+  <a href="https://sherlo.io/" title="Sherlo - Visual testing for React Native">
     <picture>
       <source media="(prefers-color-scheme: dark) and (max-width: 500px)" srcset="/assets/logo-dark.svg" width="140">
       <source media="(prefers-color-scheme: dark)" srcset="/assets/logo-dark.svg" width="176">
       <source media="(max-width: 500px)" srcset="/assets/logo-light.svg" width="140">
-      <img src="/assets/logo-light.svg" alt="Sherlo - Visual Testing for React Native Storybook" width="176" />
+      <img src="/assets/logo-light.svg" alt="Sherlo - Visual testing for React Native" width="176" />
     </picture>
   </a>
 </p>
 
-<p align="center"><strong>Visual Testing for React Native Storybook</strong></p>
+<p align="center"><strong>Visual testing for React Native</strong></p>
 
 <div align="center">
   <a href="https://www.npmjs.com/package/@sherlo/react-native-storybook"><img src="https://img.shields.io/npm/v/@sherlo/react-native-storybook.svg" alt="npm version"></a>
@@ -33,7 +33,7 @@
 
 # Sherlo
 
-**Visual regression testing for React Native Storybook**. Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
+**Visual regression testing for React Native**. Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
 
 ▶️ [Sherlo in 2 minutes](https://sherlo.io/#video)
 
@@ -164,7 +164,7 @@ Join thousands of teams using Storybook - a tool that helps you develop and docu
 <br />
 
 <div align="center">
-  <a href="https://sherlo.io" title="Sherlo - Visual Testing for React Native Storybook">Website</a> • 
+  <a href="https://sherlo.io" title="Sherlo - Visual testing for React Native">Website</a> • 
   <a href="https://app.sherlo.io" title="Sherlo review app">App</a> • 
   <a href="https://sherlo.io/docs" title="Sherlo documentation">Docs</a> • 
   <a href="./examples" title="Sherlo examples">Examples</a>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     <source media="(prefers-color-scheme: dark) and (max-width: 500px)" srcset="/assets/hero-mobile-dark.gif" width="436">
     <source media="(max-width: 500px)" srcset="/assets/hero-mobile-light.gif" width="436">
     <source media="(prefers-color-scheme: dark)" srcset="/assets/hero-desktop-dark.gif" width="560">
-    <img src="/assets/hero-desktop-light.gif" alt="Animated demo of Sherlo running visual regression tests on a React Native Storybook" width="560" />
+    <img src="/assets/hero-desktop-light.gif" alt="Animated demo of Sherlo running visual regression tests on React Native components in Storybook" width="560" />
   </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 # Sherlo
 
-**Visual regression testing for React Native**. Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
+**Visual regression testing for React Native, integrated with Storybook**. Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
 
 ▶️ [Sherlo in 2 minutes](https://sherlo.io/#video)
 
@@ -62,18 +62,7 @@
 npx sherlo init
 ```
 
-#### 2)<sup>\*</sup> Customize [test devices](https://sherlo.io/docs/config#devices) _(optional)_
-
-<!-- prettier-ignore -->
-```json
-[
-  { "id": "iphone.15", "osVersion": "17" },
-  { "id": "pixel.7", "osVersion": "13", "theme": "dark" },
-  { "id": "ipad.10.gen", "osVersion": "17", "locale": "en_GB", "fontScale": "+2" }
-]
-```
-
-#### 3) Run visual tests
+#### 2) Run visual tests
 
 ```bash
 npx sherlo test

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-A collection of example apps with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook.
+A collection of example apps with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-A collection of example apps with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native.
+Working examples of Sherlo running automated [visual regression testing for React Native](https://sherlo.io).
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,6 +1,6 @@
 # ☁️ EAS Cloud Build Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook, built with EAS Cloud Build.
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native, built with EAS Cloud Build.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/eas-cloud-build/README.md
+++ b/examples/eas-cloud-build/README.md
@@ -1,6 +1,6 @@
 # ☁️ EAS Cloud Build Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native, built with EAS Cloud Build.
+A minimal example app showing Sherlo running automated [visual regression testing for React Native](https://sherlo.io). Sherlo captures Storybook stories on iOS and Android simulators in the cloud. App binaries are built with EAS Cloud Build.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,6 +1,6 @@
 # ⚡️ EAS Update Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook, delivered via EAS Update.
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native, delivered via EAS Update.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/eas-update/README.md
+++ b/examples/eas-update/README.md
@@ -1,6 +1,6 @@
 # ⚡️ EAS Update Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native, delivered via EAS Update.
+A minimal example app showing Sherlo running automated [visual regression testing for React Native](https://sherlo.io). Sherlo captures Storybook stories on iOS and Android simulators in the cloud. App binaries receive JavaScript updates over-the-air via EAS Update.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,6 +1,6 @@
 # 📦 Standard Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native Storybook.
+A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -1,6 +1,6 @@
 # 📦 Standard Example • Sherlo
 
-A minimal example app with automated visual regression testing, powered by [Sherlo](https://sherlo.io) for React Native.
+A minimal example app showing Sherlo running automated [visual regression testing for React Native](https://sherlo.io). Sherlo captures Storybook stories on iOS and Android simulators in the cloud. App binaries ship with bundled JavaScript.
 
 - Sherlo integration
 - GitHub Actions workflow

--- a/package.json
+++ b/package.json
@@ -1,20 +1,17 @@
 {
   "name": "@sherlo/root",
   "private": true,
-  "description": "Sherlo is a Visual Testing tool for React Native Storybook",
+  "description": "Sherlo: Visual testing for React Native",
   "keywords": [
-    "testing",
     "visual testing",
     "visual regression testing",
-    "components",
-    "documentation",
-    "frontend",
-    "react-native",
-    "storybook",
-    "storybookjs",
-    "tool",
-    "ui",
-    "user interface"
+    "react native",
+    "react native visual testing",
+    "ios",
+    "android",
+    "simulators",
+    "screenshot testing",
+    "ui"
   ],
   "homepage": "https://sherlo.io",
   "repository": {

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,4 +8,4 @@ CLI for initializing and running visual tests.
 
 ## [react-native-storybook](./react-native-storybook) (`@sherlo/react-native-storybook`)
 
-Main package that enables React Native Storybook integration.
+Main package that enables Sherlo's Storybook integration for React Native.

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,4 +8,4 @@ CLI for initializing and running visual tests.
 
 ## [react-native-storybook](./react-native-storybook) (`@sherlo/react-native-storybook`)
 
-Main package that enables Sherlo's Storybook integration for React Native.
+Main package that enables integration with Storybook for React Native.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
-# Sherlo CLI - Visual Testing for React Native Storybook
+# Sherlo CLI - Visual testing for React Native
 
-The `sherlo` CLI orchestrates [visual regression testing for React Native Storybook](https://sherlo.io) - capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
+The `sherlo` CLI orchestrates [visual regression testing for React Native](https://sherlo.io) - capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# Sherlo CLI - Visual testing for React Native
+# Sherlo CLI: Visual testing for React Native
 
 The `sherlo` CLI orchestrates [visual regression testing for React Native](https://sherlo.io) - capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,12 @@
 {
   "name": "sherlo",
   "version": "1.6.4-alpha.2",
-  "description": "Sherlo CLI - visual regression testing for React Native Storybook on iOS and Android simulators",
+  "description": "Sherlo CLI - visual regression testing for React Native on iOS and Android simulators",
   "keywords": [
     "visual testing",
     "react-native",
+    "visual regression testing",
+    "react native visual testing",
     "storybook"
   ],
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sherlo",
   "version": "1.6.4-alpha.2",
-  "description": "Sherlo CLI - visual regression testing for React Native on iOS and Android simulators",
+  "description": "Sherlo CLI: Visual testing for React Native",
   "keywords": [
     "visual testing",
     "react-native",

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -55,7 +55,7 @@ async function start() {
     program
       .name('sherlo')
       .version(version, '--version', 'Output the version number')
-      .description('Sherlo CLI for React Native Storybook visual testing');
+      .description('Sherlo CLI for React Native visual testing');
 
     addInitCommand(program);
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -55,7 +55,7 @@ async function start() {
     program
       .name('sherlo')
       .version(version, '--version', 'Output the version number')
-      .description('Sherlo CLI - visual regression testing for React Native');
+      .description('Sherlo CLI: Visual testing for React Native');
 
     addInitCommand(program);
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -55,7 +55,7 @@ async function start() {
     program
       .name('sherlo')
       .version(version, '--version', 'Output the version number')
-      .description('Sherlo CLI for React Native visual testing');
+      .description('Sherlo CLI - visual regression testing for React Native');
 
     addInitCommand(program);
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,6 +1,6 @@
-# Sherlo SDK - Visual Testing for React Native Storybook
+# Sherlo SDK - Visual testing for React Native
 
-The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native Storybook](https://sherlo.io) into your app - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
+The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,4 +1,4 @@
-# Sherlo SDK - Visual testing for React Native
+# Sherlo Storybook integration: Visual testing for React Native
 
 The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
 

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sherlo/react-native-storybook",
   "version": "2.0.0-alpha.1",
-  "description": "Sherlo SDK - visual regression testing for React Native, Storybook integration",
+  "description": "Sherlo Storybook integration: Visual testing for React Native",
   "keywords": [
     "visual testing",
     "react-native",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@sherlo/react-native-storybook",
   "version": "2.0.0-alpha.1",
-  "description": "Sherlo SDK - visual regression testing for React Native Storybook on iOS and Android simulators",
+  "description": "Sherlo SDK - visual regression testing for React Native, Storybook integration",
   "keywords": [
     "visual testing",
     "react-native",
-    "storybook"
+    "storybook",
+    "visual regression testing",
+    "react native visual testing"
   ],
   "license": "MIT",
   "author": "Sherlo",


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1372

## TL;DR

Sherlo's brand pivoted during SHERLO-1369 from 'Visual Testing for React Native Storybook' to 'Visual testing for React Native'. Two combined changes: (1) drop 'Storybook' from the primary descriptor to claim the broader visual-testing-for-RN category (future-proof for upcoming integrations like React Navigation, Maestro, Expo Router), and (2) switch from title case to sentence case for brand text (matches modern B2D convention, lower-cringe for engineer audience). LinkedIn surfaces are handled in SHERLO-1369; this ticket migrates every other surface (sherlo.io, GitHub, npm, Twitter, YouTube, Discord, in-app, etc.) to match.

## Acceptance Criteria

- sherlo-marketing/CLAUDE.md 'Phrase placement' section updated to specify the new brand standard: 'Visual testing for React Native' (sentence case, no Storybook reference) as the canonical brand statement. Old title-case + Storybook convention removed. Verify by reading the section.
- All sherlo.io brand-text surfaces updated: homepage hero, page <title> tags, meta description, OG image (regenerated), Twitter card meta + image (regenerated), docs Docusaurus config title, footer brand text, privacy policy + terms + DPA brand references, llms.txt + llms-full.txt, JSON-LD SoftwareApplication description, favicon aria-label. Verify by visiting the live URLs and confirming no 'Visual Testing for React Native Storybook' string remains.
- All sherlo root repo brand-text surfaces updated: README H1 + first paragraph, GitHub repo description (visible in search), GitHub social-preview image (regenerated), all 3 example READMEs (standard, eas-update, eas-cloud-build), examples/README.md. Verify by reading repo files and checking GitHub.
- Both npm packages updated: @sherlo/react-native-storybook and @sherlo/cli package.json descriptions, README H1s + first paragraphs, CLI binary description string, keywords arrays. Both packages re-published with updated metadata. Verify by 'npm view @sherlo/react-native-storybook description' and equivalent.
- Twitter/X profile bio + banner image updated. Pinned tweet updated if it uses brand text. Verify by visiting the profile.
- Discord server description, welcome message, and channel descriptions updated. Verify by joining the server and reading the surfaces.
- YouTube channel About section + banner art updated. Existing video descriptions referencing the old brand text updated. Verify by visiting the channel and spot-checking 3 video descriptions.
- sherlo-frontend (web app) brand-text surfaces updated: login page, dashboard headers, browser tab title, OG/Twitter meta tags, any in-app marketing strings. Verify by loading the live app and inspecting the HTML.
- Transactional email templates updated (welcome, onboarding, password reset, billing). Onboarding-flow tooltips and modals reviewed for brand text. Verify by reading template files in the relevant repo.
- sherlo-leads outreach docs reviewed for brand-text consistency: docs/outreach/playbook.md, templates.md, target-personas.md, and all NotebookLM research files. Any references to the old brand string updated to the new. Verify by grepping the leads repo for 'Visual Testing for React Native Storybook' and confirming zero matches.
- Sherlo Product Hunt profile / launch page updated if Sherlo has presence there. Verify by visiting the page if it exists.
- Cold-outreach signature reviewed: 'Co-Founder, Sherlo' identity remains correct (Sherlo as proper noun stays capitalized). Verify by reading templates.md A-T1 signature block.

## Additional Context

## Context

During SHERLO-1369 (LinkedIn presence update), the Sherlo brand positioning was reconsidered and pivoted in two ways:

1. **Drop 'Storybook' from the primary descriptor**: Sherlo is positioning as visual testing for React Native broadly, not Storybook-specifically. This future-proofs the brand for upcoming integrations (React Navigation, Maestro, Expo Router) and resolves the conversion friction non-Storybook RN teams currently face. Storybook remains a current integration (mentioned in product surfaces, not in the brand line).
2. **Switch to sentence case**: Title case ('Visual Testing for React Native') reads more marketing-y; sentence case ('Visual testing for React Native') matches modern B2D conventions (Linear, Vercel, Stripe, Cursor) and the Sherlo philosophy guardrail of 'dev-to-dev voice, anti-corporate, anti-jargon, low cringe threshold' (sherlo-leads notebooklm-sources.md philosophy block).

LinkedIn surfaces (Dawid's personal profile, Sherlo company page, Devine company page) are migrated within SHERLO-1369. This ticket migrates every OTHER surface to match, so the brand is consistent across web, GitHub, npm, social media, in-app, and documentation.

## Sequencing recommendation

1. Update sherlo-marketing/CLAUDE.md 'Phrase placement' section FIRST — it's the source-of-truth document defining the convention. All other work references this.
2. Update sherlo.io (most-discoverable surface).
3. Update GitHub root README + npm package descriptions (propagate via package registry caches).
4. Update social surfaces (Twitter, Discord, YouTube).
5. Update in-app surfaces (sherlo-frontend, email templates).
6. Update internal docs (sherlo-leads outreach docs).

## Out of scope

- LinkedIn surfaces (handled in SHERLO-1369)
- Third-party content not under Sherlo control (existing comparison articles, listicles, Hacker News submissions)
- Historical blog posts on third-party platforms (Medium, dev.to) - not directly updatable
- Pre-existing customer-facing materials in customer hands (one-pagers already sent, etc.)

## Ownership

- **content**: regenerates OG images, banner art, validates all updated copy through banned-pattern + Sapling pipeline
- **www**: updates sherlo.io homepage, docs, meta tags, OG/Twitter cards, footer, legal pages, llms.txt
- **developer**: updates @sherlo/* npm package descriptions, READMEs, CLI binary description, and re-publishes
- **frontend**: updates sherlo-frontend web app brand strings, browser tab title, OG meta, email templates, onboarding flow
- **leads**: reviews outreach docs for brand-text consistency
- **marketing**: updates the CLAUDE.md Phrase placement section as source of truth
- **brain**: orchestrates the migration via subtasks (does not implement domain copy itself)

Manual operator (Dawid): Twitter, Discord, YouTube, Product Hunt - these are owned outside of code repos and require manual UI updates.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
