### PR TITLE
feat: CLI preflight: reject Android APKs missing arm64-v8a native…

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -21,6 +21,7 @@ export const DOCS_LINK = {
   builds: `${DOCS_BASE_URL}/builds`,
   buildPreview: `${DOCS_BASE_URL}/builds?type=preview-simulator#build-types`,
   buildDevelopment: `${DOCS_BASE_URL}/builds?type=development-simulator#build-types`,
+  buildAndroidAbiRequirements: `${DOCS_BASE_URL}/builds#android-abi-requirements`,
 
   testing: `${DOCS_BASE_URL}/testing`,
   testingMethods: `${DOCS_BASE_URL}/testing#testing-methods`,
@@ -40,6 +41,9 @@ export const PLATFORM_LABEL: { [platform in Platform]: string } = {
 
 export const ANDROID_FILE_TYPES = ['.apk'] as const;
 export const IOS_FILE_TYPES = ['.app', '.tar.gz', '.tar'] as const;
+
+// Mirrors sherlo-runner src/executor/android/constants.ts
+export const ANDROID_ARM64_ABI = 'arm64-v8a';
 
 export const DEFAULT_CONFIG_FILENAME = 'sherlo.config.json';
 export const DEFAULT_PROJECT_ROOT = '.';

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getBinaryInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getBinaryInfo.ts
@@ -52,9 +52,11 @@ function getBinaryInfo(params: Params): BinaryInfo | undefined {
     });
   }
 
