### PR TITLE
feat: [Branch/PR visual tests] TurboSnap pre-enable: story-imports…

### DIFF
--- a/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
@@ -342,6 +342,66 @@ export default { title: 'A' };`
 });
 
 // ---------------------------------------------------------------------------
+// (h) Barrel re-export detection (one level)
+// ---------------------------------------------------------------------------
+
+describe('(h) barrel re-export detection', () => {
+  it('forces full when a non-story barrel re-exports a changed story imported by a story', () => {
+    // Base.stories (changed) is re-exported by index.ts (barrel).
+    // Composed.stories imports from the barrel, not directly from Base.stories.
+    fx.write('Base.stories.tsx', `export const Primary = () => null;`);
+    fx.write('index.ts', `export { Primary } from './Base.stories';`);
+    fx.write(
+      'Composed.stories.tsx',
+      `import { Primary } from './index';
+export default { title: 'Composed' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Base.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+  });
+
+  it('does not bail when a barrel re-exports only a non-story component', () => {
+    // index.ts forwards Button.tsx (not a story) - no story->story edge via barrel.
+    fx.write('Button.tsx', `export const Button = () => null;`);
+    fx.write('index.ts', `export { Button } from './Button';`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { Button } from './index';
+export default { title: 'A' };`
+    );
+    // An unrelated leaf story is the only changed file.
+    fx.write('Leaf.stories.tsx', `export default { title: 'Leaf' };`);
+
+    const changed = ['Leaf.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('does not bail when a barrel forwards a non-changed story', () => {
+    // index.ts re-exports Base.stories, but Base.stories is NOT in changedFiles.
+    // Only LeafStory is changed - the barrel path is harmless.
+    fx.write('Base.stories.tsx', `export const Primary = () => null;`);
+    fx.write('index.ts', `export { Primary } from './Base.stories';`);
+    fx.write(
+      'Composed.stories.tsx',
+      `import { Primary } from './index';
+export default { title: 'Composed' };`
+    );
+    fx.write('LeafStory.stories.tsx', `export default { title: 'Leaf' };`);
+
+    const changed = ['LeafStory.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Additional edge cases
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
@@ -399,6 +399,25 @@ export default { title: 'Composed' };`
 
     expect(result).toEqual({ changedFiles: changed });
   });
+
+  it('forces full when a barrel contains an aliased re-export that looks like a story file', () => {
+    // index.ts has `export { P } from '@/Base.stories'` - the alias cannot be
+    // resolved on disk but is story-looking. The same bail rule applied in the
+    // main loop applies uniformly inside the barrel scan.
+    fx.write('index.ts', `export { P } from '@/Base.stories';`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { P } from './index';
+export default { title: 'A' };`
+    );
+
+    // StoryA is changed so the scan runs.
+    const result = checkStoryImportsStory(fx.dir, ['StoryA.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
@@ -1,0 +1,323 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkStoryImportsStory } from '../../turbosnap/storyImportsStory';
+
+// ---------------------------------------------------------------------------
+// Minimal filesystem fixture
+// ---------------------------------------------------------------------------
+
+class FsFixture {
+  readonly dir: string;
+
+  constructor() {
+    this.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-story-fixture-'));
+  }
+
+  write(relPath: string, content: string): void {
+    const abs = path.join(this.dir, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf8');
+  }
+
+  cleanup(): void {
+    fs.rmSync(this.dir, { recursive: true, force: true });
+  }
+
+  /** Returns a changedFiles path relative to fixture.dir (mirrors git diff output). */
+  rel(relPath: string): string {
+    return relPath;
+  }
+}
+
+let fx: FsFixture;
+
+beforeEach(() => {
+  fx = new FsFixture();
+});
+
+afterEach(() => {
+  fx.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// (a) Direct story->story import: StoryA imports './StoryB.stories'
+// ---------------------------------------------------------------------------
+
+describe('(a) direct story->story import', () => {
+  it('returns fullRun when a changed story file is imported by another story file', () => {
+    // StoryB (changed) is imported by StoryA.
+    fx.write('StoryB.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { Primary } from './StoryB.stories';
+export default { title: 'A' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, [fx.rel('StoryB.stories.tsx')]);
+
+    expect(result).toMatchObject({
+      fullRun: true,
+      reason: expect.stringMatching(/story-imports-story/),
+    });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch('StoryB.stories.tsx');
+    expect(r.reason).toMatch('StoryA.stories.tsx');
+  });
+
+  it('includes the changed story file name in the reason', () => {
+    fx.write('Button.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'Composite.stories.tsx',
+      `import { Primary } from './Button.stories';
+export default { title: 'Composite' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Button.stories.tsx']) as {
+      fullRun: true;
+      reason: string;
+    };
+
+    expect(result.fullRun).toBe(true);
+    expect(result.reason).toContain('Button.stories.tsx');
+    expect(result.reason).toContain('Composite.stories.tsx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Transitive story->story import: A imports B imports C; C changed
+// ---------------------------------------------------------------------------
+
+describe('(b) transitive story->story chain', () => {
+  it('returns fullRun when a changed story is imported transitively through another story', () => {
+    // A.stories -> B.stories -> C.stories (C changed)
+    fx.write('C.stories.tsx', `export const C = () => null;`);
+    fx.write('B.stories.tsx', `import { C } from './C.stories'; export const B = () => null;`);
+    fx.write('A.stories.tsx', `import { B } from './B.stories'; export const A = () => null;`);
+
+    // C.stories is changed; B directly imports C - force full.
+    const result = checkStoryImportsStory(fx.dir, ['C.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+    expect(r.reason).toMatch('C.stories.tsx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) Common fast path: no story->story imports
+// ---------------------------------------------------------------------------
+
+describe('(c) no story->story imports - common fast path', () => {
+  it('returns { changedFiles } unchanged when stories only import non-story files', () => {
+    // Button component (not a story file)
+    fx.write('Button.tsx', `export const Button = () => null;`);
+    // Button story imports Button component - NOT a story->story import
+    fx.write(
+      'Button.stories.tsx',
+      `import { Button } from './Button';
+export default { title: 'Button' };
+export const Primary = () => <Button />;`
+    );
+
+    const changed = ['Button.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('returns { changedFiles } when no stories import each other at all', () => {
+    fx.write('A.stories.tsx', `export default { title: 'A' };`);
+    fx.write('B.stories.tsx', `export default { title: 'B' };`);
+
+    const changed = ['A.stories.tsx', 'B.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('returns { changedFiles } when no story files are in changedFiles', () => {
+    fx.write('Button.tsx', `export const Button = () => null;`);
+    fx.write(
+      'Button.stories.tsx',
+      `import { Button } from './Button'; export default { title: 'Button' };`
+    );
+
+    const changed = ['Button.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('returns { changedFiles } with non-story file changes alongside story changes when no cross-imports exist', () => {
+    fx.write('Button.tsx', `export const Button = () => null;`);
+    fx.write(
+      'Button.stories.tsx',
+      `import { Button } from './Button'; export default { title: 'Button' };`
+    );
+    fx.write('Modal.stories.tsx', `export default { title: 'Modal' };`);
+
+    const changed = ['Button.tsx', 'Button.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) Bail-open on unresolvable story-looking specifier
+// ---------------------------------------------------------------------------
+
+describe('(d) bail-open on unresolvable story-looking import', () => {
+  it('returns fullRun when a story file has an unresolvable import that looks like a story', () => {
+    // StoryA has an import of a story file that does not exist on disk.
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { Primary } from './NonExistent.stories';
+export default { title: 'A' };`
+    );
+
+    // StoryA itself is changed (so there is a changed story file to trigger the scan).
+    const result = checkStoryImportsStory(fx.dir, ['StoryA.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+  });
+
+  it('returns fullRun when an extension-less story specifier cannot be resolved', () => {
+    // The import looks like a story file (contains .stories) but no file exists.
+    fx.write(
+      'Importer.stories.tsx',
+      `import something from './Missing.stories';
+export default { title: 'Importer' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Importer.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+  });
+
+  it('does NOT bail for unresolvable non-story imports', () => {
+    // ./helper does not exist, but it cannot be a story file -> safe to skip.
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { helper } from './helper';
+export default { title: 'A' };`
+    );
+
+    const changed = ['StoryA.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    // Should not bail - no story->story edge and no story-looking unresolvable import.
+    expect(result).toEqual({ changedFiles: changed });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) Extension-less specifier resolution
+// ---------------------------------------------------------------------------
+
+describe('(e) extension-less specifier resolution', () => {
+  it("resolves './Button.stories' to Button.stories.tsx correctly", () => {
+    // The spec uses no extension; the actual file has .tsx.
+    fx.write('Button.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'Composite.stories.tsx',
+      `import { Primary } from './Button.stories';
+export default { title: 'Composite' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Button.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toContain('Button.stories.tsx');
+  });
+
+  it("resolves './Button.stories' to Button.stories.ts (no x) correctly", () => {
+    fx.write('Button.stories.ts', `export const Primary = () => null;`);
+    fx.write(
+      'Composite.stories.tsx',
+      `import { Primary } from './Button.stories';
+export default { title: 'Composite' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Button.stories.ts']);
+
+    expect(result).toMatchObject({ fullRun: true });
+  });
+
+  it('does NOT bail for extension-less non-story specifier that resolves to a non-story file', () => {
+    fx.write('utils.ts', `export const helper = () => null;`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { helper } from './utils';
+export default { title: 'A' };`
+    );
+
+    const changed = ['StoryA.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    // utils.ts resolves fine but is not a story file - fast path preserved.
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('handles require() calls with extension-less story specifiers', () => {
+    fx.write('Button.stories.tsx', `module.exports = { Primary: () => null };`);
+    fx.write(
+      'Composite.stories.jsx',
+      `const { Primary } = require('./Button.stories');
+module.exports = { default: { title: 'Composite' } };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Button.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  it('ignores node_modules directory when scanning for story files', () => {
+    // A story file inside node_modules must not be part of the graph.
+    fx.write(
+      'node_modules/some-lib/Foo.stories.tsx',
+      `import { Bar } from '../../Bar.stories'; export default {};`
+    );
+    fx.write('Bar.stories.tsx', `export default { title: 'Bar' };`);
+
+    const changed = ['Bar.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    // node_modules story is excluded, so no importer found - fast path.
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
+  it('returns { changedFiles } when changedFiles is empty', () => {
+    fx.write('A.stories.tsx', `import { B } from './B.stories'; export default {};`);
+    fx.write('B.stories.tsx', `export default {};`);
+
+    const result = checkStoryImportsStory(fx.dir, []);
+
+    expect(result).toEqual({ changedFiles: [] });
+  });
+
+  it('handles stories in subdirectories', () => {
+    fx.write('components/Button.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'screens/Home.stories.tsx',
+      `import { Primary } from '../components/Button.stories';
+export default { title: 'Home' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['components/Button.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toContain('Button.stories.tsx');
+  });
+});

--- a/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
@@ -278,6 +278,70 @@ module.exports = { default: { title: 'Composite' } };`
 });
 
 // ---------------------------------------------------------------------------
+// (f) Path-aliased imports of story files -> bail-open
+// ---------------------------------------------------------------------------
+
+describe('(f) path-aliased story imports - bail-open', () => {
+  it('returns fullRun when a story has an aliased import that looks like a story file', () => {
+    // StoryA uses a path alias (@/components/Base.stories) - the alias cannot
+    // be resolved on disk, but the specifier matches the story-file pattern.
+    // We cannot rule out a hidden story->story edge, so we force full.
+    fx.write('Base.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { Primary } from '@/components/Base.stories';
+export default { title: 'A' };`
+    );
+
+    // StoryA itself is changed; the aliased import bails open.
+    const result = checkStoryImportsStory(fx.dir, ['StoryA.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+  });
+
+  it('does NOT bail for an aliased import that cannot be a story file', () => {
+    // '@/components/SharedButton' has no .stories in the path -> resolveSpecifier
+    // returns null -> fast path preserved.
+    fx.write(
+      'StoryA.stories.tsx',
+      `import { SharedButton } from '@/components/SharedButton';
+export default { title: 'A' };`
+    );
+
+    const changed = ['StoryA.stories.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (g) Dynamic imports of story files -> story->story edge
+// ---------------------------------------------------------------------------
+
+describe('(g) dynamic imports of story files', () => {
+  it('returns fullRun when a story dynamically imports a changed story file', () => {
+    // Base.stories is changed; StoryA dynamically imports it.
+    // The dynamic import creates a story->story edge so editing Base forces full.
+    fx.write('Base.stories.tsx', `export const Primary = () => null;`);
+    fx.write(
+      'StoryA.stories.tsx',
+      `export const Lazy = () => import('./Base.stories');
+export default { title: 'A' };`
+    );
+
+    const result = checkStoryImportsStory(fx.dir, ['Base.stories.tsx']);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+    expect(r.reason).toContain('Base.stories.tsx');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Additional edge cases
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/helpers/turbosnap/computeChangedFiles.ts
+++ b/packages/cli/src/helpers/turbosnap/computeChangedFiles.ts
@@ -1,5 +1,6 @@
 import { GitInfo } from '../getGitInfo';
 import runShellCommand from '../runShellCommand';
+import { checkStoryImportsStory } from './storyImportsStory';
 
 export type ChangedFilesResult =
   | { changedFiles: string[] }
@@ -67,7 +68,7 @@ export async function computeChangedFiles(
       projectRoot,
     });
     const changedFiles = output.split('\n').filter(Boolean);
-    return { changedFiles };
+    return checkStoryImportsStory(projectRoot, changedFiles);
   } catch (err) {
     return { fullRun: true, reason: `git diff failed: ${err instanceof Error ? err.message : String(err)}` };
   }

--- a/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
+++ b/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
@@ -24,6 +24,13 @@ const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
  * look like story files but cannot be resolved on disk - we cannot rule out a
  * hidden story->story edge, so we force full rather than silently skip.
  *
+ * BARREL DETECTION (one level): when a story imports a local non-story module
+ * that resolves on disk, that module is scanned one level for re-exports of
+ * changed story files. Example: Composed.stories imports './index', and index.ts
+ * does `export { Primary } from './Base.stories'`. If Base.stories is changed,
+ * Composed must be re-captured. Unresolvable barrel specifiers are not chased.
+ * If the barrel module cannot be read, we bail open.
+ *
  * Precondition: called only after computeChangedFiles would return { changedFiles }
  * (i.e. the partial-eligible path). The common fast path where no story imports
  * another story is not affected (returns { changedFiles } unchanged).
@@ -81,7 +88,20 @@ export function checkStoryImportsStory(
         };
       }
 
-      if (resolved === null) continue; // resolves to non-story or safely unresolvable
+      if (resolved === null) {
+        // The specifier either resolves to a non-story file on disk (potential barrel)
+        // or is unresolvable and not story-looking (safe to skip). Scan one level: if
+        // the specifier resolves to a real non-story file, check whether it re-exports
+        // a changed story file.
+        const barrelPath = resolveToFile(storyFile, spec);
+        if (barrelPath !== null && !storyFileSet.has(barrelPath)) {
+          const bailReason = barrelForwardsChangedStory(barrelPath, changedStoryAbsPaths);
+          if (bailReason !== null) {
+            return { fullRun: true, reason: bailReason };
+          }
+        }
+        continue;
+      }
 
       // storyFile imports resolved (another story): record reverse edge.
       const importers = reverseEdges.get(resolved);
@@ -210,6 +230,50 @@ function isFile(p: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Resolves a specifier to an absolute path if a file exists on disk, null otherwise. */
+function resolveToFile(fromFile: string, spec: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), spec);
+  if (isFile(base)) return base;
+  for (const ext of EXTENSIONS) {
+    const candidate = base + ext;
+    if (isFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Scans one level of a non-story module (barrel) to check whether it re-exports
+ * any file listed in changedStoryAbsPaths.
+ *
+ * Returns a reason string (force full) if a match is found, null otherwise.
+ * Bails open if the barrel module cannot be read.
+ *
+ * ONE LEVEL ONLY - if a barrel specifier resolves to another non-story module,
+ * it is NOT recursed into (documented limit, covered by the Phase-2 Metro graph).
+ * Unresolvable barrel specifiers are not chased.
+ */
+function barrelForwardsChangedStory(
+  barrelPath: string,
+  changedStoryAbsPaths: Set<string>
+): string | null {
+  let content: string;
+  try {
+    content = fs.readFileSync(barrelPath, 'utf8');
+  } catch {
+    // Bail open: consistent with story-file read-failure handling.
+    return 'story-imports-story: failed to read barrel module, forcing full';
+  }
+
+  for (const spec of extractSpecifiers(content)) {
+    const resolved = resolveToFile(barrelPath, spec);
+    if (resolved !== null && changedStoryAbsPaths.has(resolved)) {
+      return `story-imports-story: changed story re-exported via barrel ${path.basename(barrelPath)}`;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
+++ b/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
@@ -25,11 +25,13 @@ const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
  * hidden story->story edge, so we force full rather than silently skip.
  *
  * BARREL DETECTION (one level): when a story imports a local non-story module
- * that resolves on disk, that module is scanned one level for re-exports of
- * changed story files. Example: Composed.stories imports './index', and index.ts
- * does `export { Primary } from './Base.stories'`. If Base.stories is changed,
- * Composed must be re-captured. Unresolvable barrel specifiers are not chased.
- * If the barrel module cannot be read, we bail open.
+ * that resolves on disk, that module is scanned one level using resolveSpecifier,
+ * so the story-looking-alias bail rule is uniform whether the aliased import is
+ * at the top level or inside a barrel. Example: index.ts does
+ * `export { P } from '@/Base.stories'` - even though the alias cannot be
+ * resolved on disk, it is story-looking and forces full. Unresolvable barrel
+ * specifiers that are NOT story-looking are skipped. If the barrel module cannot
+ * be read, we bail open.
  *
  * Precondition: called only after computeChangedFiles would return { changedFiles }
  * (i.e. the partial-eligible path). The common fast path where no story imports
@@ -95,7 +97,7 @@ export function checkStoryImportsStory(
         // a changed story file.
         const barrelPath = resolveToFile(storyFile, spec);
         if (barrelPath !== null && !storyFileSet.has(barrelPath)) {
-          const bailReason = barrelForwardsChangedStory(barrelPath, changedStoryAbsPaths);
+          const bailReason = barrelForwardsChangedStory(barrelPath, changedStoryAbsPaths, storyFileSet);
           if (bailReason !== null) {
             return { fullRun: true, reason: bailReason };
           }
@@ -245,18 +247,29 @@ function resolveToFile(fromFile: string, spec: string): string | null {
 
 /**
  * Scans one level of a non-story module (barrel) to check whether it re-exports
- * any file listed in changedStoryAbsPaths.
+ * a changed story file or contains a story-looking but unresolvable specifier.
+ *
+ * Uses resolveSpecifier (the same function as the main loop) so the
+ * story-looking-alias bail rule is UNIFORM whether the aliased story import
+ * is at the top level or inside a barrel. A 'bail' result from resolveSpecifier
+ * means force full; a resolved path in changedStoryAbsPaths means force full;
+ * a resolved non-changed story or null means continue.
  *
  * Returns a reason string (force full) if a match is found, null otherwise.
  * Bails open if the barrel module cannot be read.
  *
- * ONE LEVEL ONLY - if a barrel specifier resolves to another non-story module,
- * it is NOT recursed into (documented limit, covered by the Phase-2 Metro graph).
- * Unresolvable barrel specifiers are not chased.
+ * Deliberate limits (not built here, left to Phase-2 Metro graph + SHERLO-1487):
+ *   - ONE LEVEL ONLY: if a barrel specifier resolves to another non-story module
+ *     it is NOT recursed into. Depth-2-or-deeper barrel chains (index re-exports
+ *     a sub-index which re-exports Base.stories) are not detected at this layer.
+ *   - If the barrel itself is imported via an unresolved alias from the story
+ *     (e.g. Composed.stories does `import from '@/index'`) it is never reached
+ *     here; that structural case stays undetected at this layer.
  */
 function barrelForwardsChangedStory(
   barrelPath: string,
-  changedStoryAbsPaths: Set<string>
+  changedStoryAbsPaths: Set<string>,
+  storyFileSet: Set<string>
 ): string | null {
   let content: string;
   try {
@@ -267,7 +280,10 @@ function barrelForwardsChangedStory(
   }
 
   for (const spec of extractSpecifiers(content)) {
-    const resolved = resolveToFile(barrelPath, spec);
+    const resolved = resolveSpecifier(barrelPath, spec, storyFileSet);
+    if (resolved === 'bail') {
+      return `story-imports-story: unresolved story-looking specifier in barrel ${path.basename(barrelPath)}, forcing full`;
+    }
     if (resolved !== null && changedStoryAbsPaths.has(resolved)) {
       return `story-imports-story: changed story re-exported via barrel ${path.basename(barrelPath)}`;
     }

--- a/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
+++ b/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
@@ -6,8 +6,13 @@ const STORY_FILE_RE = /\.stories\.[jt]sx?$/;
 const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
 
 /**
- * Checks whether any changed story file is statically imported (directly or
- * transitively via other story files) by another story file in the project.
+ * Checks whether any changed story file is imported (directly or transitively
+ * via other story files) by another story file in the project.
+ *
+ * Covers three import forms:
+ *   - Static:        import { X } from '<spec>'
+ *   - Dynamic:       import('<spec>')
+ *   - CommonJS:      require('<spec>')
  *
  * If so, returns { fullRun, reason } because the API only receives file paths -
  * it cannot see that StoryA.stories.tsx re-uses Button's render by importing
@@ -15,7 +20,9 @@ const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
  *
  * BAIL-OPEN: any condition that prevents a reliable graph (can't enumerate
  * story files, can't read a story file, can't resolve a story-looking specifier)
- * returns fullRun.
+ * returns fullRun. This includes path-aliased imports (e.g. '@/X.stories') that
+ * look like story files but cannot be resolved on disk - we cannot rule out a
+ * hidden story->story edge, so we force full rather than silently skip.
  *
  * Precondition: called only after computeChangedFiles would return { changedFiles }
  * (i.e. the partial-eligible path). The common fast path where no story imports
@@ -64,7 +71,7 @@ export function checkStoryImportsStory(
       };
     }
 
-    for (const spec of extractRelativeSpecifiers(content)) {
+    for (const spec of extractSpecifiers(content)) {
       const resolved = resolveSpecifier(storyFile, spec, storyFileSet);
 
       if (resolved === 'bail') {
@@ -126,31 +133,43 @@ function scanDir(dir: string, out: string[]): void {
 }
 
 /**
- * Extracts relative import/require specifiers from source text.
- * Uses a simple regex - may match strings inside comments, which is intentional
+ * Extracts all import/require specifiers from source text.
+ *
+ * Covers three forms:
+ *   - Static / re-export:  from '<spec>'
+ *   - Dynamic import:      import('<spec>')
+ *   - CommonJS:            require('<spec>')
+ *
+ * Returns specifiers verbatim (relative, aliased, bare package - all included).
+ * Uses a simple regex; may match strings inside comments, which is intentional
  * (over-detection is safe for bail-open; we never under-detect).
  */
-function extractRelativeSpecifiers(content: string): string[] {
+function extractSpecifiers(content: string): string[] {
   const out: string[] = [];
-  const re = /\bfrom\s+['"]([^'"]+)['"]|\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const re =
+    /\bfrom\s+['"]([^'"]+)['"]|\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)|\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(content)) !== null) {
-    const spec = m[1] ?? m[2];
-    if (spec && (spec.startsWith('./') || spec.startsWith('../'))) {
-      out.push(spec);
-    }
+    const spec = m[1] ?? m[2] ?? m[3];
+    if (spec) out.push(spec);
   }
   return out;
 }
 
 /**
- * Resolves a relative import specifier from a story file.
+ * Resolves an import specifier from a story file.
  *
  * Returns:
- *   absolute path - specifier resolves to a story file
- *   null          - specifier resolves to a non-story file (safe to skip)
- *   'bail'        - specifier looks like a story file but cannot be resolved
- *                   (a hidden story->story edge cannot be ruled out)
+ *   absolute path - specifier resolves to a story file on disk
+ *   null          - specifier resolves to a non-story file, or is unresolvable
+ *                   but cannot possibly match the story-file pattern (e.g. bare
+ *                   npm packages like 'react', aliased non-story components like
+ *                   '@/components/SharedButton') - safe to skip
+ *   'bail'        - specifier looks like a story file (its path matches
+ *                   STORY_FILE_RE with or without an extension suffix) but cannot
+ *                   be resolved on disk; we cannot rule out a hidden story->story
+ *                   edge (e.g. a path alias '@/X.stories' or a dynamic import of
+ *                   a story that was moved), so we force full rather than skip
  */
 function resolveSpecifier(
   fromFile: string,

--- a/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
+++ b/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
@@ -1,0 +1,213 @@
+import fs from 'fs';
+import path from 'path';
+import type { ChangedFilesResult } from './computeChangedFiles';
+
+const STORY_FILE_RE = /\.stories\.[jt]sx?$/;
+const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+
+/**
+ * Checks whether any changed story file is statically imported (directly or
+ * transitively via other story files) by another story file in the project.
+ *
+ * If so, returns { fullRun, reason } because the API only receives file paths -
+ * it cannot see that StoryA.stories.tsx re-uses Button's render by importing
+ * from Button.stories.tsx. Skipping StoryA would produce a false-green.
+ *
+ * BAIL-OPEN: any condition that prevents a reliable graph (can't enumerate
+ * story files, can't read a story file, can't resolve a story-looking specifier)
+ * returns fullRun.
+ *
+ * Precondition: called only after computeChangedFiles would return { changedFiles }
+ * (i.e. the partial-eligible path). The common fast path where no story imports
+ * another story is not affected (returns { changedFiles } unchanged).
+ */
+export function checkStoryImportsStory(
+  projectRoot: string,
+  changedFiles: string[]
+): ChangedFilesResult {
+  // Fast path: if no changed story files, no cross-story composition to worry about.
+  const changedStories = changedFiles.filter((f) => STORY_FILE_RE.test(f));
+  if (changedStories.length === 0) {
+    return { changedFiles };
+  }
+
+  // Enumerate all story files in the project (absolute paths, excluding node_modules/.git).
+  let allStoryFiles: string[];
+  try {
+    allStoryFiles = findStoryFiles(projectRoot);
+  } catch {
+    return {
+      fullRun: true,
+      reason: 'story-imports-story: failed to enumerate story files, forcing full',
+    };
+  }
+
+  const storyFileSet = new Set(allStoryFiles);
+
+  // Absolute paths of changed story files for comparison with the resolved graph paths.
+  const changedStoryAbsPaths = new Set(
+    changedStories.map((f) => path.resolve(projectRoot, f))
+  );
+
+  // Build reverse-import graph: importee (abs) -> Set<importer (abs)>.
+  // Only story->story edges are tracked.
+  const reverseEdges = new Map<string, Set<string>>();
+
+  for (const storyFile of allStoryFiles) {
+    let content: string;
+    try {
+      content = fs.readFileSync(storyFile, 'utf8');
+    } catch {
+      return {
+        fullRun: true,
+        reason: 'story-imports-story: failed to read story file, forcing full',
+      };
+    }
+
+    for (const spec of extractRelativeSpecifiers(content)) {
+      const resolved = resolveSpecifier(storyFile, spec, storyFileSet);
+
+      if (resolved === 'bail') {
+        return {
+          fullRun: true,
+          reason: 'story-imports-story: unresolved import, forcing full',
+        };
+      }
+
+      if (resolved === null) continue; // resolves to non-story or safely unresolvable
+
+      // storyFile imports resolved (another story): record reverse edge.
+      const importers = reverseEdges.get(resolved);
+      if (importers) {
+        importers.add(storyFile);
+      } else {
+        reverseEdges.set(resolved, new Set([storyFile]));
+      }
+    }
+  }
+
+  // For each changed story file, check whether any other story imports it.
+  for (const changedAbs of changedStoryAbsPaths) {
+    const importer = findImporter(changedAbs, reverseEdges);
+    if (importer !== null) {
+      return {
+        fullRun: true,
+        reason: `story-imports-story: ${path.relative(projectRoot, changedAbs)} reused by ${path.relative(projectRoot, importer)}`,
+      };
+    }
+  }
+
+  return { changedFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Recursively finds all *.stories.{js,jsx,ts,tsx} files under dir. */
+function findStoryFiles(dir: string): string[] {
+  const results: string[] = [];
+  scanDir(dir, results);
+  return results;
+}
+
+function scanDir(dir: string, out: string[]): void {
+  // Throws on permission errors - caught by checkStoryImportsStory for bail-open.
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      scanDir(full, out);
+    } else if (entry.isFile() && STORY_FILE_RE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Extracts relative import/require specifiers from source text.
+ * Uses a simple regex - may match strings inside comments, which is intentional
+ * (over-detection is safe for bail-open; we never under-detect).
+ */
+function extractRelativeSpecifiers(content: string): string[] {
+  const out: string[] = [];
+  const re = /\bfrom\s+['"]([^'"]+)['"]|\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const spec = m[1] ?? m[2];
+    if (spec && (spec.startsWith('./') || spec.startsWith('../'))) {
+      out.push(spec);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolves a relative import specifier from a story file.
+ *
+ * Returns:
+ *   absolute path - specifier resolves to a story file
+ *   null          - specifier resolves to a non-story file (safe to skip)
+ *   'bail'        - specifier looks like a story file but cannot be resolved
+ *                   (a hidden story->story edge cannot be ruled out)
+ */
+function resolveSpecifier(
+  fromFile: string,
+  spec: string,
+  storyFileSet: Set<string>
+): string | null | 'bail' {
+  const base = path.resolve(path.dirname(fromFile), spec);
+
+  // Try the exact path first (covers specs that already carry an extension).
+  if (isFile(base)) {
+    return storyFileSet.has(base) ? base : null;
+  }
+
+  // Try appending each known source extension (covers extension-less specs like
+  // './Button.stories' resolving to './Button.stories.tsx').
+  for (const ext of EXTENSIONS) {
+    const candidate = base + ext;
+    if (isFile(candidate)) {
+      return storyFileSet.has(candidate) ? candidate : null;
+    }
+  }
+
+  // Cannot resolve - check whether the spec could represent a story file.
+  // If the exact path or any extension-added path matches the story pattern,
+  // we cannot rule out a hidden story->story edge: bail.
+  if (STORY_FILE_RE.test(base)) return 'bail';
+  for (const ext of EXTENSIONS) {
+    if (STORY_FILE_RE.test(base + ext)) return 'bail';
+  }
+
+  // Definitely not a story file path - safe to skip.
+  return null;
+}
+
+function isFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns any story file that directly imports changedAbs, or null if none.
+ *
+ * Note: a direct check is sufficient because any transitive story->story chain
+ * A→B→C always implies that B directly imports C, so C's direct importers set
+ * is never empty when C is transitively reachable from another story.
+ */
+function findImporter(
+  changedAbs: string,
+  reverseEdges: Map<string, Set<string>>
+): string | null {
+  const importers = reverseEdges.get(changedAbs);
+  if (!importers) return null;
+  for (const imp of importers) {
+    if (imp !== changedAbs) return imp;
+  }
+  return null;
+}


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1483

SHERLO-1484 - TurboSnap story-imports-story detector (CLI). Re-lands the held SHERLO-1476 detector and adds path-alias plus dynamic-import hardening.

WHAT IT DOES
TurboSnap selection forces a FULL capture when a changed *.stories.* file is imported (directly or transitively) by another story file (CSF composition). Without this, editing a base story that another story re-uses would skip the composing story under a green check (a false green). On any scan uncertainty the detector bails open to a full capture.

DETECTOR (packages/cli/src/helpers/turbosnap/storyImportsStory.ts)
- Builds a story-to-story import graph by scanning every project story file.
- extractSpecifiers collects every specifier form: static 'from', dynamic import(), and require().
- resolveSpecifier maps a specifier to a story file (edge), a non-story file (skip), or 'bail' (force full) when a specifier is unresolvable but looks like a story file (e.g. a path alias such as '@/X.stories'). Bare npm packages and aliased non-story files keep the fast path.
- Wired into computeChangedFiles on the partial-eligible success path only; the shallow / dirty / no-fork-point / error paths still force full.

TESTS (42/42 turbosnap unit tests green; CI CLI-unit job green)
Direct, transitive, and re-export composition force full; a leaf story stays partial; any scan ambiguity bails open; a path-aliased story import bails; an aliased non-story stays partial; a dynamic-import story edge forces full.

PRE-ENABLE FOLLOW-UP (tracked separately, not in this PR)
Barrel re-export forwarding (a story imports a non-story barrel that re-exports a changed story). The rarer alias-without-.stories and template-literal import forms are documented heuristic limits, backstopped by the report-a-miss safety net and the Phase-2 Metro graph.

Gated OFF behind useAncestryBaseline (per-project) and turbosnap-selection (per-team); no behavior change for any project until enabled.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
