### PR TITLE
feat: Fix SDK 2.0.0 story-ID regression: enumerateStories derives…

### DIFF
--- a/.github/workflows/test:unit.yml
+++ b/.github/workflows/test:unit.yml
@@ -30,3 +30,27 @@ jobs:
       - name: Run CLI unit tests
         working-directory: packages/cli
         run: yarn test
+
+  rn-storybook-unit-tests:
+    name: SDK unit tests (@sherlo/react-native-storybook)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download Sherlo packages
+        run: ./scripts/init-env.sh
+        env:
+          CLIENT_STAGE: dev
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run SDK unit tests
+        working-directory: packages/react-native-storybook
+        run: yarn test

--- a/packages/react-native-storybook/src/__tests__/adapter.test.ts
+++ b/packages/react-native-storybook/src/__tests__/adapter.test.ts
@@ -87,6 +87,142 @@ afterEach(() => {
   delete (globalThis as any).STORIES;
 });
 
+// ---------------------------------------------------------------------------
+// Explicit-name regression (SHERLO-1491 / SHERLO-1492)
+// ---------------------------------------------------------------------------
+// Bug: adapter derived the story ID from the explicit `name` field instead of
+// the export key. Storybook keys its store by export key, so when the explicit
+// name slug differs from the export key slug, the SDK emitted an ID that
+// Storybook didn't recognise. The app fell back to the default "Please select
+// a story to preview" screen and `hasError: true` was captured.
+//
+// Fix: always derive the ID via toId(title, storyNameFromExport(exportKey)).
+// The explicit name is retained as the display `name` field only.
+
+describe('enumerateStories – explicit name regression (SHERLO-1491)', () => {
+  afterEach(() => {
+    delete (globalThis as any).STORIES;
+  });
+
+  it('derives story ID from export key, not explicit name', () => {
+    // Story: export const Foo = { name: 'Bar' } under title: 'Explicit Name'
+    // Correct ID (Storybook): 'explicit-name--foo'  (export key 'Foo')
+    // Buggy ID (pre-fix):     'explicit-name--bar'  (explicit name 'Bar')
+    const fileExports = {
+      default: { title: 'Explicit Name' },
+      Foo: { name: 'Bar', render: (): null => null },
+    };
+    const req = Object.assign(
+      (_filename: string) => fileExports,
+      { keys: () => ['./ExplicitName.stories.tsx'] },
+    );
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = {
+      _storyIndex: {
+        entries: {
+          'explicit-name--foo': {
+            id: 'explicit-name--foo',
+            title: 'Explicit Name',
+            name: 'Bar',  // Storybook stores the display name here
+            importPath: './src/ExplicitName.stories.tsx',
+          },
+        },
+      },
+    } as unknown as StorybookView;
+
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    // ID must be export-key-based (not explicit-name-based)
+    expect(storyMetas[0]!.id).toBe('explicit-name--foo');
+    // Display name must still be the explicit name
+    expect(storyMetas[0]!.name).toBe('Bar');
+    // The emitted ID must be a key in _storyIndex.entries
+    const indexIds = Object.keys((view as any)._storyIndex.entries);
+    expect(indexIds).toContain(storyMetas[0]!.id);
+  });
+
+  it('every emitted StoryMeta.id is a member of _storyIndex.entries when present in index', () => {
+    // Two stories: one with explicit name (FooBar → 'Custom Display'),
+    // one without (AnotherOne). Both must emit export-key-based IDs.
+    const fileExports = {
+      default: { title: 'My Title' },
+      FooBar: { name: 'Custom Display', render: (): null => null },
+      AnotherOne: {},
+    };
+    const req = Object.assign(
+      (_filename: string) => fileExports,
+      { keys: () => ['./MyTitle.stories.tsx'] },
+    );
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = {
+      _storyIndex: {
+        entries: {
+          'my-title--foo-bar': {
+            id: 'my-title--foo-bar',
+            title: 'My Title',
+            name: 'Custom Display',
+            importPath: './src/MyTitle.stories.tsx',
+          },
+          'my-title--another-one': {
+            id: 'my-title--another-one',
+            title: 'My Title',
+            name: 'Another One',
+            importPath: './src/MyTitle.stories.tsx',
+          },
+        },
+      },
+    } as unknown as StorybookView;
+
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(2);
+    const indexIds = new Set(Object.keys((view as any)._storyIndex.entries));
+    for (const meta of storyMetas) {
+      expect(indexIds.has(meta.id)).toBe(true);
+    }
+    const emittedIds = storyMetas.map(m => m.id).sort();
+    expect(emittedIds).toEqual(['my-title--another-one', 'my-title--foo-bar']);
+  });
+
+  it('does not emit a duplicate entry when explicit name slug differs from export key slug', () => {
+    // Pre-fix: primary pass emitted 'sometitle--bar' (from explicit name),
+    // then fallback pass found 'sometitle--foo' in indexEntries and emitted it
+    // too → two entries for the same story.
+    // Post-fix: primary pass emits 'sometitle--foo', fallback skips it → one entry.
+    const fileExports = {
+      default: { title: 'SomeTitle' },
+      Foo: { name: 'Bar', render: (): null => null },
+    };
+    const req = Object.assign(
+      (_filename: string) => fileExports,
+      { keys: () => ['./SomeTitle.stories.tsx'] },
+    );
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = {
+      _storyIndex: {
+        entries: {
+          'sometitle--foo': {
+            id: 'sometitle--foo',
+            title: 'SomeTitle',
+            name: 'Bar',
+            importPath: './src/SomeTitle.stories.tsx',
+          },
+        },
+      },
+    } as unknown as StorybookView;
+
+    const storyMetas = enumerateStories(view);
+
+    // Exactly one entry - no duplicate from the fallback pass
+    expect(storyMetas).toHaveLength(1);
+    expect(storyMetas[0]!.id).toBe('sometitle--foo');
+  });
+});
+
 describe('enumerateStories – auto-titled stories (component: without title:)', () => {
   it('preserves story-level parameters when the default export has component: but no title:', () => {
     // AUTO-TITLED story: default export uses `component:` with NO `title:`.

--- a/packages/react-native-storybook/src/__tests__/adapter.test.ts
+++ b/packages/react-native-storybook/src/__tests__/adapter.test.ts
@@ -187,6 +187,43 @@ describe('enumerateStories – explicit name regression (SHERLO-1491)', () => {
     expect(emittedIds).toEqual(['my-title--another-one', 'my-title--foo-bar']);
   });
 
+  it('resolves to the real Storybook index id when slug diverges (importPath+name fallback)', () => {
+    // Simulates a divergent-slug scenario: the SDK computes 'my-title--foo'
+    // from the export key via toId('My Title', storyNameFromExport('Foo')),
+    // but the real Storybook index has a different id 'my-title--foo-x'.
+    // The layered resolution must fall back to the importPath+displayName match
+    // to return Storybook's own id. This test FAILS on the no-op one-liner
+    // `indexEntries[exportKeyId]?.id ?? exportKeyId` because that key is absent.
+    const fileExports = {
+      default: { title: 'My Title' },
+      Foo: {}, // no explicit name
+    };
+    const req = Object.assign(
+      (_filename: string) => fileExports,
+      { keys: () => ['./MyTitle.stories.tsx'] },
+    );
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = {
+      _storyIndex: {
+        entries: {
+          'my-title--foo-x': {
+            id: 'my-title--foo-x',   // Storybook's real id (differs from SDK-computed 'my-title--foo')
+            title: 'My Title',
+            name: 'Foo',             // = storyNameFromExport('Foo')
+            importPath: './src/MyTitle.stories.tsx',
+          },
+        },
+      },
+    } as unknown as StorybookView;
+
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    // Must resolve to Storybook's real id, not the SDK-computed 'my-title--foo'
+    expect(storyMetas[0]!.id).toBe('my-title--foo-x');
+  });
+
   it('does not emit a duplicate entry when explicit name slug differs from export key slug', () => {
     // Pre-fix: primary pass emitted 'sometitle--bar' (from explicit name),
     // then fallback pass found 'sometitle--foo' in indexEntries and emitted it

--- a/packages/react-native-storybook/src/storybook/adapter.ts
+++ b/packages/react-native-storybook/src/storybook/adapter.ts
@@ -107,8 +107,11 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
             ? ((storyExport as any).story || {})
             : (storyExport as Record<string, any>);
           const explicitName = typeof annotations.name === 'string' ? annotations.name : undefined;
-          const storyName = explicitName || storyNameFromExport(exportKey);
-          const id = toId(titleStr, storyName);
+          const exportKeyName = storyNameFromExport(exportKey);
+          const exportKeyId = toId(titleStr, exportKeyName);
+          // ID is always export-key-based: Storybook keys its store by export key, not display name.
+          // Prefer the real index ID when available; synthesize only when genuinely absent from index.
+          const id = indexEntries[exportKeyId]?.id ?? exportKeyId;
           if (seen.has(id)) continue;
           seen.add(id);
           const parameters = {
@@ -116,7 +119,7 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
             ...(meta.parameters ?? {}),
             ...(annotations.parameters ?? {}),
           };
-          result.push({ id, title: titleStr, name: storyName, parameters, importPath: primaryImportPath });
+          result.push({ id, title: titleStr, name: explicitName ?? exportKeyName, parameters, importPath: primaryImportPath });
         }
       }
     }

--- a/packages/react-native-storybook/src/storybook/adapter.ts
+++ b/packages/react-native-storybook/src/storybook/adapter.ts
@@ -108,10 +108,22 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
             : (storyExport as Record<string, any>);
           const explicitName = typeof annotations.name === 'string' ? annotations.name : undefined;
           const exportKeyName = storyNameFromExport(exportKey);
+          const displayName = explicitName ?? exportKeyName;
           const exportKeyId = toId(titleStr, exportKeyName);
-          // ID is always export-key-based: Storybook keys its store by export key, not display name.
-          // Prefer the real index ID when available; synthesize only when genuinely absent from index.
-          const id = indexEntries[exportKeyId]?.id ?? exportKeyId;
+          // Layered ID resolution - prefer Storybook's real id, synthesize only when absent:
+          // 1) exact: SDK-computed export-key id matches an index key (common case)
+          // 2) divergent slug: match by importPath + display name (handles curly-apostrophe,
+          //    digit/acronym casing, and other slug divergences between storyNameFromExport
+          //    and Storybook's own normalisation)
+          // 3) genuinely absent from the index (e.g. v10 require.context-only): synthesize
+          let resolvedId: string | undefined = indexEntries[exportKeyId]?.id;
+          if (!resolvedId) {
+            const match = Object.values(indexEntries).find(
+              (e) => e.importPath === primaryImportPath && e.name === displayName
+            );
+            resolvedId = match?.id;
+          }
+          const id = resolvedId ?? exportKeyId;
           if (seen.has(id)) continue;
           seen.add(id);
           const parameters = {
@@ -119,7 +131,7 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
             ...(meta.parameters ?? {}),
             ...(annotations.parameters ?? {}),
           };
-          result.push({ id, title: titleStr, name: explicitName ?? exportKeyName, parameters, importPath: primaryImportPath });
+          result.push({ id, title: titleStr, name: displayName, parameters, importPath: primaryImportPath });
         }
       }
     }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1491

