### PR TITLE
feat: [Step 1] Git-metadata foundation: capture + persist additive…

### DIFF
--- a/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
+++ b/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import getGitInfo, { ANCESTOR_LIMIT } from '../getGitInfo';
+import GitFixture from './support/gitFixture';
+
+/**
+ * Real-git tests for getGitInfo, driven by the deterministic {@link GitFixture}
+ * harness. No git commands are mocked - these exercise the actual sub-commands
+ * getGitInfo relies on.
+ */
+
+let fixture: GitFixture;
+
+// getGitInfo reads GitHub-Actions env vars; neutralise them so the suite is
+// stable whether it runs locally or inside Actions (where they'd be set).
+const GIT_ENV_KEYS = ['GITHUB_HEAD_REF', 'GITHUB_REF_NAME'] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of GIT_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = undefined as unknown as GitFixture;
+  for (const key of GIT_ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+describe('getGitInfo - base payload', () => {
+  it('captures branchName, commitHash and commitName for a simple repo', async () => {
+    fixture = GitFixture.create();
+    const sha = fixture.commitFile('initial commit');
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('main');
+    expect(info.commitHash).toBe(sha);
+    expect(info.commitName).toBe('initial commit');
+  });
+
+  it('reports a clean, non-shallow repo and omits PR-head for a root commit', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('only commit');
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.isShallow).toBe(false);
+    expect(info.isDirty).toBe(false);
+    // Root commit has no parents -> these additive fields are omitted.
+    expect(info.parentCommitHashes).toBeUndefined();
+    expect(info.prHeadCommitHash).toBeUndefined();
+    expect(info.ancestorCommitHashes).toBeUndefined();
+  });
+});
+
+describe('getGitInfo - parents and ancestors', () => {
+  it('captures the single parent and the bounded ancestor chain', async () => {
+    fixture = GitFixture.create();
+    const c1 = fixture.commitFile('c1');
+    const c2 = fixture.commitFile('c2');
+    const c3 = fixture.commitFile('c3');
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.commitHash).toBe(c3);
+    expect(info.parentCommitHashes).toEqual([c2]);
+    // First-parent ancestry of HEAD, excluding HEAD itself, newest first.
+    expect(info.ancestorCommitHashes).toEqual([c2, c1]);
+  });
+
+  it('bounds the ancestor list to ANCESTOR_LIMIT entries', async () => {
+    fixture = GitFixture.create();
+    for (let i = 0; i <= ANCESTOR_LIMIT + 5; i++) {
+      fixture.commitFile(`commit ${i}`);
+    }
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.ancestorCommitHashes).toHaveLength(ANCESTOR_LIMIT);
+  });
+});
+
+describe('getGitInfo - PR merge ref', () => {
+  it('reports the real PR-head SHA (second parent), not the synthetic merge commit', async () => {
+    fixture = GitFixture.create();
+    const base = fixture.commitFile('base on main');
+
+    // PR source branch with its own head commit.
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head commit', 'feature.txt');
+
+    // Synthetic merge commit, as GitHub Actions creates for refs/pull/N/merge.
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    // Simulate the CI PR merge-ref environment.
+    process.env.GITHUB_REF_NAME = '123/merge';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.commitHash).toBe(mergeSha);
+    expect(info.parentCommitHashes).toEqual([base, prHead]);
+    expect(info.prHeadCommitHash).toBe(prHead);
+  });
+
+  it('does not set prHeadCommitHash for a normal merge outside a PR merge ref', async () => {
+    fixture = GitFixture.create();
+    const base = fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head commit', 'feature.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+
+    // No GITHUB_REF_NAME=*/merge -> not a PR merge ref.
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.commitHash).toBe(mergeSha);
+    expect(info.parentCommitHashes).toEqual([base, prHead]);
+    expect(info.prHeadCommitHash).toBeUndefined();
+  });
+});
+
+describe('getGitInfo - shallow clone', () => {
+  it('flags a depth-1 shallow clone as shallow', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    fixture.commitFile('c2');
+    fixture.commitFile('c3');
+
+    const shallow = fixture.shallowClone(1, 'main');
+    try {
+      const info = await getGitInfo(shallow.dir);
+      expect(info.isShallow).toBe(true);
+    } finally {
+      shallow.cleanup();
+    }
+  });
+});
+
+describe('getGitInfo - dirty working tree', () => {
+  it('flags an uncommitted change as dirty', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('clean commit');
+    fixture.makeDirty();
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.isDirty).toBe(true);
+  });
+});
+
+describe('getGitInfo - failure fallback', () => {
+  it('returns the unknown sentinel outside a git repository', async () => {
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const nonRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-not-a-repo-'));
+
+    try {
+      const info = await getGitInfo(nonRepo);
+      expect(info).toEqual({
+        commitName: 'unknown',
+        commitHash: 'unknown',
+        branchName: 'unknown',
+      });
+    } finally {
+      fs.rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/helpers/__tests__/openBuildGitInfoBackwardCompat.test.ts
+++ b/packages/cli/src/helpers/__tests__/openBuildGitInfoBackwardCompat.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OpenBuildRequest } from '@sherlo/api-types';
+// Import the real openBuild client factory (transport-agnostic): it forwards the
+// whole `gitInfo` object as the `$gitInfo: GitInfoInput!` GraphQL variable
+// without enumerating its sub-fields. That is exactly why additive optional
+// fields are backward compatible.
+import openBuild from '@sherlo/sdk-client/dist/requests/mutations/openBuild';
+
+function createFakeApolloClient() {
+  const mutate = vi.fn().mockResolvedValue({
+    data: { openBuild: { build: { index: 1 }, projectIndex: 0, teamId: 'team' } },
+  });
+  // openBuild only ever calls client.mutate(...)
+  return { client: { mutate } as any, mutate };
+}
+
+const baseRequest: Omit<OpenBuildRequest, 'gitInfo'> = {
+  buildRunConfig: {} as OpenBuildRequest['buildRunConfig'],
+  projectIndex: 0,
+  teamId: 'team',
+};
+
+describe('openBuild gitInfo backward compatibility', () => {
+  it('opens a build with the legacy 3-field payload (unknown sentinel)', async () => {
+    const { client, mutate } = createFakeApolloClient();
+
+    const legacyGitInfo = {
+      branchName: 'unknown',
+      commitHash: 'unknown',
+      commitName: 'unknown',
+    };
+
+    const result = await openBuild(client)({ ...baseRequest, gitInfo: legacyGitInfo });
+
+    expect(result).toEqual({ build: { index: 1 }, projectIndex: 0, teamId: 'team' });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0].variables.gitInfo).toEqual(legacyGitInfo);
+  });
+
+  it('opens a build with a real 3-field payload', async () => {
+    const { client, mutate } = createFakeApolloClient();
+
+    const gitInfo = {
+      branchName: 'main',
+      commitHash: 'abc123',
+      commitName: 'feat: something',
+    };
+
+    await openBuild(client)({ ...baseRequest, gitInfo });
+
+    expect(mutate.mock.calls[0][0].variables.gitInfo).toEqual(gitInfo);
+  });
+
+  it('forwards the new additive optional fields untouched when present', async () => {
+    const { client, mutate } = createFakeApolloClient();
+
+    const gitInfo = {
+      branchName: 'main',
+      commitHash: 'merge-sha',
+      commitName: 'Merge feature',
+      prHeadCommitHash: 'pr-head-sha',
+      parentCommitHashes: ['base-sha', 'pr-head-sha'],
+      ancestorCommitHashes: ['base-sha'],
+      isShallow: false,
+      isDirty: true,
+    };
+
+    await openBuild(client)({ ...baseRequest, gitInfo });
+
+    expect(mutate.mock.calls[0][0].variables.gitInfo).toEqual(gitInfo);
+  });
+});

--- a/packages/cli/src/helpers/__tests__/support/gitFixture.test.ts
+++ b/packages/cli/src/helpers/__tests__/support/gitFixture.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import GitFixture from './gitFixture';
+
+/**
+ * Self-tests for the deterministic harness. The point of the dual-date pinning +
+ * config isolation is that an identical sequence of operations yields identical
+ * SHAs across runs and machines.
+ */
+describe('GitFixture determinism', () => {
+  function buildSequence(): { fixture: GitFixture; shas: string[] } {
+    const fixture = GitFixture.create();
+    const shas = [
+      fixture.commitFile('c1'),
+      fixture.commitFile('c2'),
+      fixture.commitFile('c3'),
+    ];
+    return { fixture, shas };
+  }
+
+  it('produces identical SHAs for an identical operation sequence', () => {
+    const a = buildSequence();
+    const b = buildSequence();
+    try {
+      expect(a.shas).toEqual(b.shas);
+      // SHAs are full 40-char hex digests.
+      for (const sha of a.shas) {
+        expect(sha).toMatch(/^[0-9a-f]{40}$/);
+      }
+    } finally {
+      a.fixture.cleanup();
+      b.fixture.cleanup();
+    }
+  });
+
+  it('supports squash and detach helpers', () => {
+    const fixture = GitFixture.create();
+    try {
+      fixture.commitFile('base');
+      fixture.branch('feature', { checkout: true });
+      fixture.commitFile('feature work', 'feature.txt');
+      fixture.checkout('main');
+      const squash = fixture.squashMerge('feature');
+
+      // A squash merge yields a single-parent commit on main.
+      const parents = fixture.git(['rev-list', '--parents', '-n', '1', squash]).split(' ');
+      expect(parents).toHaveLength(2); // [self, single-parent]
+
+      fixture.detach('main');
+      // Detached HEAD reports the literal "HEAD" as its abbreviated ref.
+      expect(fixture.git(['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('HEAD');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/packages/cli/src/helpers/__tests__/support/gitFixture.ts
+++ b/packages/cli/src/helpers/__tests__/support/gitFixture.ts
@@ -1,0 +1,194 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Deterministic git-fixture harness for real-git tests.
+ *
+ * Goals:
+ * - Real `git` invocations (no mocking) so behaviour matches production.
+ * - Reproducible SHAs across machines and runs. Achieved via:
+ *   - **dual-date pinning**: every commit pins both `GIT_AUTHOR_DATE` and
+ *     `GIT_COMMITTER_DATE` to a fixed, monotonically increasing timestamp.
+ *   - **identity pinning**: author/committer name + email are fixed.
+ *   - **config isolation**: `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are routed
+ *     to /dev/null and `GIT_CONFIG_NOSYSTEM=1`, so the host's `~/.gitconfig`
+ *     (user.name, commit.gpgsign, init.defaultBranch, …) can't leak in and
+ *     perturb the hashes.
+ *
+ * Tests should still treat returned SHAs as opaque (compare against the value a
+ * helper method returns) rather than hard-coding hex strings - determinism is
+ * about stability, not about memorising a particular digest.
+ */
+
+const FIXTURE_IDENTITY = {
+  name: 'Sherlo Fixture',
+  email: 'fixture@sherlo.io',
+} as const;
+
+// Fixed epoch base (2021-01-01T00:00:00Z). Each commit advances by a fixed step
+// so ordering is well-defined while remaining fully deterministic.
+const BASE_EPOCH_SECONDS = 1_609_459_200;
+const COMMIT_STEP_SECONDS = 60;
+
+export class GitFixture {
+  readonly dir: string;
+  private commitCount = 0;
+
+  private constructor(dir: string) {
+    this.dir = dir;
+  }
+
+  /** Creates an isolated temp dir and runs `git init` on the `main` branch. */
+  static create(): GitFixture {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-git-fixture-'));
+    const fixture = new GitFixture(dir);
+    fixture.git(['init', '-q', '--initial-branch=main']);
+    return fixture;
+  }
+
+  /** Runs a raw git command in the fixture repo and returns trimmed stdout. */
+  git(args: string[], extraEnv: NodeJS.ProcessEnv = {}): string {
+    return execFileSync('git', args, {
+      cwd: this.dir,
+      encoding: 'utf8',
+      env: this.env(extraEnv),
+    }).trim();
+  }
+
+  /** Writes (or overwrites) a tracked file with deterministic content. */
+  writeFile(file: string, content: string): void {
+    fs.writeFileSync(path.join(this.dir, file), content, 'utf8');
+  }
+
+  /**
+   * Stages all changes and commits with date/identity pinning.
+   * @returns the full SHA of the new commit.
+   */
+  commit(message: string, opts: { allowEmpty?: boolean } = {}): string {
+    this.git(['add', '-A']);
+    const args = ['commit', '-q', '-m', message];
+    if (opts.allowEmpty) args.push('--allow-empty');
+    this.git(args, this.commitDateEnv());
+    return this.head();
+  }
+
+  /** Convenience: writes a file derived from `message`, then commits. */
+  commitFile(message: string, file = 'file.txt'): string {
+    this.writeFile(file, `content for: ${message}\n`);
+    return this.commit(message);
+  }
+
+  /** Creates a branch (without switching to it by default). */
+  branch(name: string, opts: { checkout?: boolean } = {}): void {
+    if (opts.checkout) {
+      this.git(['checkout', '-q', '-b', name]);
+    } else {
+      this.git(['branch', name]);
+    }
+  }
+
+  /** Switches to an existing branch, tag, or commit. */
+  checkout(ref: string): void {
+    this.git(['checkout', '-q', ref]);
+  }
+
+  /** Detaches HEAD at the given ref. */
+  detach(ref: string): void {
+    this.git(['checkout', '-q', '--detach', ref]);
+  }
+
+  /**
+   * Merges `ref` into the current branch with a real merge commit (`--no-ff`).
+   * The resulting commit has two parents: [current-tip, ref-tip].
+   * @returns the merge commit SHA.
+   */
+  merge(ref: string, message = `Merge ${ref}`): string {
+    this.git(['merge', '-q', '--no-ff', '--no-edit', '-m', message, ref], this.commitDateEnv());
+    return this.head();
+  }
+
+  /**
+   * Squash-merges `ref` into the current branch: collapses `ref`'s changes into
+   * a single new commit on the current branch with a single parent.
+   * @returns the squash commit SHA.
+   */
+  squashMerge(ref: string, message = `Squash ${ref}`): string {
+    this.git(['merge', '-q', '--squash', ref]);
+    return this.commit(message);
+  }
+
+  /** Rebases the current branch onto `ref`. */
+  rebase(ref: string): void {
+    this.git(['rebase', '-q', ref], this.commitDateEnv());
+  }
+
+  /**
+   * Produces a shallow (`--depth`) clone of this repo and returns a fixture
+   * pointing at the clone. The clone shares the same isolated git env.
+   */
+  shallowClone(depth = 1, ref = 'main'): GitFixture {
+    // mkdtemp creates an empty dir; git clone is happy to populate an empty dir.
+    const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-git-shallow-'));
+    // Run the clone from a known-existing cwd (the target dir is the argument).
+    // file:// is required for git to honour --depth against a local path.
+    execFileSync(
+      'git',
+      ['clone', '-q', `--depth=${depth}`, '--branch', ref, `file://${this.dir}`, cloneDir],
+      { cwd: os.tmpdir(), encoding: 'utf8', env: this.env({}) }
+    );
+    return new GitFixture(cloneDir);
+  }
+
+  /** Introduces an uncommitted change so the working tree is dirty. */
+  makeDirty(file = 'dirty.txt'): void {
+    this.writeFile(file, `uncommitted-${this.commitCount}\n`);
+  }
+
+  /** Full SHA of HEAD. */
+  head(): string {
+    return this.git(['rev-parse', 'HEAD']);
+  }
+
+  /** Full SHA of an arbitrary ref. */
+  revParse(ref: string): string {
+    return this.git(['rev-parse', ref]);
+  }
+
+  /** Removes the temp directory. */
+  cleanup(): void {
+    fs.rmSync(this.dir, { recursive: true, force: true });
+  }
+
+  /* ----------------------------------------------------------------------- */
+
+  private env(extraEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      // Config isolation - the host gitconfig must not influence hashes.
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      // Identity pinning.
+      GIT_AUTHOR_NAME: FIXTURE_IDENTITY.name,
+      GIT_AUTHOR_EMAIL: FIXTURE_IDENTITY.email,
+      GIT_COMMITTER_NAME: FIXTURE_IDENTITY.name,
+      GIT_COMMITTER_EMAIL: FIXTURE_IDENTITY.email,
+      ...extraEnv,
+    };
+  }
+
+  /** Dual-date pinning for the next commit; advances the deterministic clock. */
+  private commitDateEnv(): NodeJS.ProcessEnv {
+    const seconds = BASE_EPOCH_SECONDS + this.commitCount * COMMIT_STEP_SECONDS;
+    this.commitCount += 1;
+    const isoDate = `${seconds} +0000`;
+    return {
+      GIT_AUTHOR_DATE: isoDate,
+      GIT_COMMITTER_DATE: isoDate,
+    };
+  }
+}
+
+export default GitFixture;

--- a/packages/cli/src/helpers/getGitInfo.ts
+++ b/packages/cli/src/helpers/getGitInfo.ts
@@ -1,6 +1,41 @@
 import { Build } from '@sherlo/api-types';
 import runShellCommand from './runShellCommand';
 
+/**
+ * Git metadata captured for a build.
+ *
+ * The first three fields ({@link GitInfo.branchName}, {@link GitInfo.commitHash},
+ * {@link GitInfo.commitName}) are the historical, always-present payload. Every
+ * other field is OPTIONAL and additive: it is captured on a best-effort basis
+ * and is simply omitted when it can't be determined (older git, no PR context,
+ * a failing sub-command, …). This keeps the payload backward compatible - an
+ * old CLI sending only the three base fields (or the `'unknown'` sentinel)
+ * remains a valid `GitInfo`/`Build['gitInfo']`.
+ */
+export type GitInfo = Build['gitInfo'] & {
+  /**
+   * On a pull-request *merge ref* checkout (e.g. GitHub Actions' synthetic
+   * `refs/pull/N/merge` commit) `commitHash` points at the throw-away merge
+   * commit. This field carries the *real* PR-head SHA instead - the second
+   * parent of the merge commit.
+   */
+  prHeadCommitHash?: string;
+  /** Direct parent SHAs of `HEAD` (two or more on a merge commit). */
+  parentCommitHashes?: string[];
+  /**
+   * Bounded first-parent ancestry of `HEAD`, newest first, excluding `HEAD`
+   * itself. Capped at {@link ANCESTOR_LIMIT} entries.
+   */
+  ancestorCommitHashes?: string[];
+  /** Whether the repository is a shallow clone (e.g. `clone --depth 1`). */
+  isShallow?: boolean;
+  /** Whether the working tree has uncommitted changes. */
+  isDirty?: boolean;
+};
+
+/** Maximum number of ancestor SHAs captured in {@link GitInfo.ancestorCommitHashes}. */
+export const ANCESTOR_LIMIT = 20;
+
 async function resolveBranchName(projectRoot: string): Promise<string> {
   // GitHub Actions: GITHUB_HEAD_REF is set on pull_request events (PR source branch)
   const githubHeadRef = process.env.GITHUB_HEAD_REF;
@@ -18,7 +53,82 @@ async function resolveBranchName(projectRoot: string): Promise<string> {
   });
 }
 
-async function getGitInfo(projectRoot: string): Promise<Build['gitInfo']> {
+/**
+ * Detects whether we're sitting on a CI-provided pull-request *merge ref*.
+ *
+ * On `pull_request` events GitHub checks out a synthetic merge commit and sets
+ * `GITHUB_REF_NAME` to `"<number>/merge"`. In that situation `HEAD` is the merge
+ * commit and its second parent is the actual PR head.
+ */
+function isPullRequestMergeRef(): boolean {
+  const githubRefName = process.env.GITHUB_REF_NAME;
+  return !!githubRefName && githubRefName.includes('/merge');
+}
+
+/**
+ * Best-effort capture of the additive git fields. Each field is resolved
+ * independently and silently dropped on failure so that a single unsupported
+ * sub-command can never compromise the base payload.
+ */
+async function getAdditionalGitInfo(projectRoot: string): Promise<Partial<GitInfo>> {
+  const additional: Partial<GitInfo> = {};
+
+  const safe = async (fn: () => Promise<void>): Promise<void> => {
+    try {
+      await fn();
+    } catch {
+      // Additive field - leave it undefined and carry on.
+    }
+  };
+
+  await safe(async () => {
+    // %P lists the full parent SHAs separated by spaces (empty for the root commit).
+    const parents = await runShellCommand({
+      command: 'git log -1 --pretty=format:%P',
+      projectRoot,
+    });
+    const parentCommitHashes = parents.split(' ').filter(Boolean);
+    if (parentCommitHashes.length > 0) {
+      additional.parentCommitHashes = parentCommitHashes;
+
+      // On a PR merge ref the second parent is the real PR-head commit.
+      if (isPullRequestMergeRef() && parentCommitHashes.length >= 2) {
+        additional.prHeadCommitHash = parentCommitHashes[1];
+      }
+    }
+  });
+
+  await safe(async () => {
+    const ancestors = await runShellCommand({
+      command: `git rev-list --first-parent --skip=1 --max-count=${ANCESTOR_LIMIT} HEAD`,
+      projectRoot,
+    });
+    const ancestorCommitHashes = ancestors.split('\n').filter(Boolean);
+    if (ancestorCommitHashes.length > 0) {
+      additional.ancestorCommitHashes = ancestorCommitHashes;
+    }
+  });
+
+  await safe(async () => {
+    const isShallow = await runShellCommand({
+      command: 'git rev-parse --is-shallow-repository',
+      projectRoot,
+    });
+    additional.isShallow = isShallow.trim() === 'true';
+  });
+
+  await safe(async () => {
+    const status = await runShellCommand({
+      command: 'git status --porcelain',
+      projectRoot,
+    });
+    additional.isDirty = status.trim().length > 0;
+  });
+
+  return additional;
+}
+
+async function getGitInfo(projectRoot: string): Promise<GitInfo> {
   try {
     const commitName = await runShellCommand({
       command: 'git log -1 --pretty=format:%s',
@@ -27,7 +137,9 @@ async function getGitInfo(projectRoot: string): Promise<Build['gitInfo']> {
     const commitHash = await runShellCommand({ command: 'git rev-parse HEAD', projectRoot });
     const branchName = await resolveBranchName(projectRoot);
 
-    return { commitName, commitHash, branchName };
+    const additional = await getAdditionalGitInfo(projectRoot);
+
+    return { commitName, commitHash, branchName, ...additional };
   } catch (error) {
     console.warn("Couldn't get git info", error);
 


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1399

## Summary

Step 1 of the branch/PR visual-testing workflow rollout - strictly additive, no behavior change (CLI side of SHERLO-1399).

Extends the Sherlo CLI git capture (getGitInfo) to additionally collect OPTIONAL git metadata, threaded through the shared GitInfo type and the openBuild payload as optional fields so old CLIs and the 'unknown' sentinel keep working byte-identically.

New optional gitInfo fields:
- prHeadCommitHash - real PR-head SHA (second parent of a PR merge commit, resolved on GitHub Actions merge refs rather than the synthetic merge commit)
- parentCommitHashes - direct parent SHAs of HEAD
- ancestorCommitHashes - bounded first-parent ancestry, newest first (max 20)
- isShallow - shallow-clone flag
- isDirty - dirty working-tree flag

Each additive field is captured best-effort and silently omitted on failure, so a single unsupported git sub-command can never compromise the base payload.

Also adds a reusable deterministic git-fixture test harness (real git; dual-date + identity pinning + GIT_CONFIG isolation for stable SHAs) supporting init/commit/branch/checkout/merge/squash/rebase/shallow/detached/dirty - the foundation later git tests reuse.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*

## Test Plan

- Real-git fixture tests for every new field, including the PR merge-ref to real PR-head SHA case, shallow clone, dirty tree, parents, and bounded ancestry
- Backward-compat test: legacy 3-field payload and the 'unknown' sentinel still open a build; the openBuild client forwards new fields untouched when present
- 111 CLI tests green, tsc --noEmit clean
