### PR TITLE
feat: [Product bug] @sherlo-io/cli mis-populates prHeadCommitHash…

### DIFF
--- a/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
+++ b/packages/cli/src/helpers/__tests__/getGitInfo.test.ts
@@ -1,6 +1,22 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import getGitInfo, { ANCESTOR_LIMIT } from '../getGitInfo';
 import GitFixture from './support/gitFixture';
+
+/**
+ * Writes a GitHub Actions event payload to a temp file and returns its path, so
+ * a test can point GITHUB_EVENT_PATH at it (mirroring how the runner exposes the
+ * triggering event's JSON to a job). Registered for cleanup in afterEach.
+ */
+const eventFiles: string[] = [];
+function writeGitHubEvent(payload: unknown): string {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-gh-event-')), 'event.json');
+  fs.writeFileSync(file, JSON.stringify(payload), 'utf8');
+  eventFiles.push(file);
+  return file;
+}
 
 /**
  * Real-git tests for getGitInfo, driven by the deterministic {@link GitFixture}
@@ -15,6 +31,7 @@ let fixture: GitFixture;
 const GIT_ENV_KEYS = [
   'GITHUB_HEAD_REF',
   'GITHUB_REF_NAME',
+  'GITHUB_EVENT_PATH',
   'SHERLO_BRANCH',
   'BITRISE_GIT_BRANCH',
   'CIRCLE_BRANCH',
@@ -35,6 +52,9 @@ beforeEach(() => {
 afterEach(() => {
   fixture?.cleanup();
   fixture = undefined as unknown as GitFixture;
+  while (eventFiles.length) {
+    fs.rmSync(path.dirname(eventFiles.pop()!), { recursive: true, force: true });
+  }
   for (const key of GIT_ENV_KEYS) {
     if (savedEnv[key] === undefined) {
       delete process.env[key];
@@ -214,6 +234,95 @@ describe('getGitInfo - PR merge ref (refs/pull/N/merge)', () => {
     expect(info.commitHash).toBe(mergeSha);
     expect(info.prHeadCommitHash).toBeUndefined();
     expect(info.mergeBaseSha).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR merge ref – shallow clone (fetch-depth:1) PR-head recovery (SHERLO-1629)
+//
+// On GitHub's DEFAULT actions/checkout (fetch-depth:1) the synthetic merge
+// commit is present but its parents are grafted away, so `git rev-parse HEAD^2`
+// fails and the PR head can't be read from local history. Without a fallback,
+// prHeadCommitHash is omitted and commitHash decays to the ephemeral merge SHA -
+// which the server then uses as the commit-hash GSI key, hiding an approved PR
+// build from later builds. The CLI recovers the real PR head from the CI event
+// payload (GITHUB_EVENT_PATH -> pull_request.head.sha) instead.
+// ---------------------------------------------------------------------------
+
+describe('getGitInfo - PR merge ref shallow clone (event-payload PR-head recovery)', () => {
+  it('recovers the real PR head from the GitHub event payload when HEAD^2 is unavailable', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head commit', 'feature.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+
+    // depth=1 clone of the merge commit: HEAD^2 (the PR head) is grafted away.
+    const shallow = fixture.shallowClone(1, 'main');
+    try {
+      process.env.GITHUB_REF_NAME = '123/merge';
+      // The runner exposes the pull_request event, whose payload carries the PR head.
+      process.env.GITHUB_EVENT_PATH = writeGitHubEvent({ pull_request: { head: { sha: prHead } } });
+
+      const info = await getGitInfo(shallow.dir);
+
+      // The fix: prHeadCommitHash is the REAL PR head, recovered from the CI signal.
+      expect(info.prHeadCommitHash).toBe(prHead);
+      expect(info.prHeadCommitHash).not.toBe(mergeSha);
+      // commitHash can't be anchored to grafted-away history, so it gracefully stays
+      // the merge SHA. The server keys on `prHeadCommitHash ?? commitHash`, so the
+      // real PR head still wins.
+      expect(info.commitHash).toBe(mergeSha);
+      expect(info.isShallow).toBe(true);
+    } finally {
+      shallow.cleanup();
+    }
+  });
+
+  it('omits prHeadCommitHash (never the merge SHA) on a shallow merge ref with no event payload', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    fixture.commitFile('pr head commit', 'feature.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+
+    const shallow = fixture.shallowClone(1, 'main');
+    try {
+      process.env.GITHUB_REF_NAME = '123/merge';
+      // No GITHUB_EVENT_PATH: neither HEAD^2 nor a CI signal is available.
+
+      const info = await getGitInfo(shallow.dir);
+
+      // Omit rather than record the wrong (merge) SHA - do not fabricate a PR head.
+      expect(info.prHeadCommitHash).toBeUndefined();
+      expect(info.prHeadCommitHash).not.toBe(mergeSha);
+      expect(info.isShallow).toBe(true);
+    } finally {
+      shallow.cleanup();
+    }
+  });
+
+  it('prefers the local HEAD^2 over the event payload on a full clone', async () => {
+    fixture = GitFixture.create();
+    fixture.commitFile('base on main');
+    fixture.branch('feature', { checkout: true });
+    const prHead = fixture.commitFile('pr head commit', 'feature.txt');
+    fixture.checkout('main');
+    const mergeSha = fixture.merge('feature');
+    fixture.detach(mergeSha);
+
+    process.env.GITHUB_REF_NAME = '123/merge';
+    // A deliberately wrong event payload must NOT override the authoritative local HEAD^2.
+    process.env.GITHUB_EVENT_PATH = writeGitHubEvent({
+      pull_request: { head: { sha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' } },
+    });
+
+    const info = await getGitInfo(fixture.dir);
+
+    expect(info.prHeadCommitHash).toBe(prHead);
+    expect(info.commitHash).toBe(prHead);
   });
 });
 

--- a/packages/cli/src/helpers/getGitInfo.ts
+++ b/packages/cli/src/helpers/getGitInfo.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { Build } from '@sherlo/api-types';
 import runShellCommand from './runShellCommand';
 
@@ -71,6 +72,31 @@ function isPullRequestMergeRef(): boolean {
   const refName = process.env.GITHUB_REF_NAME;
   if (!refName) return false;
   return /^\d+\/merge$/.test(refName) || refName.startsWith('gh-readonly-queue/');
+}
+
+/**
+ * The real PR-head SHA reported directly by GitHub Actions, independent of the
+ * local clone depth.
+ *
+ * On a `pull_request` event GitHub writes the triggering event's JSON payload to
+ * the file named by `GITHUB_EVENT_PATH`, and `pull_request.head.sha` in that
+ * payload is the tip of the PR branch - exactly the second parent (HEAD^2) of
+ * the synthetic `refs/pull/N/merge` commit. We read it as a shallow-clone-proof
+ * source for the PR head: on GitHub's default fetch-depth:1 checkout the merge
+ * commit's parents are grafted away, so `git rev-parse HEAD^2` can't recover
+ * this SHA locally. Returns undefined when the file or field is absent (e.g. a
+ * merge_group event, which carries no PR head).
+ */
+function getPrHeadShaFromGitHubEvent(): string | undefined {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return undefined;
+  try {
+    const payload = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    const sha = payload?.pull_request?.head?.sha;
+    return typeof sha === 'string' && sha.length > 0 ? sha : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -185,23 +211,44 @@ async function getAdditionalGitInfo(
     }
   };
 
+  // Resolves a git revision to its SHA, returning undefined instead of throwing
+  // when the revision can't be resolved (e.g. HEAD^2 on a shallow clone whose
+  // parent objects were grafted away).
+  const safeRevParse = async (rev: string): Promise<string | undefined> => {
+    try {
+      return await runShellCommand({ command: `git rev-parse ${rev}`, projectRoot });
+    } catch {
+      return undefined;
+    }
+  };
+
   const onMergeRef = isPullRequestMergeRef();
 
-  // Determine the canonical commit SHA to anchor all ancestry queries.
-  // On a PR merge ref the real PR head is the SECOND parent (HEAD^2).
+  // On a synthetic merge-ref checkout, resolve the REAL PR head.
+  //
+  // The PR head is the second parent (HEAD^2) of the merge commit. On a full
+  // clone `git rev-parse HEAD^2` returns it directly. On GitHub's DEFAULT
+  // fetch-depth:1 shallow checkout the parent objects are grafted away and that
+  // command fails, so we fall back to the PR-head SHA GitHub records in the
+  // pull_request event payload.
+  //
+  // `prHeadCommitHash` must carry the real PR head in BOTH cases: the server
+  // keys the commit-hash GSI on it, so a wrong value (e.g. the ephemeral merge
+  // SHA) makes an approved PR build invisible to later builds. It also signals
+  // that this build originates from a synthetic merge ref - without it a
+  // canonicalised commitHash is indistinguishable from a direct push.
+  //
+  // `canonicalSha` anchors the LOCAL ancestry queries below. We only set it when
+  // the PR head actually exists in this clone (deep clone); on a shallow clone
+  // it stays undefined so those queries run against HEAD and degrade gracefully
+  // instead of failing on a grafted-away object.
   let canonicalSha: string | undefined;
-  await safe(async () => {
-    if (onMergeRef) {
-      canonicalSha = await runShellCommand({
-        command: 'git rev-parse HEAD^2',
-        projectRoot,
-      });
-      // Signal to the server that this build originates from a synthetic merge
-      // ref.  Without this field a canonicalised commitHash is indistinguishable
-      // from a direct push to the same SHA.
-      additional.prHeadCommitHash = canonicalSha;
-    }
-  });
+  if (onMergeRef) {
+    const localPrHead = await safeRevParse('HEAD^2');
+    const prHead = localPrHead ?? getPrHeadShaFromGitHubEvent();
+    if (prHead) additional.prHeadCommitHash = prHead;
+    canonicalSha = localPrHead;
+  }
 
   // Parent SHAs of the canonical commit.
   await safe(async () => {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1629

## Root cause (refined from the ticket's diagnosis)

SHERLO-1629: within-PR accept-once silently broke because an approved PR build was keyed in the commitHash GSI by the ephemeral merge-ref SHA instead of the real PR head, so a later build could not find it (getCanonicalCommitHash = prHeadCommitHash ?? commitHash).

Confirmation refined the diagnosis:
- The ticket's headline fix (set gitInfo.prHeadCommitHash to the real PR head) was ALREADY implemented on main and shipped in published 2.0.1 (commits #163/#164): getGitInfo sets prHeadCommitHash = git rev-parse HEAD^2.
- The genuine LIVE bug that survives 2.0.1: on GitHub's DEFAULT actions/checkout (fetch-depth:1) shallow checkout of a refs/pull/N/merge ref, the merge commit's parents are grafted away, so git rev-parse HEAD^2 fails. prHeadCommitHash was then omitted and commitHash decayed to the merge SHA -> the build was GSI-keyed by the merge SHA -> approved PR build invisible to later builds -> the unchanged approved story rebaselined and flipped to unreviewed.

## Fix

Recover the real PR head from the CI event payload (GITHUB_EVENT_PATH -> pull_request.head.sha) when local HEAD^2 is unavailable. Local HEAD^2 stays preferred (authoritative git); when neither exists, prHeadCommitHash is omitted rather than set to a wrong SHA. Adds 3 tests for the previously-uncovered shallow-clone scenario. yarn build OK; yarn test 206 passed (getGitInfo 44).

## PROD EXPOSURE (acceptance criterion)

YES. Real customers using the default shallow checkout hit this same bug (approved stories return to unreviewed on a second push). This fix resolves it for them.

## AC #1 confirmation note

The E2E run 28751401698 artifacts (pr-build-c.txt / pr-build-d.txt) were off-disk and could not be retrieved to read build C's stored field values. Root cause was instead confirmed mechanistically and locked with reproduction tests (stronger than the artifact snapshot). Happy to have the tester dept fetch the artifacts if you want the exact stored SHAs for the record.

## Out of scope (operator / optional)

- OPERATOR-ONLY: publishing the fixed CLI to npm + ensuring the dev env picks it up. Not automated.
- OPTIONAL api GSI dual-key hardening (sherlo-api): deferred - it needs a DB migration (sensitive path) and the root-cause fix already resolves the bug. Recommend a separate follow-up PR if the defense-in-depth layer is wanted.
- The E2E test 06-pr-ancestry-scenario.spec.ts:315 is untouched.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