## TL;DR

Since SDK 2.0.0, the Storybook adapter's enumerateStories generates a story's ID from its explicit `name`/`storyName` when present, while Storybook keys its own store by the export key. Any story whose display-name slug differs from its export-key slug gets an ID Storybook cannot resolve: the SDK requests it, Storybook silently shows 'Please select a story to preview', and the runner times out and uploads that default screen flagged hasError=true. This hit customer build 294 (7 stories, both platforms, deterministic; reproduced across builds 293/294/295 including a freshly rebuilt binary). Before 2.0.0 the SDK read Storybook's own story.id directly and was structurally immune. Realign ID derivation to Storybook's IDs and lock it with a regression test.

## Acceptance Criteria

- enumerateStories never derives a story's ID from its explicit `name`/`storyName`; for every story present in view._storyIndex.entries, the emitted StoryMeta.id equals Storybook's own ID for that story.
- A story declared `export const Foo` with explicit `name: 'Bar'` under an explicit `title:` enumerates the ID `<title>--foo` (not `<title>--bar`) and is selectable and snapshot-able (no 'Please select a story to preview' default screen).
- The Storybook v10 capability that motivated the 2.0.0 rewrite is preserved: stories present only via require.context and genuinely absent from view._storyIndex.entries are still enumerated and snapshotted.