+  // androidAbis is local-only validation data - strip it before building the upload payload
+  const { androidAbis: _androidAbis, ...localInfo } = localBinariesInfo[platform] ?? {};
   let binaryInfo = {
     ...mapRemoteBinaryInfo(remoteBinariesInfoOrUploadInfo[platform]),
-    ...localBinariesInfo[platform],
+    ...localInfo,
   };
 
   if (checkIfBinaryInfoIsMissingRequiredFields(binaryInfo)) {

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInArchive.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInArchive.ts
@@ -51,6 +51,39 @@ async function accessFileInArchive({
 
 export default accessFileInArchive;
 
+/**
+ * Lists all entries under lib/ in an APK (zip archive).
+ * Returns the raw entry paths (e.g. "lib/arm64-v8a/libfoo.so").
+ * Returns [] when the APK has no lib/ entries (no native libraries).
+ */
+export async function listApkLibEntries({
+  archive,
+  projectRoot,
+}: {
+  archive: string;
+  projectRoot: string;
+}): Promise<string[]> {
+  let output: string;
+  try {
+    output = await runShellCommand({
+      command: `unzip -l "${archive}" "lib/*"`,
+      projectRoot,
+    });
+  } catch (error) {
+    // exit code 11 = no matching entries; APK has no native libraries
+    if ((error as any)?.code === 11) return [];
+    throwError({ type: 'unexpected', error });
+  }
+
+  const entries: string[] = [];
+  for (const line of output!.split('\n')) {
+    // Each content line in `unzip -l` output ends with the entry path after <length> <date> <time>
+    const match = line.match(/\s+(lib\/.*)$/);
+    if (match) entries.push(match[1]);
+  }
+  return entries;
+}
+
 /* ========================================================================== */
 
 type TarVersion = 'GNU' | 'BSD';

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
@@ -8,7 +8,7 @@ import { BinaryInfo, BuildType, Command } from '../../../../types';
 import { validatePlatformPaths } from '../../../shared';
 import throwError from '../../../throwError';
 import runShellCommand from '../../../runShellCommand';
-import accessFileInArchive from './accessFileInArchive';
+import accessFileInArchive, { listApkLibEntries } from './accessFileInArchive';
 import accessFileInDirectory from './accessFileInDirectory';
 
 const SHERLO_JSON_FILENAME = 'sherlo.json';
@@ -36,7 +36,7 @@ const IOS_TAR_BUNDLE_PREFIX = '*.app/';
 type LocalBinariesInfo = { android?: LocalBinaryInfo; ios?: LocalBinaryInfo };
 type LocalBinaryInfo = Pick<
   BinaryInfo,
-  'hash' | 'buildType' | 'sdkVersion' | 'fileName' | 'expoSdkVersion' | 'hasExpoDevClient'
+  'hash' | 'buildType' | 'sdkVersion' | 'fileName' | 'expoSdkVersion' | 'hasExpoDevClient' | 'androidAbis' | 'apkPath'
 >;
 
 async function getLocalBinariesInfo({
@@ -108,6 +108,8 @@ async function getLocalBinaryInfoForPlatform({
   let readSherloFile: () => Promise<string | undefined>;
   let checkHasExpoDevClient: () => Promise<boolean>;
   let readExpoAppConfig: () => Promise<string | undefined>;
+  let androidAbis: string[] | undefined;
+  let apkPath: string | undefined;
 
   if (fileName.endsWith('.app')) {
     checkHasJsBundle = () =>
@@ -199,6 +201,11 @@ async function getLocalBinaryInfoForPlatform({
         type: archiveType,
         projectRoot,
       });
+
+    if (fileName.endsWith('.apk')) {
+      androidAbis = await getAndroidApkAbis({ apkPath: platformPath, projectRoot });
+      apkPath = platformPath;
+    }
   } else {
     throwError({
       type: 'unexpected',
@@ -237,7 +244,7 @@ async function getLocalBinaryInfoForPlatform({
     projectRoot,
   });
 
-  return { hash, buildType, sdkVersion, fileName, expoSdkVersion, hasExpoDevClient };
+  return { hash, buildType, sdkVersion, fileName, expoSdkVersion, hasExpoDevClient, androidAbis, apkPath };
 }
 
 async function getExpoSdkVersion({
@@ -312,6 +319,22 @@ async function checkApkManifestContains({
   } catch {
     return false;
   }
+}
+
+async function getAndroidApkAbis({
+  apkPath,
+  projectRoot,
+}: {
+  apkPath: string;
+  projectRoot: string;
+}): Promise<string[]> {
+  const libEntries = await listApkLibEntries({ archive: apkPath, projectRoot });
+  const abis = new Set<string>();
+  for (const entry of libEntries) {
+    const match = entry.match(/^lib\/([^/]+)\//);
+    if (match) abis.add(match[1]);
+  }
+  return Array.from(abis);
 }
 
 async function getBinaryHash(filePath: string): Promise<string> {

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/getLocalBinariesInfo.ts
@@ -36,7 +36,7 @@ const IOS_TAR_BUNDLE_PREFIX = '*.app/';
 type LocalBinariesInfo = { android?: LocalBinaryInfo; ios?: LocalBinaryInfo };
 type LocalBinaryInfo = Pick<
   BinaryInfo,
-  'hash' | 'buildType' | 'sdkVersion' | 'fileName' | 'expoSdkVersion' | 'hasExpoDevClient' | 'androidAbis' | 'apkPath'
+  'hash' | 'buildType' | 'sdkVersion' | 'fileName' | 'expoSdkVersion' | 'hasExpoDevClient' | 'androidAbis'
 >;
 
 async function getLocalBinariesInfo({
@@ -109,7 +109,6 @@ async function getLocalBinaryInfoForPlatform({
   let checkHasExpoDevClient: () => Promise<boolean>;
   let readExpoAppConfig: () => Promise<string | undefined>;
   let androidAbis: string[] | undefined;
-  let apkPath: string | undefined;
 
   if (fileName.endsWith('.app')) {
     checkHasJsBundle = () =>
@@ -204,7 +203,6 @@ async function getLocalBinaryInfoForPlatform({
 
     if (fileName.endsWith('.apk')) {
       androidAbis = await getAndroidApkAbis({ apkPath: platformPath, projectRoot });
-      apkPath = platformPath;
     }
   } else {
     throwError({
@@ -244,7 +242,7 @@ async function getLocalBinaryInfoForPlatform({
     projectRoot,
   });
 
-  return { hash, buildType, sdkVersion, fileName, expoSdkVersion, hasExpoDevClient, androidAbis, apkPath };
+  return { hash, buildType, sdkVersion, fileName, expoSdkVersion, hasExpoDevClient, androidAbis };
 }
 
 async function getExpoSdkVersion({

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
@@ -1,4 +1,5 @@
 import {
+  ANDROID_ARM64_ABI,
   DOCS_LINK,
   EAS_BUILD_ON_COMPLETE_COMMAND,
   EXPO_DEV_CLIENT_PACKAGE_NAME,
@@ -24,6 +25,8 @@ function validateBinariesInfo({
   validateHasSherlo(binariesInfo);
 
   validateBuildType({ binariesInfo, command });
+
+  validateAndroidAbiRequirements(binariesInfo);
 
   if (command === TEST_EAS_UPDATE_COMMAND) {
     validateEasUpdateRequirements(binariesInfo);
@@ -84,6 +87,25 @@ function validateBuildType({
         })
       );
     }
+  }
+}
+
+function validateAndroidAbiRequirements({ android }: BinariesInfo) {
+  if (!android?.androidAbis) return;
+
+  const abis = android.androidAbis;
+  // An APK with no lib/ entries has no native code and installs on any ABI - pass
+  if (abis.length === 0) return;
+
+  if (!abis.includes(ANDROID_ARM64_ABI)) {
+    const detectedAbis = abis.join(', ');
+    const apkPath = android.apkPath ?? android.fileName;
+
+    throwError(getError(
+      android.expoSdkVersion
+        ? { type: 'missing_arm64_abi_expo', detectedAbis, apkPath }
+        : { type: 'missing_arm64_abi_bare_rn', detectedAbis, apkPath }
+    ));
   }
 }
 
@@ -166,6 +188,8 @@ type BinaryError =
       expoSdkVersion: string;
     }
   | { type: 'outdated_expo_version'; platformLabels: string[]; expoSdkVersion: string }
+  | { type: 'missing_arm64_abi_expo'; detectedAbis: string; apkPath: string }
+  | { type: 'missing_arm64_abi_bare_rn'; detectedAbis: string; apkPath: string }
 
 function getError(error: BinaryError) {
   switch (error.type) {
@@ -265,6 +289,33 @@ function getError(error: BinaryError) {
             error.platformLabels.length > 1 ? 'Builds are' : 'Build is'
           } created after updating the package\n`,
         learnMoreLink: DOCS_LINK.testEasUpdate,
+      };
+
+    case 'missing_arm64_abi_expo':
+      return {
+        message:
+          `Android build is missing arm64-v8a native libraries; ` +
+          `Sherlo's Android emulators require arm64-v8a\n\n` +
+          `Detected ABIs: ${error.detectedAbis}\n\n` +
+          `Please verify:\n` +
+          `1. \`expo-build-properties\` plugin is in your app config and \`buildArchs\` includes \`arm64-v8a\` ` +
+          `(the Expo default already does - check if it was overridden)\n` +
+          `2. A new build was created after any config changes\n` +
+          `3. Run \`unzip -l ${error.apkPath} | grep lib/\` to confirm which ABIs are in the APK\n`,
+        learnMoreLink: DOCS_LINK.buildAndroidAbiRequirements,
+      };
+
+    case 'missing_arm64_abi_bare_rn':
+      return {
+        message:
+          `Android build is missing arm64-v8a native libraries; ` +
+          `Sherlo's Android emulators require arm64-v8a\n\n` +
+          `Detected ABIs: ${error.detectedAbis}\n\n` +
+          `Please verify:\n` +
+          `1. \`reactNativeArchitectures\` in \`android/gradle.properties\` includes \`arm64-v8a\`\n` +
+          `2. A new build was created after any config changes\n` +
+          `3. Run \`unzip -l ${error.apkPath} | grep lib/\` to confirm which ABIs are in the APK\n`,
+        learnMoreLink: DOCS_LINK.buildAndroidAbiRequirements,
       };
 
   }

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo.ts
@@ -99,12 +99,12 @@ function validateAndroidAbiRequirements({ android }: BinariesInfo) {
 
   if (!abis.includes(ANDROID_ARM64_ABI)) {
     const detectedAbis = abis.join(', ');
-    const apkPath = android.apkPath ?? android.fileName;
+    const fileName = android.fileName;
 
     throwError(getError(
       android.expoSdkVersion
-        ? { type: 'missing_arm64_abi_expo', detectedAbis, apkPath }
-        : { type: 'missing_arm64_abi_bare_rn', detectedAbis, apkPath }
+        ? { type: 'missing_arm64_abi_expo', detectedAbis, fileName }
+        : { type: 'missing_arm64_abi_bare_rn', detectedAbis, fileName }
     ));
   }
 }
@@ -188,8 +188,8 @@ type BinaryError =
       expoSdkVersion: string;
     }
   | { type: 'outdated_expo_version'; platformLabels: string[]; expoSdkVersion: string }
-  | { type: 'missing_arm64_abi_expo'; detectedAbis: string; apkPath: string }
-  | { type: 'missing_arm64_abi_bare_rn'; detectedAbis: string; apkPath: string }
+  | { type: 'missing_arm64_abi_expo'; detectedAbis: string; fileName: string }
+  | { type: 'missing_arm64_abi_bare_rn'; detectedAbis: string; fileName: string }
 
 function getError(error: BinaryError) {
   switch (error.type) {
@@ -301,7 +301,7 @@ function getError(error: BinaryError) {
           `1. \`expo-build-properties\` plugin is in your app config and \`buildArchs\` includes \`arm64-v8a\` ` +
           `(the Expo default already does - check if it was overridden)\n` +
           `2. A new build was created after any config changes\n` +
-          `3. Run \`unzip -l ${error.apkPath} | grep lib/\` to confirm which ABIs are in the APK\n`,
+          `3. Run \`unzip -l ${error.fileName} | grep lib/\` to confirm which ABIs are in the APK\n`,
         learnMoreLink: DOCS_LINK.buildAndroidAbiRequirements,
       };
 
@@ -314,7 +314,7 @@ function getError(error: BinaryError) {
           `Please verify:\n` +
           `1. \`reactNativeArchitectures\` in \`android/gradle.properties\` includes \`arm64-v8a\`\n` +
           `2. A new build was created after any config changes\n` +
-          `3. Run \`unzip -l ${error.apkPath} | grep lib/\` to confirm which ABIs are in the APK\n`,
+          `3. Run \`unzip -l ${error.fileName} | grep lib/\` to confirm which ABIs are in the APK\n`,
         learnMoreLink: DOCS_LINK.buildAndroidAbiRequirements,
       };
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -142,6 +142,8 @@ export type BinaryInfo = {
   url?: string;
   expoSdkVersion?: string;
   hasExpoDevClient?: boolean;
+  androidAbis?: string[];
+  apkPath?: string;
 };
 
 export type EasUpdateInfo = {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -143,7 +143,6 @@ export type BinaryInfo = {
   expoSdkVersion?: string;
   hasExpoDevClient?: boolean;
   androidAbis?: string[];
-  apkPath?: string;
 };
 
 export type EasUpdateInfo = {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1440

Implements the Android APK ABI preflight in the CLI binary validation (SHERLO-1441, part of SHERLO-1440).

The CLI lists the APK lib/ ABI entries during getLocalBinariesInfo and fails fast in validateBinariesInfo when native libs exist but arm64-v8a is absent - before any upload. This replaces the old failure mode where such APKs uploaded successfully and then failed on the emulator with a cryptic INSTALL_FAILED_NO_MATCHING_ABIS after retries.

The error message branches on workflow: Expo builds point to buildArchs in expo-build-properties; bare React Native points to reactNativeArchitectures in android/gradle.properties. Both link to the new docs section. An APK with no lib/ entries, or one that includes arm64-v8a, passes unchanged.

## Changes
- constants.ts: ANDROID_ARM64_ABI (comment cross-refs the runner emulator images) and DOCS_LINK.buildAndroidAbiRequirements
- types.ts: androidAbis on BinaryInfo (local-only validation data)
- accessFileInArchive.ts: listApkLibEntries (unzip-based lib/ listing, returns empty on no-match / exit 11)
- getLocalBinariesInfo.ts: getAndroidApkAbis collection for APK files
- validateBinariesInfo.ts: validateAndroidAbiRequirements with two new typed BinaryError variants and verbatim content-authored copy

Applies to every command path that inspects a local Android APK (standard, eas-update, eas-build-on-complete). tsc clean, 148 unit tests pass.

## Review update (commit 05bcbc62) - wire hygiene
Addressed a review finding: the ABI preflight inputs are local-only validation data and must not ride to the backend.
- Dropped apkPath (an absolute local filesystem path) from BinaryInfo entirely. The error message self-check now uses the already-present fileName, so it reads: Run unzip -l android.apk | grep lib/
- androidAbis is still used by the local fail-fast validation but is now stripped from the upload payload in getBinaryInfo (no longer spread into the wire binaryInfo). The validation runs earlier on a local-derived object, so fail-fast behavior is unchanged.
- E2E snapshots regenerated accordingly in sherlo-tester#56; all 3 specs pass.

Companion PRs: sherlo-www#54 (docs, the learnMoreLink target) and sherlo-tester#56 (E2E).

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*

## Test Plan

148 CLI unit tests pass; tsc --noEmit clean. E2E (sherlo-tester#56) passes 3/3 against the rebuilt CLI: x86-only Expo rejected with Expo hint (not bare-RN), x86-only bare-RN rejected with bare-RN hint (not Expo), unmodified arm64-v8a passes the preflight. Post-fix: confirmed apkPath is removed and androidAbis no longer rides to the upload payload.
