### PR TITLE
feat: [Hardening] Ancestry baseline hardening: frozen per-build re…

### DIFF
--- a/.github/workflows/test:unit.yml
+++ b/.github/workflows/test:unit.yml
@@ -1,0 +1,32 @@
+name: 'test:unit'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+jobs:
+  cli-unit-tests:
+    name: CLI unit tests (@sherlo/cli)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download Sherlo packages
+        run: ./scripts/init-env.sh
+        env:
+          CLIENT_STAGE: dev
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run CLI unit tests
+        working-directory: packages/cli
+        run: yarn test

--- a/packages/cli/src/commands/test/helpers/__tests__/executeCommand.test.ts
+++ b/packages/cli/src/commands/test/helpers/__tests__/executeCommand.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildRerunArgs } from '../executeCommand';
+
+describe('buildRerunArgs - re-run hint flag formatting', () => {
+  it('converts camelCase option keys to kebab-case CLI flags', () => {
+    const args = buildRerunArgs('test:standard', {
+      gitBranch: 'my-feature',
+      projectRoot: '/app',
+      token: 'tok123',
+    });
+
+    expect(args).toContain('--git-branch');
+    expect(args).toContain('--project-root');
+    expect(args).toContain('--token');
+    // No camelCase flags in the output.
+    expect(args.join(' ')).not.toMatch(/--[a-z]+[A-Z]/);
+  });
+
+  it('emits --git-branch, not --gitBranch', () => {
+    const args = buildRerunArgs('test:standard', { gitBranch: 'feature/foo' });
+
+    expect(args).toContain('--git-branch');
+    expect(args).toContain('feature/foo');
+    expect(args).not.toContain('--gitBranch');
+  });
+
+  it('omits falsy string values', () => {
+    const args = buildRerunArgs('test:standard', { gitBranch: '', token: 'tok' });
+
+    expect(args).not.toContain('--git-branch');
+    expect(args).toContain('--token');
+  });
+
+  it('emits boolean flags without a value when true, omits when false', () => {
+    const args = buildRerunArgs('test:eas-cloud-build', {
+      waitForEasBuild: true,
+      someBoolFalse: false,
+    });
+
+    expect(args).toContain('--wait-for-eas-build');
+    expect(args).not.toContain('--some-bool-false');
+  });
+
+  it('prefixes the command as the first element', () => {
+    const args = buildRerunArgs('test:standard', { token: 'x' });
+
+    expect(args[0]).toBe('test:standard');
+  });
+});

--- a/packages/cli/src/commands/test/helpers/executeCommand.ts
+++ b/packages/cli/src/commands/test/helpers/executeCommand.ts
@@ -24,16 +24,7 @@ async function executeCommand(
     delete filteredOptions[IOS_OPTION];
   }
 
-  const args = [command];
-  Object.entries(filteredOptions).forEach(([key, value]) => {
-    if (typeof value === 'boolean') {
-      if (value) {
-        args.push(`--${key}`);
-      }
-    } else if (value) {
-      args.push(`--${key}`, String(value));
-    }
-  });
+  const args = buildRerunArgs(command, filteredOptions);
 
   console.log();
 
@@ -70,3 +61,23 @@ async function executeCommand(
 }
 
 export default executeCommand;
+
+/**
+ * Builds the args array for the re-run hint, converting each camelCase option
+ * key to its kebab-case CLI flag (e.g. `gitBranch` → `--git-branch`).
+ */
+export function buildRerunArgs(
+  command: string,
+  options: Record<string, string | boolean>
+): string[] {
+  const args = [command];
+  for (const [key, value] of Object.entries(options)) {
+    const flag = key.replace(/[A-Z]/g, c => `-${c.toLowerCase()}`);
+    if (typeof value === 'boolean') {
+      if (value) args.push(`--${flag}`);
+    } else if (value) {
+      args.push(`--${flag}`, String(value));
+    }
+  }
+  return args;
+}

--- a/packages/cli/src/commands/testEasCloudBuild/testEasCloudBuild.ts
+++ b/packages/cli/src/commands/testEasCloudBuild/testEasCloudBuild.ts
@@ -48,7 +48,7 @@ async function testEasCloudBuild(passedOptions: Options<THIS_COMMAND>) {
       projectIndex,
       asyncUpload: true,
       buildRunConfig: getBuildRunConfig({ commandParams }),
-      gitInfo: await getGitInfo(commandParams.projectRoot),
+      gitInfo: await getGitInfo(commandParams.projectRoot, { branchOverride: commandParams.gitBranch }),
       message: commandParams.message,
     })
     .catch(handleClientError);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -74,6 +74,7 @@ export const FULL_INIT_COMMAND = 'npx sherlo init';
 
 export const ANDROID_OPTION = 'android';
 export const BRANCH_OPTION = 'branch';
+export const GIT_BRANCH_OPTION = 'gitBranch';
 export const CONFIG_OPTION = 'config';
 export const DIAGNOSTICS_OPTION = 'diagnostics';
 export const EAS_ANDROID_URL_OPTION = 'easAndroidUrl';

--- a/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
+++ b/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
@@ -10,9 +10,19 @@ import GitFixture from './support/gitFixture';
 
 let fixture: GitFixture;
 