## Additional Context

## Root cause (verified)

The SDK's enumerateStories (packages/react-native-storybook/src/storybook/adapter.ts:101-103) builds a story's ID from the explicit display name:

```ts
const explicitName = typeof annotations.name === 'string' ? annotations.name : undefined;
const storyName = explicitName || storyNameFromExport(exportKey); // explicit name wins
const id = toId(titleStr, storyName);
```

Storybook RN keys its store by the export key only (the explicit `name` sets the display name, never the ID). So when a story's display-name slug differs from its export-key slug, the SDK emits an ID into START (and thus into initialSelection) that is not a key in Storybook's store. initialSelection no-ops to the default screen (no crash, no error), the SDK display-poll never matches, no REQUEST_SNAPSHOT is sent, and the runner times out (testWatcher) and still runs testing:upload_screenshot, uploading the default screen with hasError=true.

The adapter's fallback loop (adapter.ts:121-160) separately emits the correct export-key ID from view._storyIndex.entries, so each affected story produces two START entries: the correct one (renders) and the display-name one (fails). This is why both an 'old twin' and a failing snapshot appear in the same run.

## Evidence

- Customer build 294 (prod), device pixel.7.pro-13-light and iPhone: 7 stories captured the default screen, all status R / hasError=true / isNew=true.
- The START story list is device-emitted (entity=app); config.sherlo carries no story list. So the list comes from the running app's own enumeration. The reused-native-binary / stale-bundle theory was investigated and falsified.
- The same stories fail identically across builds 293, 294 and 295 including a freshly rebuilt binary, so it is not a native, bundle, or reuse cause. It is a deterministic per-story-definition SDK defect.

