### PR TITLE
feat: Give the E2E tester a TEST-only feature-flag write capabilit…

### DIFF
--- a/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/turbosnap/storyImportsStory.test.ts
@@ -464,3 +464,91 @@ export default { title: 'Home' };`
     expect(r.reason).toContain('Button.stories.tsx');
   });
 });
+
+// ---------------------------------------------------------------------------
+// (i) Relative projectRoot - the real runtime passes DEFAULT_PROJECT_ROOT = '.'
+//
+// REGRESSION GUARD: all the tests above pass an ABSOLUTE fx.dir as projectRoot,
+// so they never exercised the production code path where projectRoot is '.'.
+// With a relative root, findStoryFiles emitted relative paths into storyFileSet
+// while resolveSpecifier compares against ABSOLUTE (path.resolve) paths, so the
+// membership test never matched and no story->story edge was ever recorded - the
+// detector silently fell through to { changedFiles } in every real build.
+// These cases run with cwd set to the fixture and a relative projectRoot so they
+// mirror the EAS-cloud runtime exactly.
+// ---------------------------------------------------------------------------
+
+describe('(i) relative projectRoot (production DEFAULT_PROJECT_ROOT = ".")', () => {
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fx.dir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  it('detects a direct cross-import with projectRoot "." (S6)', () => {
+    // Mirrors the e2e fixture: ComposedCard imports the changed SharedButton story.
+    fx.write(
+      'src/components/TurboSnap/SharedButton.stories.tsx',
+      `export const Primary = () => null;
+export default { title: 'SharedButton' };`
+    );
+    fx.write(
+      'src/components/TurboSnap/ComposedCard.stories.tsx',
+      `import { Primary } from './SharedButton.stories';
+export default { title: 'ComposedCard' };
+export const WithButton = Primary;`
+    );
+
+    const result = checkStoryImportsStory('.', [
+      'src/components/TurboSnap/SharedButton.stories.tsx',
+    ]);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+    expect(r.reason).toContain('SharedButton.stories.tsx');
+    expect(r.reason).toContain('ComposedCard.stories.tsx');
+  });
+
+  it('detects a barrel chain with projectRoot "." (S7)', () => {
+    // BarrelBase.stories (changed) re-exported via storyBarrel.ts, imported by BarrelCard.
+    fx.write(
+      'src/components/TurboSnap/BarrelBase.stories.tsx',
+      `export const Base = () => null;
+export default { title: 'BarrelBase' };`
+    );
+    fx.write(
+      'src/components/TurboSnap/storyBarrel.ts',
+      `export { Base } from './BarrelBase.stories';`
+    );
+    fx.write(
+      'src/components/TurboSnap/BarrelCard.stories.tsx',
+      `import { Base } from './storyBarrel';
+export default { title: 'BarrelCard' };
+export const Reused = Base;`
+    );
+
+    const result = checkStoryImportsStory('.', [
+      'src/components/TurboSnap/BarrelBase.stories.tsx',
+    ]);
+
+    expect(result).toMatchObject({ fullRun: true });
+    const r = result as { fullRun: true; reason: string };
+    expect(r.reason).toMatch(/story-imports-story/);
+  });
+
+  it('preserves the fast path with projectRoot "." when no story imports another', () => {
+    fx.write('src/A.stories.tsx', `export default { title: 'A' };`);
+    fx.write('src/B.stories.tsx', `export default { title: 'B' };`);
+
+    const changed = ['src/A.stories.tsx'];
+    const result = checkStoryImportsStory('.', changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+});

--- a/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
+++ b/packages/cli/src/helpers/turbosnap/storyImportsStory.ts
@@ -47,10 +47,17 @@ export function checkStoryImportsStory(
     return { changedFiles };
   }
 
+  // Normalize projectRoot to an absolute path. The runtime passes a relative root
+  // (DEFAULT_PROJECT_ROOT = '.'), which would make findStoryFiles emit relative
+  // paths into storyFileSet while resolveSpecifier compares against ABSOLUTE paths
+  // (path.resolve), so storyFileSet.has(...) would never match and no story->story
+  // edge would ever be recorded. Resolving here keeps both sides absolute.
+  const absRoot = path.resolve(projectRoot);
+
   // Enumerate all story files in the project (absolute paths, excluding node_modules/.git).
   let allStoryFiles: string[];
   try {
-    allStoryFiles = findStoryFiles(projectRoot);
+    allStoryFiles = findStoryFiles(absRoot);
   } catch {
     return {
       fullRun: true,
@@ -62,7 +69,7 @@ export function checkStoryImportsStory(
 
   // Absolute paths of changed story files for comparison with the resolved graph paths.
   const changedStoryAbsPaths = new Set(
-    changedStories.map((f) => path.resolve(projectRoot, f))
+    changedStories.map((f) => path.resolve(absRoot, f))
   );
 
   // Build reverse-import graph: importee (abs) -> Set<importer (abs)>.
@@ -121,7 +128,7 @@ export function checkStoryImportsStory(
     if (importer !== null) {
       return {
         fullRun: true,
-        reason: `story-imports-story: ${path.relative(projectRoot, changedAbs)} reused by ${path.relative(projectRoot, importer)}`,
+        reason: `story-imports-story: ${path.relative(absRoot, changedAbs)} reused by ${path.relative(absRoot, importer)}`,
       };
     }
   }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1488

## TL;DR

Sherlo's E2E harness (sherlo-tester) must self-provision its own feature-flag preconditions on the TEST stack - e.g. enable a rollout flag like turbosnap-selection before a run - WITHOUT a human SYSTEM_ADMIN running the write each time. Today the setFeatureRollout mutation / the feature-rollout-test DynamoDB write needs SYSTEM_ADMIN credentials the harness lacks (its organic account is not admin; the dispatched dept profile is read-only by design), so every E2E that needs a flag flipped requires a manual human admin write. This task does two things: (1) build a programmatic TEST-scoped flag-write path the harness can call during setup, and (2) PROVE it by running the deferred TurboSnap live E2E green - self-provisioning the flag via the new path, no human in the loop. THE HARD CONSTRAINT: the capability must be STRUCTURALLY UNABLE to write feature flags on PROD (a self-serve TEST helper, never a PROD lever). Safety is two independent layers: a TEST-scoped credential that has no PROD access (PROD's AppSync endpoint, DynamoDB table, and account/role are separate), AND an explicit stage guard in the write path that refuses any stage other than 'test'. Either layer alone blocks PROD; together a PROD write is impossible by construction. The TurboSnap live E2E run here is the pre-enable validation deferred from SHERLO-1483 - the detector code (story-imports-story incl. alias/dynamic/barrel) shipped + was Director-verified + merged there; only the live run remained, and it moves here so it runs hands-off via this capability.

## Acceptance Criteria

- The E2E harness can set a feature-rollout flag on the TEST stack programmatically during setup (no human in the loop), demonstrated by it enabling turbosnap-selection on TEST itself.
- Provably TEST-ONLY: a PROD-targeted feature-flag write attempted through this path is REJECTED, enforced by BOTH a test-scoped credential with no PROD access AND an explicit stage guard that refuses stage !== 'test'; verified by a test asserting a PROD-targeted write fails and that the credential cannot reach the PROD table/endpoint.
- The change grants ONLY this narrow TEST feature-flag write - it does not broaden write access for the harness or any dispatched session anywhere else; the read-only-by-design boundary elsewhere is preserved.
- The deferred TurboSnap live e2e-turbosnap.yml runs GREEN on the deployed test stack with the flag self-provisioned by this capability (no human write): S1 (byte-identical inheritance - an inherited story's snapshot URL equals its baseline's), S2 (a shared-component change captures an unedited dependent story and the check blocks on a planted regression), S6 (story-imports-story via relative import forces full), and S7 (barrel composition forces full) all pass; the run URL + per-scenario results are recorded on this ticket.
- The PROD-exclusion design (the two layers) and how the harness uses the path are documented on this ticket / in the repo.

## Additional Context

Raised during the SHERLO-1483 live-E2E setup, where the api dept (read-only profile) could not enable turbosnap-selection on TEST and a human SYSTEM_ADMIN write was required. The operator decided to build the self-serve capability and run the live E2E through it rather than do the manual write, so the TurboSnap live-E2E validation moves here from SHERLO-1483 (whose detector code is shipped + Director-verified + merged). Ownership: api (the TEST-scoped flag-write authorization + the stage guard) and tester (the harness integration + the live E2E run). The entire value of this ticket is the PROD exclusion - if it cannot be made provably TEST-only, it should not ship. Prerequisites already in place from SHERLO-1483: the api + runner are on test (api deploy run 27980001503), and the merged CLI (#166+#167) is published to the @test dist-tag (run 27980111496); re-publish/re-deploy only if those have gone stale.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