-// getGitInfo reads GitHub-Actions env vars; neutralise them so the suite is
-// stable whether it runs locally or inside Actions (where they'd be set).
-const GIT_ENV_KEYS = ['GITHUB_HEAD_REF', 'GITHUB_REF_NAME'] as const;
+// getGitInfo reads env vars from several CI providers; neutralise all of them
+// so the suite is stable whether it runs locally or inside any CI environment.
+const GIT_ENV_KEYS = [
+  'GITHUB_HEAD_REF',
+  'GITHUB_REF_NAME',
+  'SHERLO_BRANCH',
+  'BITRISE_GIT_BRANCH',
+  'CIRCLE_BRANCH',
+  'CI_COMMIT_REF_NAME',
+  'CM_BRANCH',
+  'BUILD_SOURCEBRANCH',
+  'SYSTEM_PULLREQUEST_SOURCEBRANCH',
+] as const;
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
@@ -34,6 +44,10 @@ afterEach(() => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Base payload
+// ---------------------------------------------------------------------------
+
 describe('getGitInfo - base payload', () => {
   it('captures branchName, commitHash and commitName for a simple repo', async () => {
     fixture = GitFixture.create();
@@ -46,7 +60,7 @@ describe('getGitInfo - base payload', () => {
     expect(info.commitName).toBe('initial commit');
   });
 
-  it('reports a clean, non-shallow repo and omits PR-head for a root commit', async () => {
+  it('reports a clean, non-shallow repo and omits ancestry fields for a root commit', async () => {
     fixture = GitFixture.create();
     fixture.commitFile('only commit');
 
@@ -56,10 +70,15 @@ describe('getGitInfo - base payload', () => {
     expect(info.isDirty).toBe(false);
     // Root commit has no parents -> these additive fields are omitted.
     expect(info.parentCommitHashes).toBeUndefined();
-    expect(info.prHeadCommitHash).toBeUndefined();
     expect(info.ancestorCommitHashes).toBeUndefined();
+    // Not on a merge ref -> prHeadCommitHash absent.
+    expect(info.prHeadCommitHash).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Parents and ancestors
+// ---------------------------------------------------------------------------
 
 describe('getGitInfo - parents and ancestors', () => {
   it('captures the single parent and the bounded ancestor chain', async () => {
@@ -76,7 +95,7 @@ describe('getGitInfo - parents and ancestors', () => {
     expect(info.ancestorCommitHashes).toEqual([c2, c1]);
   });
 
-  it('bounds the ancestor list to ANCESTOR_LIMIT entries', async () => {
+  it('bounds the ancestor list to ANCESTOR_LIMIT (200) entries', async () => {
     fixture = GitFixture.create();
     for (let i = 0; i <= ANCESTOR_LIMIT + 5; i++) {
       fixture.commitFile(`commit ${i}`);
@@ -84,50 +103,465 @@ describe('getGitInfo - parents and ancestors', () => {
 
     const info = await getGitInfo(fixture.dir);
 
+    expect(ANCESTOR_LIMIT).toBe(200);
     expect(info.ancestorCommitHashes).toHaveLength(ANCESTOR_LIMIT);
-  });
+  }, 30_000);
 });
 
-describe('getGitInfo - PR merge ref', () => {
-  it('reports the real PR-head SHA (second parent), not the synthetic merge commit', async () => {
-    fixture = GitFixture.create();
-    const base = fixture.commitFile('base on main');
+// ---------------------------------------------------------------------------
+// PR merge ref – canonicalisation
+// ---------------------------------------------------------------------------
 
-    // PR source branch with its own head commit.
+describe('getGitInfo - PR merge ref (refs/pull/N/merge)', () => {
+  it('sets commitHash to the PR head (second parent), not the synthetic merge commit', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+
     fixture.branch('feature', { checkout: true });
     const prHead = fixture.commitFile('pr head commit', 'feature.txt');
 
-    // Synthetic merge commit, as GitHub Actions creates for refs/pull/N/merge.
     fixture.checkout('main');
     const mergeSha = fixture.merge('feature');
     fixture.detach(mergeSha);
 
-    // Simulate the CI PR merge-ref environment.
     process.env.GITHUB_REF_NAME = '123/merge';
 
     const info = await getGitInfo(fixture.dir);
 
-    expect(info.commitHash).toBe(mergeSha);
-    expect(info.parentCommitHashes).toEqual([base, prHead]);
-    expect(info.prHeadCommitHash).toBe(prHead);
+    // commitHash must be the real PR head, not the synthetic merge commit.
+    expect(info.commitHash).toBe(prHead);
+    expect(info.commitHash).not.toBe(mergeSha);
   });
 
-  it('does not set prHeadCommitHash for a normal merge outside a PR merge ref', async () => {
+  it('sets parentCommitHashes and ancestorCommitHashes relative to the PR head', async () => {
     fixture = GitFixture.create();
     const base = fixture.commitFile('base on main');
+
     fixture.branch('feature', { checkout: true });
     const prHead = fixture.commitFile('pr head commit', 'feature.txt');
+
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = '123/merge';
+
+    const info = await getGitInfo(fixture.dir);
+
+    // PR head's parent is `base`, NOT [base, prHead] (those are the merge's parents).
+    expect(info.parentCommitHashes).toEqual([base]);
+    // PR head's first-parent ancestry also leads to `base`.
+    expect(info.ancestorCommitHashes).toEqual([base]);
+  });
+
+  it('sets prHeadCommitHash to the PR head SHA as a merge-ref signal', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head', 'feature.txt');
+
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = '42/merge';
+
+    const info = await getGitInfo(fixture.dir);
+
+    // prHeadCommitHash signals to the server that this is a synthetic merge ref.
+    expect(info.prHeadCommitHash).toBe(prHead);
+    // commitHash is also the PR head (canonicalised).
+    expect(info.commitHash).toBe(prHead);
+  });
+
+  it('computes mergeBaseSha as the true fork-point, not the base-branch tip', async () => {
+    fixture = GitFixture.create();
+    const forkPoint = fixture.commitFile('fork point');
+
+    // Feature branch forks from forkPoint.
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head', 'feature.txt');
+
+    // Main advances AFTER the fork (so base tip != fork point).
+    fixture.checkout('main');
+    const baseTip = fixture.commitFile('base advances after fork');
+
+    // Create the synthetic merge commit.
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = '7/merge';
+
+    const info = await getGitInfo(fixture.dir);
+
+    // The true fork-point is `forkPoint`, not `baseTip`.
+    expect(info.mergeBaseSha).toBe(forkPoint);
+    expect(info.mergeBaseSha).not.toBe(baseTip);
+  });
+
+  it('does not canonicalise for a normal merge outside a PR merge ref env', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head commit', 'feature.txt');
     fixture.checkout('main');
     const mergeSha = fixture.merge('feature');
 
-    // No GITHUB_REF_NAME=*/merge -> not a PR merge ref.
+    // No GITHUB_REF_NAME set -> not a PR merge ref.
     const info = await getGitInfo(fixture.dir);
 
     expect(info.commitHash).toBe(mergeSha);
-    expect(info.parentCommitHashes).toEqual([base, prHead]);
+    expect(info.prHeadCommitHash).toBeUndefined();
+    expect(info.mergeBaseSha).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// merge_group canonicalisation
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - merge_group (gh-readonly-queue)', () => {
+  it('canonicalises commitHash to the PR head (second parent)', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('merge queue pr head', 'feature.txt');
+
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = 'gh-readonly-queue/main/pr-7-abc123';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.commitHash).toBe(prHead);
+    expect(info.commitHash).not.toBe(mergeSha);
+  });
+
+  it('sets prHeadCommitHash to the PR head SHA for merge_group refs', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base');
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head', 'f.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = 'gh-readonly-queue/main/pr-7-abc123';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.prHeadCommitHash).toBe(prHead);
+  });
+
+  it('resolves branchName to the base branch extracted from the ref', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head', 'f.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = 'gh-readonly-queue/main/pr-7-abc123';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('main');
+  });
+
+  it('omits prHeadCommitHash on a plain (non-merge-ref) checkout', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+
+    const info = await getGitInfo(fixture.dir);
+
     expect(info.prHeadCommitHash).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Branch resolution precedence
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - branch resolution precedence', () => {
+  it('explicit branchOverride (--git-branch flag) wins over all env vars', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.SHERLO_BRANCH = 'from-env';
+    process.env.BITRISE_GIT_BRANCH = 'from-bitrise';
+    process.env.GITHUB_HEAD_REF = 'from-github';
+
+    const info = await getGitInfo(fixture.dir, { branchOverride: 'explicit-override' });
+
+    expect(info.branchName).toBe('explicit-override');
+  });
+
+  it('SHERLO_BRANCH wins over provider env vars', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.SHERLO_BRANCH = 'sherlo-branch';
+    process.env.BITRISE_GIT_BRANCH = 'from-bitrise';
+    process.env.CIRCLE_BRANCH = 'from-circle';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('sherlo-branch');
+  });
+
+  it('treats bare "merge" value in SHERLO_BRANCH as absent', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.SHERLO_BRANCH = 'merge';
+    process.env.BITRISE_GIT_BRANCH = 'from-bitrise';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('from-bitrise');
+  });
+
+  it('BITRISE_GIT_BRANCH is used when higher-priority signals absent', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.BITRISE_GIT_BRANCH = 'my-feature';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('my-feature');
+  });
+
+  it('CIRCLE_BRANCH wins over GitLab and below', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.CIRCLE_BRANCH = 'circle-feature';
+    process.env.CI_COMMIT_REF_NAME = 'gitlab-branch';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('circle-feature');
+  });
+
+  it('CI_COMMIT_REF_NAME (GitLab) wins over Codemagic and below', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.CI_COMMIT_REF_NAME = 'gitlab-feature';
+    process.env.CM_BRANCH = 'codemagic-branch';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('gitlab-feature');
+  });
+
+  it('CM_BRANCH (Codemagic) wins over Azure and below', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.CM_BRANCH = 'codemagic-feature';
+    process.env.BUILD_SOURCEBRANCH = 'refs/heads/azure-branch';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('codemagic-feature');
+  });
+
+  it('SYSTEM_PULLREQUEST_SOURCEBRANCH (Azure PR) strips refs/heads/ and wins over BUILD_SOURCEBRANCH', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'refs/heads/azure-pr-source';
+    process.env.BUILD_SOURCEBRANCH = 'refs/heads/azure-target';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('azure-pr-source');
+  });
+
+  it('BUILD_SOURCEBRANCH with refs/heads/ stripped wins over GitHub vars', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.BUILD_SOURCEBRANCH = 'refs/heads/azure-feature';
+    process.env.GITHUB_HEAD_REF = 'github-feature';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('azure-feature');
+  });
+
+  it('treats bare "merge" in BUILD_SOURCEBRANCH after stripping as absent', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.BUILD_SOURCEBRANCH = 'refs/heads/merge';
+    process.env.GITHUB_HEAD_REF = 'github-feature';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('github-feature');
+  });
+
+  it('GITHUB_HEAD_REF wins over GITHUB_REF_NAME', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.GITHUB_HEAD_REF = 'feature/my-pr';
+    process.env.GITHUB_REF_NAME = 'other-ref';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('feature/my-pr');
+  });
+
+  it('GITHUB_REF_NAME is used when it is not a merge ref', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.GITHUB_REF_NAME = 'push-branch';
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('push-branch');
+  });
+
+  it('skips GITHUB_REF_NAME that encodes a PR merge ref (N/merge)', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    process.env.GITHUB_REF_NAME = '42/merge';
+    // No other CI env set and not on a real branch -> falls back to git
+
+    const info = await getGitInfo(fixture.dir);
+
+    // The git fallback for a non-detached HEAD returns the branch name.
+    expect(info.branchName).toBe('main');
+  });
+
+  it('detached HEAD without any CI signal yields "HEAD" sentinel', async () => {
+    fixture = GitFixture.create();
+    const sha = fixture.commitFile('c1');
+    fixture.detach(sha);
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.branchName).toBe('HEAD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repoSlug
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - repoSlug', () => {
+  it('captures owner/repo from an HTTPS remote', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    fixture.git(['remote', 'add', 'origin', 'https://github.com/acme/my-app.git']);
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.repoSlug).toBe('acme/my-app');
+  });
+
+  it('captures owner/repo from an SSH remote', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    fixture.git(['remote', 'add', 'origin', 'git@github.com:acme/my-app.git']);
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.repoSlug).toBe('acme/my-app');
+  });
+
+  it('is host-agnostic (works for GitLab, Bitbucket, etc.)', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    fixture.git(['remote', 'add', 'origin', 'git@gitlab.com:org/project.git']);
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.repoSlug).toBe('org/project');
+  });
+
+  it('is omitted when no origin remote is configured', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    // No remote added.
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.repoSlug).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeBaseSha
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - mergeBaseSha', () => {
+  it('is omitted for a non-merge-ref checkout', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.mergeBaseSha).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-parent ancestor windows (merge commits)
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - perParentAncestorCommitHashes', () => {
+  it('captures per-parent windows for the non-first parents of a merge commit', async () => {
+    fixture = GitFixture.create();
+    // Single commit on main before branching so f1's direct parent is c1.
+    const c1 = fixture.commitFile('c1');
+
+    fixture.branch('feature', { checkout: true });
+    const f1 = fixture.commitFile('f1', 'f.txt');
+    const f2 = fixture.commitFile('f2', 'f.txt');
+
+    fixture.checkout('main');
+    fixture.merge('feature');
+
+    const info = await getGitInfo(fixture.dir);
+
+    // parentCommitHashes = [c1 (main tip), f2 (feature tip)]
+    expect(info.parentCommitHashes).toEqual([c1, f2]);
+
+    // perParentAncestorCommitHashes[0] = first-parent ancestors of f2 (skip f2 itself)
+    // f2 → f1 → c1; skip f2 → [f1, c1]
+    expect(info.perParentAncestorCommitHashes).toBeDefined();
+    expect(info.perParentAncestorCommitHashes![0]).toEqual([f1, c1]);
+  });
+
+  it('is absent for a non-merge (single-parent) commit', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('c1');
+    fixture.commitFile('c2');
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.perParentAncestorCommitHashes).toBeUndefined();
+  });
+
+  it('is absent when the canonical commit is a PR head with a single parent', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr-head', 'f.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+    process.env.GITHUB_REF_NAME = '1/merge';
+
+    const info = await getGitInfo(fixture.dir);
+
+    // canonical = PR head (single-parent commit)
+    expect(info.perParentAncestorCommitHashes).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shallow clone
+// ---------------------------------------------------------------------------
 
 describe('getGitInfo - shallow clone', () => {
   it('flags a depth-1 shallow clone as shallow', async () => {
@@ -146,6 +580,10 @@ describe('getGitInfo - shallow clone', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Dirty working tree
+// ---------------------------------------------------------------------------
+
 describe('getGitInfo - dirty working tree', () => {
   it('flags an uncommitted change as dirty', async () => {
     fixture = GitFixture.create();
@@ -157,6 +595,10 @@ describe('getGitInfo - dirty working tree', () => {
     expect(info.isDirty).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Failure fallback
+// ---------------------------------------------------------------------------
 
 describe('getGitInfo - failure fallback', () => {
   it('returns the unknown sentinel outside a git repository', async () => {

--- a/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
+++ b/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
@@ -281,6 +281,58 @@ describe('getGitInfo - merge_group (gh-readonly-queue)', () => {
 
     expect(info.prHeadCommitHash).toBeUndefined();
   });
+
+  it('sets parentCommitHashes and ancestorCommitHashes relative to the PR head', async () => {
+    fixture = GitFixture.create();
+    const base = fixture.commitFile('base on main');
+
+    fixture.branch('feature', { checkout: true });
+    const prParent = fixture.commitFile('pr commit 1', 'f.txt');
+    const prHead = fixture.commitFile('pr head', 'f.txt');
+
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = 'gh-readonly-queue/main/pr-42-abc';
+
+    const info = await getGitInfo(fixture.dir);
+
+    // Canonicalised to PR head – ancestry is relative to the real PR commit.
+    expect(info.commitHash).toBe(prHead);
+    // PR head's immediate parent is prParent, not the merge's [base, prHead].
+    expect(info.parentCommitHashes).toEqual([prParent]);
+    // First-parent ancestry of PR head: prParent → base.
+    expect(info.ancestorCommitHashes).toEqual([prParent, base]);
+  });
+
+  it('degrades gracefully on a shallow clone of a merge_group ref (no crash, isShallow detected)', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head', 'feature.txt');
+    fixture.checkout('main');
+    fixture.merge('feature');
+
+    // Shallow clone at depth=1: merge commit is present but parent history is grafted away.
+    const shallow = fixture.shallowClone(1, 'main');
+    try {
+      process.env.GITHUB_REF_NAME = 'gh-readonly-queue/main/pr-5-xyz';
+
+      const info = await getGitInfo(shallow.dir);
+
+      // Must not throw; base fields must always be present.
+      expect(info.branchName).toBeDefined();
+      expect(info.commitHash).toBeDefined();
+      expect(info.commitName).toBeDefined();
+      // Shallow clone is detected.
+      expect(info.isShallow).toBe(true);
+      // Deep ancestry is unavailable in a shallow clone – omitted rather than crashing.
+      expect(info.ancestorCommitHashes).toBeUndefined();
+    } finally {
+      shallow.cleanup();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -573,6 +625,30 @@ describe('getGitInfo - shallow clone', () => {
     const shallow = fixture.shallowClone(1, 'main');
     try {
       const info = await getGitInfo(shallow.dir);
+      expect(info.isShallow).toBe(true);
+    } finally {
+      shallow.cleanup();
+    }
+  });
+
+  it('degrades gracefully on a shallow merge-ref clone: no crash, base fields populated', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head', 'feature.txt');
+    fixture.checkout('main');
+    fixture.merge('feature');
+
+    // depth=1 → only the merge commit is available; parent commits are truncated.
+    const shallow = fixture.shallowClone(1, 'main');
+    try {
+      process.env.GITHUB_REF_NAME = '5/merge';
+      const info = await getGitInfo(shallow.dir);
+
+      // Must not fall back to the 'unknown' sentinel - we're inside a valid repo.
+      expect(info.commitName).not.toBe('unknown');
+      expect(info.commitHash).not.toBe('unknown');
+      expect(info.branchName).not.toBe('unknown');
       expect(info.isShallow).toBe(true);
     } finally {
       shallow.cleanup();

--- a/packages/cli/src/helpers/getGitInfo.ts
+++ b/packages/cli/src/helpers/getGitInfo.ts
@@ -15,38 +15,146 @@ import runShellCommand from './runShellCommand';
 export type GitInfo = Build['gitInfo'] & {
   /**
    * On a pull-request *merge ref* checkout (e.g. GitHub Actions' synthetic
-   * `refs/pull/N/merge` commit) `commitHash` points at the throw-away merge
-   * commit. This field carries the *real* PR-head SHA instead - the second
-   * parent of the merge commit.
+   * `refs/pull/N/merge` commit or a GitHub merge-queue ref) `commitHash` is
+   * canonicalised to the real PR-head SHA (the second parent of the merge
+   * commit). This field carries that same PR-head SHA and acts as the
+   * server-side SIGNAL that the build originated from a synthetic merge ref –
+   * without it a canonicalised commit is indistinguishable from a direct push
+   * to the same SHA.
    */
   prHeadCommitHash?: string;
-  /** Direct parent SHAs of `HEAD` (two or more on a merge commit). */
+  /** Direct parent SHAs of the canonical commit, newest first. */
   parentCommitHashes?: string[];
   /**
-   * Bounded first-parent ancestry of `HEAD`, newest first, excluding `HEAD`
-   * itself. Capped at {@link ANCESTOR_LIMIT} entries.
+   * Bounded first-parent ancestry of the canonical commit, newest first,
+   * excluding the commit itself. Capped at {@link ANCESTOR_LIMIT} entries.
    */
   ancestorCommitHashes?: string[];
+  /**
+   * Per-parent first-parent ancestry windows for non-first parents of the
+   * canonical commit (i.e. parents[1], parents[2], …). The outer array is
+   * index-aligned with `parentCommitHashes.slice(1)`.  Each inner array is
+   * bounded at {@link ANCESTOR_LIMIT} entries.
+   *
+   * Only present when the canonical commit is a merge commit.
+   */
+  perParentAncestorCommitHashes?: string[][];
+  /**
+   * True fork-point between the PR branch and the base branch, computed as
+   * `git merge-base HEAD^1 HEAD^2` on a synthetic merge ref.  This is the
+   * common ancestor at the time the PR was created and differs from the
+   * base-branch tip whenever the base has advanced since the PR forked.
+   */
+  mergeBaseSha?: string;
+  /** Normalised `owner/repo` slug derived from the `origin` remote URL. */
+  repoSlug?: string;
   /** Whether the repository is a shallow clone (e.g. `clone --depth 1`). */
   isShallow?: boolean;
   /** Whether the working tree has uncommitted changes. */
   isDirty?: boolean;
 };
 
-/** Maximum number of ancestor SHAs captured in {@link GitInfo.ancestorCommitHashes}. */
-export const ANCESTOR_LIMIT = 20;
+/** Maximum number of ancestor SHAs captured per ancestry window. */
+export const ANCESTOR_LIMIT = 200;
 
-async function resolveBranchName(projectRoot: string): Promise<string> {
-  // GitHub Actions: GITHUB_HEAD_REF is set on pull_request events (PR source branch)
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the current HEAD is a CI-provided synthetic merge commit:
+ *
+ * - **refs/pull/N/merge** – GitHub Actions `pull_request` event (GITHUB_REF_NAME = "N/merge")
+ * - **merge_group** – GitHub merge queue (GITHUB_REF_NAME starts with "gh-readonly-queue/")
+ */
+function isPullRequestMergeRef(): boolean {
+  const refName = process.env.GITHUB_REF_NAME;
+  if (!refName) return false;
+  return /^\d+\/merge$/.test(refName) || refName.startsWith('gh-readonly-queue/');
+}
+
+/**
+ * For a `merge_group` ref (`gh-readonly-queue/<base>/<pr-spec>`) returns the
+ * base branch name, otherwise undefined.
+ */
+function getMergeGroupBaseBranch(refName: string): string | undefined {
+  const match = refName.match(/^gh-readonly-queue\/([^/]+)\//);
+  return match?.[1];
+}
+
+/**
+ * Returns true for a value that is present but should be treated as
+ * branch-absent (e.g. a CI placeholder like "merge").
+ */
+function isBranchAbsent(value: string | undefined): boolean {
+  return !value || value === 'merge';
+}
+
+/**
+ * Resolves the branch name using a strict precedence chain:
+ *
+ * 1. Explicit caller-supplied override (--git-branch flag)
+ * 2. SHERLO_BRANCH env var
+ * 3. CI-provider env vars (Bitrise → CircleCI → GitLab → Codemagic → Azure)
+ * 4. merge_group base-branch extracted from GITHUB_REF_NAME
+ * 5. GITHUB_HEAD_REF (PR source branch on pull_request events)
+ * 6. GITHUB_REF_NAME (skipped when it encodes a merge ref like "N/merge")
+ * 7. git rev-parse --abbrev-ref HEAD (detached HEAD → "HEAD")
+ */
+async function resolveBranchName(projectRoot: string, branchOverride?: string): Promise<string> {
+  // 1. --git-branch flag
+  if (branchOverride) return branchOverride;
+
+  // 2. SHERLO_BRANCH
+  const sherloBranch = process.env.SHERLO_BRANCH;
+  if (!isBranchAbsent(sherloBranch)) return sherloBranch!;
+
+  // 3a. Bitrise
+  const bitriseBranch = process.env.BITRISE_GIT_BRANCH;
+  if (!isBranchAbsent(bitriseBranch)) return bitriseBranch!;
+
+  // 3b. CircleCI
+  const circleBranch = process.env.CIRCLE_BRANCH;
+  if (!isBranchAbsent(circleBranch)) return circleBranch!;
+
+  // 3c. GitLab CI
+  const gitlabBranch = process.env.CI_COMMIT_REF_NAME;
+  if (!isBranchAbsent(gitlabBranch)) return gitlabBranch!;
+
+  // 3d. Codemagic
+  const codemagicBranch = process.env.CM_BRANCH;
+  if (!isBranchAbsent(codemagicBranch)) return codemagicBranch!;
+
+  // 3e. Azure DevOps: SYSTEM_PULLREQUEST_SOURCEBRANCH preferred in PR context,
+  // BUILD_SOURCEBRANCH otherwise. Both may carry a "refs/heads/" prefix that
+  // must be stripped to get a bare branch name.
+  const azurePrBranch = process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH;
+  if (azurePrBranch) {
+    const stripped = azurePrBranch.replace(/^refs\/heads\//, '');
+    if (!isBranchAbsent(stripped)) return stripped;
+  }
+  const azureBranch = process.env.BUILD_SOURCEBRANCH;
+  if (azureBranch) {
+    const stripped = azureBranch.replace(/^refs\/heads\//, '');
+    if (!isBranchAbsent(stripped)) return stripped;
+  }
+
+  const githubRefName = process.env.GITHUB_REF_NAME;
+
+  // 4. merge_group: extract the base branch from the ref name
+  if (githubRefName) {
+    const mergeGroupBase = getMergeGroupBaseBranch(githubRefName);
+    if (mergeGroupBase) return mergeGroupBase;
+  }
+
+  // 5. GITHUB_HEAD_REF (PR source branch on pull_request events)
   const githubHeadRef = process.env.GITHUB_HEAD_REF;
   if (githubHeadRef) return githubHeadRef;
 
-  // GitHub Actions: GITHUB_REF_NAME is set on all events (branch/tag name)
-  // On PR events it contains "123/merge" which is not a real branch, so skip those
-  const githubRefName = process.env.GITHUB_REF_NAME;
+  // 6. GITHUB_REF_NAME (skip PR merge refs like "123/merge")
   if (githubRefName && !githubRefName.includes('/merge')) return githubRefName;
 
-  // Local git / fallback
+  // 7. git fallback (detached HEAD yields "HEAD")
   return await runShellCommand({
     command: 'git rev-parse --abbrev-ref HEAD',
     projectRoot,
@@ -54,23 +162,19 @@ async function resolveBranchName(projectRoot: string): Promise<string> {
 }
 
 /**
- * Detects whether we're sitting on a CI-provided pull-request *merge ref*.
- *
- * On `pull_request` events GitHub checks out a synthetic merge commit and sets
- * `GITHUB_REF_NAME` to `"<number>/merge"`. In that situation `HEAD` is the merge
- * commit and its second parent is the actual PR head.
- */
-function isPullRequestMergeRef(): boolean {
-  const githubRefName = process.env.GITHUB_REF_NAME;
-  return !!githubRefName && githubRefName.includes('/merge');
-}
-
-/**
- * Best-effort capture of the additive git fields. Each field is resolved
+ * Best-effort capture of additive git fields. Each field is resolved
  * independently and silently dropped on failure so that a single unsupported
  * sub-command can never compromise the base payload.
+ *
+ * When HEAD is a CI synthetic merge commit (PR merge ref or merge_group),
+ * **all** commit-identity fields are canonicalised to the real PR head (the
+ * second parent).  This ensures that `commitHash`, `parentCommitHashes`, and
+ * `ancestorCommitHashes` describe the PR author's work, not the ephemeral
+ * merge commit that CI creates.
  */
-async function getAdditionalGitInfo(projectRoot: string): Promise<Partial<GitInfo>> {
+async function getAdditionalGitInfo(
+  projectRoot: string
+): Promise<{ additional: Partial<GitInfo>; canonicalSha?: string }> {
   const additional: Partial<GitInfo> = {};
 
   const safe = async (fn: () => Promise<void>): Promise<void> => {
@@ -81,32 +185,92 @@ async function getAdditionalGitInfo(projectRoot: string): Promise<Partial<GitInf
     }
   };
 
+  const onMergeRef = isPullRequestMergeRef();
+
+  // Determine the canonical commit SHA to anchor all ancestry queries.
+  // On a PR merge ref the real PR head is the SECOND parent (HEAD^2).
+  let canonicalSha: string | undefined;
   await safe(async () => {
-    // %P lists the full parent SHAs separated by spaces (empty for the root commit).
+    if (onMergeRef) {
+      canonicalSha = await runShellCommand({
+        command: 'git rev-parse HEAD^2',
+        projectRoot,
+      });
+      // Signal to the server that this build originates from a synthetic merge
+      // ref.  Without this field a canonicalised commitHash is indistinguishable
+      // from a direct push to the same SHA.
+      additional.prHeadCommitHash = canonicalSha;
+    }
+  });
+
+  // Parent SHAs of the canonical commit.
+  await safe(async () => {
+    const target = canonicalSha ?? 'HEAD';
     const parents = await runShellCommand({
-      command: 'git log -1 --pretty=format:%P',
+      command: `git log -1 --pretty=format:%P ${target}`,
       projectRoot,
     });
     const parentCommitHashes = parents.split(' ').filter(Boolean);
     if (parentCommitHashes.length > 0) {
       additional.parentCommitHashes = parentCommitHashes;
-
-      // On a PR merge ref the second parent is the real PR-head commit.
-      if (isPullRequestMergeRef() && parentCommitHashes.length >= 2) {
-        additional.prHeadCommitHash = parentCommitHashes[1];
-      }
     }
   });
 
+  // First-parent ancestor chain of the canonical commit.
   await safe(async () => {
+    const target = canonicalSha ?? 'HEAD';
     const ancestors = await runShellCommand({
-      command: `git rev-list --first-parent --skip=1 --max-count=${ANCESTOR_LIMIT} HEAD`,
+      command: `git rev-list --first-parent --skip=1 --max-count=${ANCESTOR_LIMIT} ${target}`,
       projectRoot,
     });
     const ancestorCommitHashes = ancestors.split('\n').filter(Boolean);
     if (ancestorCommitHashes.length > 0) {
       additional.ancestorCommitHashes = ancestorCommitHashes;
     }
+  });
+
+  // Per-parent first-parent windows for non-first parents (merge commits).
+  await safe(async () => {
+    const parents = additional.parentCommitHashes;
+    if (!parents || parents.length < 2) return;
+    const windows: string[][] = [];
+    for (const parentSha of parents.slice(1)) {
+      try {
+        const out = await runShellCommand({
+          command: `git rev-list --first-parent --skip=1 --max-count=${ANCESTOR_LIMIT} ${parentSha}`,
+          projectRoot,
+        });
+        windows.push(out.split('\n').filter(Boolean));
+      } catch {
+        windows.push([]);
+      }
+    }
+    if (windows.length > 0) {
+      additional.perParentAncestorCommitHashes = windows;
+    }
+  });
+
+  // mergeBaseSha: true fork-point between PR branch and base branch.
+  // `git merge-base HEAD^1 HEAD^2` finds the common ancestor at the time the
+  // PR was created, which differs from HEAD^1 (base-branch tip) whenever the
+  // base has advanced since the PR forked.
+  await safe(async () => {
+    if (onMergeRef) {
+      additional.mergeBaseSha = await runShellCommand({
+        command: 'git merge-base HEAD^1 HEAD^2',
+        projectRoot,
+      });
+    }
+  });
+
+  // repoSlug: normalised "owner/repo" from the origin remote URL.
+  await safe(async () => {
+    const remoteUrl = await runShellCommand({
+      command: 'git remote get-url origin',
+      projectRoot,
+    });
+    const slug = parseRepoSlug(remoteUrl);
+    if (slug) additional.repoSlug = slug;
   });
 
   await safe(async () => {
@@ -125,19 +289,42 @@ async function getAdditionalGitInfo(projectRoot: string): Promise<Partial<GitInf
     additional.isDirty = status.trim().length > 0;
   });
 
-  return additional;
+  return { additional, canonicalSha };
 }
 
-async function getGitInfo(projectRoot: string): Promise<GitInfo> {
+/**
+ * Parses an `owner/repo` slug out of any common git remote URL format.
+ *
+ * Handles HTTPS (`https://host/owner/repo.git`) and SSH
+ * (`git@host:owner/repo.git`) forms, host-agnostic.
+ */
+function parseRepoSlug(remoteUrl: string): string | undefined {
+  // SSH: git@host:owner/repo.git
+  const sshMatch = remoteUrl.match(/^[^@]+@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+  // HTTPS: https://host/owner/repo.git or http://host/owner/repo
+  const httpsMatch = remoteUrl.match(/^https?:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?(?:\/)?$/);
+  if (httpsMatch) return httpsMatch[1];
+  return undefined;
+}
+
+async function getGitInfo(
+  projectRoot: string,
+  opts?: { branchOverride?: string }
+): Promise<GitInfo> {
   try {
+    const { additional, canonicalSha } = await getAdditionalGitInfo(projectRoot);
+
+    const commitHash = canonicalSha
+      ? canonicalSha
+      : await runShellCommand({ command: 'git rev-parse HEAD', projectRoot });
+
     const commitName = await runShellCommand({
-      command: 'git log -1 --pretty=format:%s',
+      command: 'git log -1 --pretty=format:%s ' + (canonicalSha ?? 'HEAD'),
       projectRoot,
     });
-    const commitHash = await runShellCommand({ command: 'git rev-parse HEAD', projectRoot });
-    const branchName = await resolveBranchName(projectRoot);
 
-    const additional = await getAdditionalGitInfo(projectRoot);
+    const branchName = await resolveBranchName(projectRoot, opts?.branchOverride);
 
     return { commitName, commitHash, branchName, ...additional };
   } catch (error) {

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -71,7 +71,7 @@ async function uploadOrReuseBuildsAndRunTests({
         },
         easUpdateData,
       }),
-      gitInfo: await getGitInfo(commandParams.projectRoot),
+      gitInfo: await getGitInfo(commandParams.projectRoot, { branchOverride: commandParams.gitBranch }),
       sdkVersion: binariesInfo.sdkVersion,
       message: commandParams.message,
     })

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -25,6 +25,7 @@ import {
   EAS_BUILD_SCRIPT_NAME_OPTION,
   EAS_IOS_URL_OPTION,
   EAS_UPDATE_SLUG_OPTION,
+  GIT_BRANCH_OPTION,
   INCLUDE_OPTION,
   INIT_COMMAND,
   IOS_FILE_TYPES,
@@ -117,6 +118,10 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
   [BRANCH_OPTION]: [
     `--${BRANCH_OPTION} <branch>`,
     'Name of the EAS Update branch to fetch the latest update from',
+  ],
+  [GIT_BRANCH_OPTION]: [
+    `--git-branch <branch>`,
+    'Override the git branch name captured for this build (takes precedence over SHERLO_BRANCH and all CI-provider env vars)',
   ],
   [CONFIG_OPTION]: [
     `--${CONFIG_OPTION} <path>`,
@@ -330,6 +335,7 @@ function getTestCommonOptions(variant: 'withPlatformPaths' | 'withoutPlatformPat
     ...(variant === 'withPlatformPaths' ? [IOS_OPTION] : []),
     TOKEN_OPTION,
     MESSAGE_OPTION,
+    GIT_BRANCH_OPTION,
     INCLUDE_OPTION,
     CONFIG_OPTION,
     PROJECT_ROOT_OPTION,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -10,6 +10,7 @@ import {
   EAS_BUILD_SCRIPT_NAME_OPTION,
   EAS_IOS_URL_OPTION,
   EAS_UPDATE_SLUG_OPTION,
+  GIT_BRANCH_OPTION,
   INCLUDE_OPTION,
   INIT_COMMAND,
   IOS_FILE_TYPES,
@@ -70,6 +71,7 @@ type OptionsFormat = 'raw' | 'normalized';
 type CommonOptions<M extends OptionsMode, F extends OptionsFormat> = {
   [MESSAGE_OPTION]?: string;
   [TOKEN_OPTION]?: string;
+  [GIT_BRANCH_OPTION]?: string;
   [INCLUDE_OPTION]?: F extends 'raw' ? string : string[];
   [DIAGNOSTICS_OPTION]?: F extends 'raw' ? string : string[];
 } & (M extends 'withDefaults'


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1426

## TL;DR

Two verified audits (29 + 32 confirmed findings) showed the live gate-on ancestry engine is a bounded approximation with reachable correctness holes and unbounded DynamoDB read amplification, and the merged-but-UNPUBLISHED CLI git capture has shape defects (PR merge-ref builds capture the BASE branch's ancestry, so within-PR accept-once breaks on every push) that are free to fix ONLY until the first publish. This ticket retires every design-decision-free defect in one pass: the api subtask makes gate-on resolution deterministic, bounded, and correct (frozen once-per-build frontier with read budgets, bounded fallback chain ending at a default-main last resort, PR-head canonicalisation server-side, same-SHA tiebreak, shallow/truncation guard, memory-horizon + comment-continuity parity restores, human-beats-bot conflict rule, resolution trace, commitHash GSI backfill, server-side experimental allowlist guard); the developer subtask amends CLI capture while changes are free (canonical PR-head capture, CI-provider branch matrix + SHERLO_BRANCH override, repoSlug + mergeBaseSha, merge_group detection, ancestor bound raised to 200 + per-parent windows). Everything is gate-on only: a project with useAncestryBaseline OFF stays byte-identical, all new CLI fields are optional and backward-compatible, and NOTHING is published to npm in this ticket. Deferred: topological deepening (A1/A2) to the next ticket E2, and the CLI --wait exit-code mode to its own follow-up (it requires a new project-token-authorized build-result query that does not exist yet).

## Acceptance Criteria

- Gate-ON baseline resolution computes the frontier and per-frontier-build outcome inputs exactly ONCE per build, frozen and threaded like the useAncestryBaseline flag (openBuild -> QueuedBuildRun -> ActiveBuildRun, surviving the requeue cycle); point-in-time semantics: mid-run approvals/re-runs take effect from the NEXT build, proven by a test that includes a requeue leg; per-testSnapshot DynamoDB reads stay within a model-based budget (<= 2 + number of frontier lines; <=5 for the standard 1-2-parent case) enforced by a read-count integration test; no resolution path performs an unbounded/full-partition scan.
- The empty-frontier fallback chain is: same-branch (guarded by relatedness-or-recency so a recycled branch name cannot inherit a dead unrelated lineage; 'HEAD'/'unknown' branchNames never match; the existing isDirty exclusion preserved on every fallback axis) then default-main last resort (the latest finished ACCEPTED non-dirty build on project.mainBranch) - a first build on a new branch off an untested main commit compares against the latest main baseline instead of coming up all-new; a gate-on build with NO ancestry metadata (old-CLI 3-string payload) routes through this SAME fallback chain and carries a visible 'ancestry unavailable: update sherlo CLI' degradation stamp on the build record.
- PR merge-ref builds are canonicalised to the real PR head END TO END: the CLI captures commitHash/parentCommitHashes/ancestorCommitHashes relative to the PR head (second parent of the synthetic merge), and the server canonicalises identity, GSI lookup, approval filing, and frontier seeding via prHeadCommitHash for old payloads - proven by an L1 test that approves on PR build N and shows build N+1 still sees the approval, and by an L2 real-git merge-ref fixture test.
- Same-SHA re-runs can never mask an earlier approved build (prefer accepted, else latest finished, applied with index < current BEFORE winner reduction - covering both the merge-time mask and a mid-run queued re-run); shallow or truncated ancestry triggers the fallback chain instead of false-NEW; bot-vs-human disagreement is never a CONFLICT (human approval outranks bot images; a human DENY is never overridden by bot auto-accept; CONFLICT is reserved for same-rank divergence).
- Legacy parity is restored under the gate: a story/target re-added after its identity was absent from the frontier window is restored via missingSnapshotsStatusData memory as a FORCED-REVIEW comparison baseline (surfaced, never silent, never brand-new); comment threads (continuousCommentsData) carry across consecutive gate-on builds.
- Every gate-on resolution persists a structured resolutionTrace on the snapshot record ({path: ancestry|branchFallback|defaultMain|new|conflict, frontierBuildIndexes, winnerBuildIndex, droppedCandidates with reasons, conflictImages when conflict}) and the conflict path logs its evidence (no more empty {} log); a one-shot migration backfills the commitHash GSI attribute for pre-deploy builds (with a test proving a pre-backfill build becomes resolvable); running the migration against prod is a separate operator-coordinated step, NOT part of this ticket's DoD.
- editProjectMainBranch enforces the experimental allowlist server-side: ENABLING useAncestryBaseline is rejected for a team not in the allowlist (mirrored into api constants next to SYSTEM_ADMINS with a cross-reference comment pointing at the frontend copy); DISABLING is always allowed; mainBranch/shouldAutoApproveOnMainBranch edits are unaffected - all four semantics proven by L1 tests.
- CLI: branch detection works on detached-HEAD CI via a provider env matrix (Bitrise, CircleCI, GitLab, Codemagic, Azure - using BUILD_SOURCEBRANCH with the refs/heads/ prefix stripped and SYSTEM_PULLREQUEST_SOURCEBRANCH in PR context, never bare BUILD_SOURCEBRANCHNAME) plus an explicit SHERLO_BRANCH env / --branch flag override with documented precedence; merge_group (GitHub merge queue) refs are detected, capture the PR head, and normalize branchName away from the gh-readonly-queue/* throwaway; repoSlug and best-effort mergeBaseSha are captured as new OPTIONAL gitInfo fields (persisted by the api subtask, consumed later by E2/App); the ancestor window is raised to 200 with per-parent windows captured for merge commits; capture failures never fail a build.
- Non-breaking invariants hold everywhere: the existing gate-OFF parity spec stays green and the legacy path is untouched; all new gitInfo fields are optional (an old CLI payload still produces a valid build); the api subtask's schema additions are merged AND explicitly deployed to the test stage (release_to_test deploy is workflow_dispatch/PR-label only, NOT automatic on merge) BEFORE the developer subtask merges; no npm publish of any kind happens in this ticket.

## Additional Context

The hardening step of the branch/PR programme, executing the re-baselined plan in .local-data/planning/branching-backlog.md (rows E1 + C1) with findings from branching-audit.md (incl. the ADDENDUM) and DoD tests from branching-e2e-catalog.md build-order group 1 MINUS the A1/A2-dependent scenarios deferred to E2 (listed in OUT of scope). Everything below is gate-on only; gate-off must remain byte-identical (the wiring gate is the early-return at _getBaselineAndPreviousSnapshotInfo.ts:57).

## Three Manager-pinned engine rules (implement as law)

1. REBASE RESCUE = EMPTY-FRONTIER-ONLY (catalog decision 1): the branch-name fallback stays a LAST RESORT, never a permanent second frontier axis. After a rebase/force-push the user re-approves once (changed-vs-main stories only) - expected, documented behavior. The same-branch match must carry a relatedness-or-recency guard: accept the name-matched build only if it shares a commit with the current build's captured ancestry/parents OR falls inside a recency window (the recency arm is what still rescues an honest post-rebase same-branch build whose SHAs were all rewritten).
2. HUMAN ALWAYS WINS (catalog decision 9): bot-vs-human disagreement is never a CONFLICT. When a human approval exists for a snapshot, bot-approval candidates (isAutoApprovedOnMainBranch / actorKind bot) are dropped from the distinct-image conflict check and the human image wins; a human DENY is never overridden by bot auto-accept. CONFLICT stays reserved for same-rank divergence (human-vs-human, or bot-vs-bot with no human).
3. SURFACE, NEVER SILENT (catalog decision 10): a story restored from memory after absence is presented as a FORCED REVIEW with the recovered image as the comparison baseline - not silently restored, not baseline-less new.

## api subtask - engine hardening (sherlo-api)

Files: resolvers/mutations/testSnapshot/_getBaselineAndPreviousSnapshotInfo/ (_getBaselineViaAncestry.ts), helpers/baseline/{buildFrontier,resolveSnapshotBaseline,getSnapshotOutcome}/, helpers/build/getBuildByCommitHash.ts, the openBuild -> QueuedBuildRun -> ActiveBuildRun freeze path, editProjectMainBranch.ts, one migration script, getPublicSchemaEndpoint/publicSchema.ts, tests/src/specs/baseline/.
(1) FROZEN PER-BUILD RESOLUTION: today the frontier is recomputed inside EVERY testSnapshot call (~21 sequential getBuildByCommitHash GSI queries + a double-fetch getBuild+getSnapshot prefetch per frontier build per snapshot - verified ~25k reads for a 400-snapshot build), and the empty-frontier fallback _getLatestPriorBranchBuildBaseline (currently _getBaselineViaAncestry.ts:331-405) pages the ENTIRE build partition per snapshot. Resolve the frontier + each frontier build's outcome inputs once per build and freeze them, threaded exactly like the useAncestryBaseline flag (write: openBuild.ts:112 via putNewBuildToQueueAndRunIfPossible; read: _getBaselineAndPreviousSnapshotInfo.ts:30-35). IMPORTANT freeze-point facts: ActiveBuildRun is created at startBuildRun (not openBuild), and on runner overtake it is DELETED and recreated via the queue (pushActiveBuildToQueue re-threads preserved fields, e.g. useAncestryBaseline at line 83) - the frozen frontier MUST survive the active->queue->active requeue cycle (thread it the same way, or store it requeue-stable keyed by buildKey); add a requeue leg to the point-in-time test. SIZE: frozen data = frontier lines (build indexes) + per-frontier-build snapshot status maps in a COMPRESSED/compact form (Build-table dictionary-compression precedent) or a separate storage item keyed by buildKey - mind the DynamoDB 400KB item cap at 400-snapshot scale; keep frozen fields OUT of the ActiveBuildRun GraphQL type (storage-only). Per-snapshot candidate Snapshot reads stay per-testSnapshot inside the read budget. This restructure also retires two verified races: a mid-run reviewBuild producing torn frontiers across one build's snapshots, and a QUEUED same-SHA re-run flipping getBuildByCommitHash's answer mid-build. Document the point-in-time semantics.
(2) BOUNDED FALLBACK CHAIN (audit A3 + G3 + F2-server): empty frontier -> same-branch fallback WITH the pinned relatedness/recency guard -> default-main last resort (the latest finished ACCEPTED non-dirty build on project.mainBranch - the same image legacy isActive resolution effectively yields on a trunk project). The existing isDirty exclusion is preserved on every fallback axis. Every lookup page-capped; no full-partition scans (a genuinely-new story must not scan the whole project). branchName 'HEAD' and 'unknown' are branch-absent sentinels: they never match the same-branch fallback (a shared sentinel constant; the frontend already carries a NOTE deferring to this ticket). A gate-on build with NO ancestry metadata (old-CLI 3-string payload) routes through this SAME fallback chain (per the catalog scenarios old-cli-and-sentinel-gitinfo-under-gate-on and gate-flip-on-then-off - NOT a legacy short-circuit) and stamps the build record with a visible degradation signal ('ancestry unavailable: update sherlo CLI'); if any new user-facing Slack copy is added for this, its wording ships through the content dept.
(3) PR-HEAD CANONICALISATION SERVER-SIDE (A4): when gitInfo.prHeadCommitHash is present, use the real PR head for build identity (commitHash GSI denormalization in convertBuildToBuildDb), approval filing, and frontier seeding - so old payloads and the C1-amended CLI converge on head-keyed identity.
(4) SAME-SHA TIEBREAK (A5 + the queued-re-run race): getBuildByCommitHash currently reduces to the single highest-index build with no status filter and the caller discards index >= current AFTER selection (turning a tested commit into a CI gap). Move the constraints INTO candidate selection: among same-SHA builds pick the best with index < currentBuildIndex, preferring an accepted outcome, else the latest finished.
(5) SHALLOW/TRUNCATION GUARD (A6): isShallow (or an ancestry window that hit its bound without resolving) means 'ancestry incomplete' -> take the fallback chain, never emit brand-new purely from truncation. isShallow becomes load-bearing (do not delete it).
(6) MEMORY-HORIZON RESTORE (G2 + pinned rule 3): when the pure resolver returns null but the frontier is NON-empty, consult the nearest frontier build's missingSnapshotsStatusData.lastBuildIndex before declaring brand-new; restore the recovered image as a forced-review comparison baseline.
(7) COMMENT CONTINUITY (G1): the ancestry path currently hardcodes previousSnapshotInfo.wasPresentInActiveBuild:false in both result builders (_getBaselineViaAncestry.ts:303 and :379), which provably disables continuousCommentsData for every gate-on build. Derive it from the winning baseline-source build so threads carry when statuses qualify (parity with legacy behavior).
(8) HUMAN-BEATS-BOT (pinned rule 2): implement in resolveSnapshotBaseline's pool/conflict logic; the actorKind tagging already exists (getSnapshotOutcome.ts:52 maps isAutoApprovedOnMainBranch -> bot); today the conflict gate (resolveSnapshotBaseline.ts:82-83) ignores actorKind, so bot-vs-human CAN emit CONFLICT - that is the defect to fix.
(9) RESOLUTION TRACE (S5): structured logEvent on every return path (the conflict path currently logs a literal {} at _getBaselineViaAncestry.ts:174) AND a small persisted resolutionTrace on the snapshot record: {path: ancestry|branchFallback|defaultMain|new|conflict, frontierBuildIndexes, winnerBuildIndex, droppedCandidates:[{buildIndex, reason}], conflictImages?}. This is the support/explain surface the future conflict UI (T6d) and GitHub check (T8) will consume.
(10) MIGRATION: one-shot backfill writing the top-level commitHash GSI attribute for pre-deploy builds (the GSI is sparse; builds written before SHERLO-1400's deploy are invisible to ancestry lookups today). Follow the existing migrations/ pattern (compressBuildsMigration, replaceIsUnstableMigration). The subtask delivers and test-proves the migration; RUNNING it against prod is a separate operator-coordinated step, not part of this subtask's DoD.
(11) GATE ALLOWLIST GUARD (Manager-decided): mirror EXPERIMENTAL_BRANCHES_ENABLED_TEAM_IDS (6 team IDs, currently only in sherlo-frontend apps/app/src/constants.ts:19-26) into api constants.ts next to SYSTEM_ADMINS, with a cross-reference comment in the api file pointing at the frontend copy (the frontend-side back-reference is a one-line follow-up owned outside this ticket - sherlo-frontend is not in this ticket's repos); editProjectMainBranch rejects ENABLING useAncestryBaseline for a non-allowlisted teamId; disabling always allowed; mainBranch/shouldAutoApproveOnMainBranch untouched (pre-existing features). This is a stopgap replaced at GA by a server-authoritative rollout lever.
(12) HYGIENE (S4 cheap parts): delete the dormant commented-out original-snapshot-deletion code in testSnapshot.ts (~lines 249-253 and 329-346; a future-bug landmine given baselines alias old S3 objects); make a missing baseline S3 object fail with a distinct, actionable error instead of a generic comparison failure.

## developer subtask - CLI capture amendment (sherlo repo; capture changes are FREE until first publish - sherlo@latest 2.0.0 predates the capture commit, so no real build exists in the new format yet)

Files: packages/cli/src/helpers/getGitInfo.ts, CLI L0/L2 tests per the existing git-fixture harness from SHERLO-1399 (packages/cli/src/helpers/__tests__/support/gitFixture.ts).
(1) CANONICAL PR-HEAD CAPTURE (F1, fixes within-PR accept-once): on a PR merge ref (refs/pull/N/merge - and merge_group, below), capture commitHash = the REAL PR head (second parent), and capture parentCommitHashes + ancestorCommitHashes RELATIVE TO THE PR HEAD (git rev-list --first-parent <prHead>), not relative to the synthetic merge commit (which yields the BASE branch's chain - the verified defect). Keep setting prHeadCommitHash. Do not add a merge-SHA alias field in this ticket (deferred - see OUT of scope).
(2) CI PROVIDER BRANCH MATRIX + OVERRIDE (F2): resolveBranchName today knows only GITHUB_* vars then falls back to `git rev-parse --abbrev-ref HEAD`, which returns the literal 'HEAD' on the detached checkouts that Bitrise/CircleCI/GitLab/Codemagic/Azure all use - collapsing every branch into one pseudo-branch. Add the provider matrix (BITRISE_GIT_BRANCH, CIRCLE_BRANCH, CI_COMMIT_REF_NAME, CM_BRANCH; Azure: BUILD_SOURCEBRANCH with the refs/heads/ prefix stripped, preferring SYSTEM_PULLREQUEST_SOURCEBRANCH in PR context, and treating a bare 'merge' value as branch-absent - never bare BUILD_SOURCEBRANCHNAME, which truncates slash-containing branch names) plus an explicit override with documented precedence: --branch flag > SHERLO_BRANCH env > provider envs > GITHUB_* > git fallback. The 'HEAD'/'unknown' fallbacks remain valid sentinels (the server now treats them as branch-absent).
(3) REPO + MERGE-BASE CAPTURE (F4): repoSlug normalized from the origin remote URL (owner/repo, host-agnostic) and best-effort mergeBaseSha (`git merge-base HEAD origin/$GITHUB_BASE_REF` in GitHub PR context; GitLab equivalent via CI_MERGE_REQUEST_TARGET_BRANCH_NAME when cheap). Both OPTIONAL; capture failures must never fail a build (same graceful-degradation contract as the existing capture).
(4) MERGE QUEUE (F5): detect GITHUB_EVENT_NAME=merge_group; the gh-readonly-queue/<base>/pr-<n>-<sha> ref is a synthetic merge whose second parent is the PR head - capture prHeadCommitHash + canonicalise per (1), and normalize branchName away from the throwaway queue ref (use the base branch encoded in the ref path).
(5) ANCESTOR WINDOW (A2 capture side): raise the rev-list bound from 20 to 200 (~8KB worst case, fine for DynamoDB); for MERGE commits additionally capture a bounded first-parent window per non-first parent (the input E2's deepening will chain through; the engine's own LIMITATION comment at buildFrontier.ts:45-52 names per-parent capture as the requirement). Field shape coordinated with the api subtask's schema addition.

## Cross-subtask coordination (IMPORTANT)

The api subtask owns the schema/type additions for ALL new gitInfo fields (repoSlug, mergeBaseSha, per-parent ancestry windows - optional, storage-only in this ticket; E2/App consume later), including getPublicSchemaEndpoint/publicSchema.ts (the hand-maintained SDK-introspectable schema - a fifth surface beyond the four-layer rule). GraphQL rejects unknown input fields, so the ordering is: the api subtask's schema must be merged to dev AND EXPLICITLY DEPLOYED to the test stage - test-stage deploys are workflow_dispatch / PR-label (pr-deploy/pr-test) only, NOT automatic on merge (merging to dev auto-deploys the DEV stage only) - and the deploy confirmed BEFORE the developer subtask merges (its E2E gate runs the real CLI against the test env). The developer subtask's L0/L2 tests use the existing git-fixture harness + graphql-client stub and do not need the live schema. Subtasks may be developed in parallel; only the MERGE order is constrained.

## Explicitly OUT of scope (deferred, do not build)

- A1/A2 topological deepening (second-parent chaining, >20-hop walk) -> next ticket E2 (needs this ticket's frozen frontier + settled capture shape). The A1/A2-dependent catalog group-1 scenarios belong to E2 and must NOT be attempted here: post-merge-gapped-second-parent, update-branch-merges-main-into-pr, rapid-sequential-merges-out-of-order, deep-merge-case-f, deep-history-beyond-capture-window.
- CLI --wait exit-code mode (audit F3): requires a project-token-authorized build-result query that does not exist (the sdk handler exposes only mutations; getTest requires a TEAM token the CLI does not hold). Deferred to its own follow-up ticket (api query + sdk-client publish into sherlo-lib + CLI flag together).
- Merge-SHA alias field (the synthetic refs/pull/N/merge SHA stored as an alias) - lands with the T9/S1 association work.
- branchIndex GSI (page-capped fallback suffices for now); conflict UI marker (T6d/T8 consume the resolutionTrace); per-branch comment identity (post-T9); live GitHub calls in resolution, a git-graph service, or a mutable per-branch last-accepted pointer (rejected by the ancestry-oracle contract); retention/GC and PR-volume economics (separate product decisions); ANY npm publish (the test channel via release_to_test.yml is dispatched after this ticket merges; @latest only at GA).

## Ownership

- api: engine hardening items 1-12 + schema additions for the new optional gitInfo fields (incl. publicSchema.ts) + the L1 integration suite.
- developer: CLI capture items 1-5 + L0/L2 tests.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