## Regression history

- Pre-2.0.0 (tag 1.6.3): prepareSnapshots.ts iterated view._idToPrepared and used `storyId: rawStory.id` directly (Storybook's own ID). No ID computation existed; immune by construction.
- The correct intermediate (commit 8248ff89, 2.0.0-alpha.1): introduced adapter.ts but still emitted view._storyIndex.entries real IDs, using toId only as a matcher via storyNameFromExport(key) (export key, never the explicit name).
- Regression commit 8ec8193c ('v10 adapter - enumerate from raw require.context'): flipped the primary source to require.context and started generating IDs with `explicitName || storyNameFromExport(exportKey)`. Shipped in tag 2.0.0 (dev HEAD identical).
- The band-aid that would have masked this (commit 47f6cb02, 'populate view._storyIndex.entries so Storybook can navigate to every story we ship via START') did NOT ship in 2.0.0 (only reads of _storyIndex remain), so the generated IDs are never registered with Storybook.

## Why it changed (do not blind-revert)

The rewrite was real Storybook RN v10 support: v10 broke _idToPrepared lazy population for legacy CSF stories, so the pre-2.0.0 path would hang or under-count. The fix must keep working on v10, so a full revert to _idToPrepared is not acceptable.

## Recommended fix (option a)

Prefer view._storyIndex.entries IDs as the source of truth; synthesize an ID only when an export is genuinely missing from the index, and when synthesizing mirror Storybook exactly (export key via storyNameFromExport, never the explicit name). Keep the explicit `name` only as the display name field. This re-converges toward the correct intermediate (8248ff89's findExportKeyForStory) plus the require.context completeness pass.

Mandatory minimal change: adapter.ts:101-103 (remove `explicitName` from ID derivation). Ideally extend lines 94-111 to reconcile the computed export against indexEntries so the real ID is preferred. No change needed in prepareSnapshots.ts or useSetInitialTestingData.ts - they pass storyMeta.id straight through, so fixing the adapter fixes START, initialSelection, and the display-poll in one place.

## Ownership

- developer: the SDK fix in the `sherlo` repo (adapter.ts) and the regression tests.
- runner: out of scope for this ticket. The runner faithfully captures whatever the SDK signals. A separate hardening idea (testing:snapshot_failed should not silently upload the default screen as a hasError=true snapshot) is intentionally deferred.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
