### PR TITLE
feat: Add --wait flag to CLI to poll for test results before exiti…

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -93,6 +93,8 @@ export const PROJECT_ROOT_OPTION = 'projectRoot';
 export const TOKEN_OPTION = 'token';
 export const INCLUDE_OPTION = 'include';
 export const WAIT_FOR_EAS_BUILD_OPTION = 'waitForEasBuild';
+export const WAIT_OPTION = 'wait';
+export const WAIT_TIMEOUT_OPTION = 'waitTimeout';
 
 export const COLOR = {
   reported: 'FFB36C',

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -33,9 +33,9 @@ function buildResponse(
   runStatus: string,
   viewStatusesCount?: { approved: number; noChanges: number; reported: number; unreviewed: number },
   runError?: unknown
-): { getBuild: Record<string, unknown> } {
+): { getBuildStatus: Record<string, unknown> } {
   return {
-    getBuild: {
+    getBuildStatus: {
       runStatus,
       viewStatusesCount: viewStatusesCount ?? null,
       runError: runError ?? null,
@@ -311,7 +311,7 @@ describe('waitForBuildResult', () => {
   /* AUTH - header format and auth-failure handling                      */
   /* ------------------------------------------------------------------ */
 
-  it('sends the correct Authorization header (JSON-stringified token object)', async () => {
+  it('sends the correct Authorization header and getBuildStatus query', async () => {
     mockGraphqlResponse(
       200,
       buildResponse('finished', { approved: 0, noChanges: 1, reported: 0, unreviewed: 0 })
@@ -334,6 +334,11 @@ describe('waitForBuildResult', () => {
     const headers = fetchCallArgs[1]?.headers;
     expect(headers).toBeDefined();
     expect(headers.Authorization).toBe(JSON.stringify({ authToken: API_TOKEN }));
+
+    // Verify the POST body uses getBuildStatus (machine-auth query), not getBuild
+    const body = JSON.parse(fetchCallArgs[1]?.body);
+    expect(body.query).toMatch('getBuildStatus');
+    expect(body.query).not.toMatch(/\bgetBuild\b/);
   });
 
   it('exits 2 (ERROR) immediately on HTTP 401 without retrying', async () => {
@@ -434,12 +439,12 @@ describe('waitForBuildResult', () => {
   /* NULL BUILD - build not found yet                                     */
   /* ------------------------------------------------------------------ */
 
-  it('retries when getBuild returns null (build not found)', async () => {
+  it('retries when getBuildStatus returns null (build not found)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
       statusText: 'OK',
-      json: async () => ({ data: { getBuild: null } }),
+      json: async () => ({ data: { getBuildStatus: null } }),
     });
     mockGraphqlResponse(
       200,

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Tests for waitForBuildResult - the --wait polling helper.
+ *
+ * Each exit-code case is covered by mocking the fetch response from the
+ * GraphQL endpoint. Timer mocks accelerate the polling loop so tests
+ * complete instantly.
+ */
+
+import fetch from 'node-fetch';
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
+import waitForBuildResult, {
+  EXIT_BLOCK,
+  EXIT_ERROR,
+  EXIT_GREEN,
+  EXIT_TIMEOUT,
+} from '../waitForBuildResult';
+
+// The token format used throughout: 32-char apiToken + 8-char teamId + projectIndex
+const API_TOKEN = 'A'.repeat(32);
+const TEAM_ID = 'B'.repeat(8);
+const PROJECT_INDEX = 42;
+const TOKEN = `${API_TOKEN}${TEAM_ID}${PROJECT_INDEX}`;
+const BUILD_INDEX = 1;
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+const mockFetch = fetch as unknown as Mock;
+
+// Helper: build a minimal GraphQL response body
+function buildResponse(
+  runStatus: string,
+  viewStatusesCount?: { approved: number; noChanges: number; reported: number; unreviewed: number },
+  runError?: unknown
+): { getBuild: Record<string, unknown> } {
+  return {
+    getBuild: {
+      runStatus,
+      viewStatusesCount: viewStatusesCount ?? null,
+      runError: runError ?? null,
+      startedAt: null,
+      queuedAt: null,
+      finishedAt: null,
+    },
+  };
+}
+
+function mockGraphqlResponse(status: number, data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => ({ data }),
+  });
+}
+
+describe('waitForBuildResult', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* EXIT 0 - GREEN                                                      */
+  /* ------------------------------------------------------------------ */
+
+  it('exits 0 (GREEN) when build finishes with no unreviewed and no reported', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+  });
+
+  it('exits 0 (GREEN) when viewStatusesCount has no reported/unreviewed (even if nullish)', async () => {
+    // simulate a build that finished before view statuses populated
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 0, noChanges: 3, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+  });
+
+  it('exits 0 (GREEN) when viewStatusesCount is missing (treat as zero)', async () => {
+    mockGraphqlResponse(200, buildResponse('finished'));
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* EXIT 1 - BLOCK (unreviewed or reported changes)                     */
+  /* ------------------------------------------------------------------ */
+
+  it('exits 1 (BLOCK) when build finishes with unreviewed changes', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 3, noChanges: 5, reported: 0, unreviewed: 3 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_BLOCK);
+  });
+
+  it('exits 1 (BLOCK) when build finishes with reported (denied) changes', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 3, noChanges: 5, reported: 2, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_BLOCK);
+  });
+
+  it('exits 1 (BLOCK) when both unreviewed and reported are present', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 1, noChanges: 2, reported: 1, unreviewed: 2 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_BLOCK);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* EXIT 2 - ERROR / CANCELED                                           */
+  /* ------------------------------------------------------------------ */
+
+  it('exits 2 (ERROR) when build runStatus is "error"', async () => {
+    mockGraphqlResponse(200, buildResponse('error'));
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_ERROR);
+  });
+
+  it('exits 2 (ERROR) when build runStatus is "canceled"', async () => {
+    mockGraphqlResponse(200, buildResponse('canceled'));
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_ERROR);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* EXIT 3 - TIMEOUT                                                    */
+  /* ------------------------------------------------------------------ */
+
+  it('exits 3 (TIMEOUT) when build never reaches terminal state within waitTimeout', async () => {
+    // Build stays "inProgress" forever
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ data: buildResponse('inProgress') }),
+      })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+      waitTimeoutMinutes: 1, // 1 minute timeout
+    });
+
+    // Advance well past the timeout (1min timeout + enough 15s polling cycles)
+    // With 15s polls: 0s, 15s, 30s, 45s, 60s (not > yet), 75s → timeout fires
+    await vi.advanceTimersByTimeAsync(120_000);
+    const result = await promise;
+
+    expect(result).toBe(EXIT_TIMEOUT);
+  }, 10_000);
+
+  /* ------------------------------------------------------------------ */
+  /* RESILIENCE - network errors are retried                              */
+  /* ------------------------------------------------------------------ */
+
+  it('retries on network error and eventually succeeds', async () => {
+    // First call fails with network error
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    // Second call succeeds with finished/green
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 2, noChanges: 4, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on HTTP error and eventually succeeds', async () => {
+    // First call returns HTTP 500
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    });
+    // Second call succeeds
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 1, noChanges: 1, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* AUTH - header format and auth-failure handling                      */
+  /* ------------------------------------------------------------------ */
+
+  it('sends the correct Authorization header (JSON-stringified token object)', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 0, noChanges: 1, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Verify the exact Authorization header the Lambda authorizer expects
+    const fetchCallArgs = mockFetch.mock.calls[0];
+    const headers = fetchCallArgs[1]?.headers;
+    expect(headers).toBeDefined();
+    expect(headers.Authorization).toBe(JSON.stringify({ authToken: API_TOKEN }));
+  });
+
+  it('exits 2 (ERROR) immediately on HTTP 401 without retrying', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+    });
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_ERROR);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
+  });
+
+  it('exits 2 (ERROR) immediately on HTTP 403 without retrying', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({}),
+    });
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_ERROR);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
+  });
+
+  it('exits 2 (ERROR) immediately on GraphQL auth error without retrying', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        errors: [{ errorType: 'UnauthorizedException', message: 'Not authorized' }],
+      }),
+    });
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_ERROR);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* STATE TRANSITIONS - polls through in-progress states                 */
+  /* ------------------------------------------------------------------ */
+
+  it('polls through queued → inProgress → finished states', async () => {
+    mockGraphqlResponse(200, buildResponse('queued'));
+    mockGraphqlResponse(200, buildResponse('inProgress'));
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 1, noChanges: 1, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* NULL BUILD - build not found yet                                     */
+  /* ------------------------------------------------------------------ */
+
+  it('retries when getBuild returns null (build not found)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ data: { getBuild: null } }),
+    });
+    mockGraphqlResponse(
+      200,
+      buildResponse('finished', { approved: 0, noChanges: 1, reported: 0, unreviewed: 0 })
+    );
+
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -29,5 +29,6 @@ export { default as stripAnsi } from './stripAnsi';
 export { default as throwError } from './throwError';
 export { default as uploadOrReuseBuildsAndRunTests } from './uploadOrReuseBuildsAndRunTests';
 export { default as validateLocalBinaries } from './validateLocalBinaries';
+export { default as waitForBuildResult } from './waitForBuildResult';
 export { default as withCommandTimeout } from './withCommandTimeout';
 export { default as wrapInBox } from './wrapInBox';

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -1,5 +1,6 @@
 import sdkClient from '@sherlo/sdk-client';
 import chalk from 'chalk';
+import logWarning from './logWarning';
 import { TEST_EAS_UPDATE_COMMAND, TEST_STANDARD_COMMAND } from '../constants';
 import { CommandParams, EasUpdateData } from '../types';
 import getAppBuildUrl from './getAppBuildUrl';
@@ -146,6 +147,11 @@ function printEasUpdateData(easUpdateData: EasUpdateData) {
 function parseWaitTimeout(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
   const minutes = parseInt(raw, 10);
-  if (isNaN(minutes) || minutes < 1) return undefined;
+  if (isNaN(minutes) || minutes < 1) {
+    logWarning({
+      message: `Invalid --wait-timeout "${raw}"; using default 45 minutes.`,
+    });
+    return undefined;
+  }
   return minutes;
 }

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -13,6 +13,7 @@ import printResultsUrl from './printResultsUrl';
 import reporting from './reporting';
 import { computeChangedFiles, computeNativeFingerprint } from './turbosnap';
 import uploadOrPrintBinaryReuse from './uploadOrPrintBinaryReuse';
+import waitForBuildResult from './waitForBuildResult';
 
 async function uploadOrReuseBuildsAndRunTests({
   commandParams,
@@ -110,6 +111,21 @@ async function uploadOrReuseBuildsAndRunTests({
 
   printResultsUrl(url);
 
+  if (commandParams.wait) {
+    const exitCode = await waitForBuildResult({
+      token: commandParams.token,
+      buildIndex: buildIndex,
+      projectIndex,
+      teamId,
+      waitTimeoutMinutes: parseWaitTimeout(commandParams.waitTimeout),
+    });
+
+    // --wait mode: the exit code IS the contract. Flush telemetry then exit.
+    await reporting.flush().finally(() => {
+      process.exit(exitCode);
+    });
+  }
+
   return { url };
 }
 
@@ -125,4 +141,11 @@ function printEasUpdateData(easUpdateData: EasUpdateData) {
       `└─ author: ${chalk.blue(easUpdateData.author)}\n` +
       `└─ branch: ${chalk.blue(easUpdateData.branch)}\n`
   );
+}
+
+function parseWaitTimeout(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const minutes = parseInt(raw, 10);
+  if (isNaN(minutes) || minutes < 1) return undefined;
+  return minutes;
 }

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -1,0 +1,297 @@
+import fetch from 'node-fetch';
+import chalk from 'chalk';
+import getAppBuildUrl from './getAppBuildUrl';
+import getTokenParts from './getTokenParts';
+
+/*
+ * EXIT CODE CONTRACT
+ * =============================================================================
+ * Mirrors the GitHub check-state mapping decided for the sherlo/visual-tests
+ * check, so the CI exit code and the GitHub check conclusion never drift.
+ *
+ *   0 - GREEN:  build finished, every story noChanges or already approved
+ *               (zero unreviewed, zero reported).
+ *   1 - BLOCK:  build finished with unreviewed or reported/denied changes.
+ *               A human must review in the dashboard.
+ *   2 - ERROR:  build ended in a build/system error (infrastructure/capture
+ *               failure, canceled, or authentication/permission denied).
+ *   3 - TIMEOUT: --wait-timeout elapsed before reaching a terminal state.
+ *               Conservative - timeout is a BLOCK, never a pass.
+ *
+ * GitHub check mapping (for reference):
+ *   exit 0 → conclusion: "success"
+ *   exit 1 → conclusion: "action_required"
+ *   exit 2 → conclusion: "failure"
+ *   exit 3 → conclusion: "action_required" (timeout)
+ * =============================================================================
+ */
+
+export const EXIT_GREEN = 0;
+export const EXIT_BLOCK = 1;
+export const EXIT_ERROR = 2;
+export const EXIT_TIMEOUT = 3;
+
+const DEFAULT_WAIT_TIMEOUT_MINUTES = 45;
+const POLL_INTERVAL_MS = 15_000; // fixed interval, no API hammering
+
+type BuildStatusResponse = {
+  getBuild: {
+    runStatus: 'canceled' | 'error' | 'finished' | 'inProgress' | 'queued' | 'waiting';
+    viewStatusesCount?: {
+      approved: number;
+      noChanges: number;
+      reported: number;
+      unreviewed: number;
+    };
+    runError?: unknown;
+    startedAt?: string;
+    queuedAt?: string;
+    finishedAt?: string;
+  } | null;
+};
+
+async function waitForBuildResult({
+  token,
+  buildIndex,
+  projectIndex,
+  teamId,
+  waitTimeoutMinutes,
+}: {
+  token: string;
+  buildIndex: number;
+  projectIndex: number;
+  teamId: string;
+  waitTimeoutMinutes?: number;
+}): Promise<number> {
+  const timeoutMs = (waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES) * 60 * 1000;
+  const startTime = Date.now();
+  const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
+
+  const { apiToken } = getTokenParts(token);
+  const endpointUrl = getEndpointUrl();
+
+  console.log(
+    chalk.dim(
+      `⏳ Waiting for build results (timeout: ${
+        waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES
+      }min)...`
+    )
+  );
+
+  let lastStatus = '';
+
+  while (true) {
+    // Check timeout before each poll
+    if (Date.now() - startTime > timeoutMs) {
+      console.log();
+      console.log(
+        chalk.yellow(
+          `⏰ Timeout reached after ${waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES} minutes.`
+        )
+      );
+      console.log(chalk.yellow('   The build may still be running. Check the dashboard:'));
+      console.log(chalk.blue(`   ${url}`));
+      console.log();
+      return EXIT_TIMEOUT;
+    }
+
+    let build: NonNullable<BuildStatusResponse['getBuild']> | null = null;
+
+    try {
+      build = await fetchBuildStatus(endpointUrl, apiToken, {
+        index: buildIndex,
+        projectIndex,
+        teamId,
+      });
+    } catch (error) {
+      // Auth failures are not retryable - stop immediately
+      if (error instanceof AuthError) {
+        console.log();
+        console.log(chalk.red(`🔒 ${error.message}`));
+        console.log(chalk.blue(`   Dashboard: ${url}`));
+        console.log();
+        return EXIT_ERROR;
+      }
+
+      // Transient network blips are retried
+      console.log(chalk.dim(`   Network error, retrying... (${(error as Error).message})`));
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+
+    if (!build) {
+      console.log(chalk.dim('   Build not found, retrying...'));
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+
+    // Print progress when status changes
+    const progressLine = formatProgressLine(build);
+    if (progressLine !== lastStatus) {
+      console.log(progressLine);
+      lastStatus = progressLine;
+    }
+
+    const exitCode = evaluateTerminalState(build, url);
+
+    if (exitCode !== null) {
+      return exitCode;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+/* ========================================================================== */
+/* INTERNALS                                                                   */
+/* ========================================================================== */
+
+function getEndpointUrl(): string {
+  const sdkEnv = require('@sherlo/sdk-client/dist/env.json');
+  return process.env.SHERLO_API_URL ?? sdkEnv.endpoints.url;
+}
+
+class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+async function fetchBuildStatus(
+  endpointUrl: string,
+  apiToken: string,
+  variables: { index: number; projectIndex: number; teamId: string }
+): Promise<NonNullable<BuildStatusResponse['getBuild']> | null> {
+  const response = await fetch(endpointUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: JSON.stringify({ authToken: apiToken }),
+    },
+    body: JSON.stringify({
+      query: `
+        query getBuild($index: Int!, $projectIndex: Int!, $teamId: String!) {
+          getBuild(index: $index, projectIndex: $projectIndex, teamId: $teamId) {
+            runStatus
+            viewStatusesCount {
+              approved
+              noChanges
+              reported
+              unreviewed
+            }
+            runError
+            startedAt
+            queuedAt
+            finishedAt
+          }
+        }
+      `,
+      variables,
+    }),
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new AuthError(`Authentication failed (HTTP ${response.status}) - check your token`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const json = (await response.json()) as { data?: BuildStatusResponse; errors?: unknown[] };
+
+  if (json.errors?.length) {
+    const errorTypes = json.errors.map((e: any) => e?.errorType ?? '').filter(Boolean);
+    const isAuthError = errorTypes.some((t: string) => /unauthorized|forbidden|auth/i.test(t));
+    if (isAuthError) {
+      throw new AuthError('Authentication failed - GraphQL authorization error. Check your token.');
+    }
+    throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+
+  return json.data?.getBuild ?? null;
+}
+
+function evaluateTerminalState(
+  build: NonNullable<BuildStatusResponse['getBuild']>,
+  url: string
+): number | null {
+  const { runStatus, viewStatusesCount } = build;
+
+  switch (runStatus) {
+    case 'finished': {
+      const unreviewed = viewStatusesCount?.unreviewed ?? 0;
+      const reported = viewStatusesCount?.reported ?? 0;
+
+      if (unreviewed === 0 && reported === 0) {
+        console.log();
+        console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
+        console.log(chalk.blue(`   ${url}`));
+        console.log();
+        return EXIT_GREEN;
+      }
+
+      console.log();
+      console.log(chalk.yellow('⚠️  Build finished with changes requiring review.'));
+      if (unreviewed > 0) {
+        console.log(chalk.yellow(`   ${unreviewed} story/stories unreviewed.`));
+      }
+      if (reported > 0) {
+        console.log(chalk.yellow(`   ${reported} story/stories reported.`));
+      }
+      console.log(chalk.blue(`   Review here: ${url}`));
+      console.log();
+      return EXIT_BLOCK;
+    }
+
+    case 'error':
+    case 'canceled': {
+      console.log();
+      console.log(chalk.red(`❌ Build ended in "${runStatus}" state.`));
+      if (build.runError) {
+        console.log(chalk.red(`   Error: ${JSON.stringify(build.runError)}`));
+      }
+      console.log(chalk.blue(`   ${url}`));
+      console.log();
+      return EXIT_ERROR;
+    }
+
+    default:
+      // queued, waiting, inProgress - still running
+      return null;
+  }
+}
+
+function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuild']>): string {
+  const { runStatus, startedAt, queuedAt, finishedAt } = build;
+
+  const statusLabel: Record<string, string> = {
+    queued: '🟡 Queued',
+    waiting: '🟡 Waiting',
+    inProgress: '🔵 Running',
+    finished: '🟢 Finished',
+    error: '🔴 Error',
+    canceled: '⚪ Canceled',
+  };
+
+  let line = chalk.dim(`   ${statusLabel[runStatus] ?? runStatus}`);
+
+  if (queuedAt) {
+    line += chalk.dim(` | queued: ${queuedAt}`);
+  }
+  if (startedAt) {
+    line += chalk.dim(` | started: ${startedAt}`);
+  }
+  if (finishedAt) {
+    line += chalk.dim(` | finished: ${finishedAt}`);
+  }
+
+  return line;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default waitForBuildResult;

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -35,7 +35,7 @@ const DEFAULT_WAIT_TIMEOUT_MINUTES = 45;
 const POLL_INTERVAL_MS = 15_000; // fixed interval, no API hammering
 
 type BuildStatusResponse = {
-  getBuild: {
+  getBuildStatus: {
     runStatus: 'canceled' | 'error' | 'finished' | 'inProgress' | 'queued' | 'waiting';
     viewStatusesCount?: {
       approved: number;
@@ -79,6 +79,7 @@ async function waitForBuildResult({
   );
 
   let lastStatus = '';
+  let pollCount = 0;
 
   while (true) {
     // Check timeout before each poll
@@ -95,7 +96,7 @@ async function waitForBuildResult({
       return EXIT_TIMEOUT;
     }
 
-    let build: NonNullable<BuildStatusResponse['getBuild']> | null = null;
+    let build: NonNullable<BuildStatusResponse['getBuildStatus']> | null = null;
 
     try {
       build = await fetchBuildStatus(endpointUrl, apiToken, {
@@ -138,6 +139,14 @@ async function waitForBuildResult({
       return exitCode;
     }
 
+    // Periodic heartbeat so CI systems never see 5+ min of silence
+    pollCount++;
+    if (pollCount % 20 === 0) {
+      const elapsedMin = Math.round((Date.now() - startTime) / 60_000);
+      const statusLabel = build.runStatus === 'inProgress' ? 'running' : build.runStatus;
+      console.log(chalk.dim(`   still ${statusLabel}... (${elapsedMin}m elapsed)`));
+    }
+
     await sleep(POLL_INTERVAL_MS);
   }
 }
@@ -162,7 +171,7 @@ async function fetchBuildStatus(
   endpointUrl: string,
   apiToken: string,
   variables: { index: number; projectIndex: number; teamId: string }
-): Promise<NonNullable<BuildStatusResponse['getBuild']> | null> {
+): Promise<NonNullable<BuildStatusResponse['getBuildStatus']> | null> {
   const response = await fetch(endpointUrl, {
     method: 'POST',
     headers: {
@@ -171,8 +180,8 @@ async function fetchBuildStatus(
     },
     body: JSON.stringify({
       query: `
-        query getBuild($index: Int!, $projectIndex: Int!, $teamId: String!) {
-          getBuild(index: $index, projectIndex: $projectIndex, teamId: $teamId) {
+        query getBuildStatus($index: Int!, $projectIndex: Int!, $teamId: String!) {
+          getBuildStatus(index: $index, projectIndex: $projectIndex, teamId: $teamId) {
             runStatus
             viewStatusesCount {
               approved
@@ -210,11 +219,11 @@ async function fetchBuildStatus(
     throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
   }
 
-  return json.data?.getBuild ?? null;
+  return json.data?.getBuildStatus ?? null;
 }
 
 function evaluateTerminalState(
-  build: NonNullable<BuildStatusResponse['getBuild']>,
+  build: NonNullable<BuildStatusResponse['getBuildStatus']>,
   url: string
 ): number | null {
   const { runStatus, viewStatusesCount } = build;
@@ -263,7 +272,7 @@ function evaluateTerminalState(
   }
 }
 
-function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuild']>): string {
+function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStatus']>): string {
   const { runStatus, startedAt, queuedAt, finishedAt } = build;
 
   const statusLabel: Record<string, string> = {

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -44,9 +44,6 @@ type BuildStatusResponse = {
       unreviewed: number;
     };
     runError?: unknown;
-    startedAt?: string;
-    queuedAt?: string;
-    finishedAt?: string;
   } | null;
 };
 
@@ -190,9 +187,6 @@ async function fetchBuildStatus(
               unreviewed
             }
             runError
-            startedAt
-            queuedAt
-            finishedAt
           }
         }
       `,
@@ -273,7 +267,7 @@ function evaluateTerminalState(
 }
 
 function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStatus']>): string {
-  const { runStatus, startedAt, queuedAt, finishedAt } = build;
+  const { runStatus } = build;
 
   const statusLabel: Record<string, string> = {
     queued: '🟡 Queued',
@@ -284,19 +278,7 @@ function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStat
     canceled: '⚪ Canceled',
   };
 
-  let line = chalk.dim(`   ${statusLabel[runStatus] ?? runStatus}`);
-
-  if (queuedAt) {
-    line += chalk.dim(` | queued: ${queuedAt}`);
-  }
-  if (startedAt) {
-    line += chalk.dim(` | started: ${startedAt}`);
-  }
-  if (finishedAt) {
-    line += chalk.dim(` | finished: ${finishedAt}`);
-  }
-
-  return line;
+  return chalk.dim(`   ${statusLabel[runStatus] ?? runStatus}`);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -41,6 +41,8 @@ import {
   TEST_STANDARD_COMMAND,
   TOKEN_OPTION,
   WAIT_FOR_EAS_BUILD_OPTION,
+  WAIT_OPTION,
+  WAIT_TIMEOUT_OPTION,
 } from './constants';
 import { logWarning, reporting, withCommandTimeout } from './helpers';
 
@@ -170,6 +172,16 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
     `--${WAIT_FOR_EAS_BUILD_OPTION}`,
     'Start waiting for EAS Build to be triggered manually',
   ],
+  [WAIT_OPTION]: [
+    `--${WAIT_OPTION}`,
+    'Wait for test results and exit with a code encoding the outcome:\n' +
+      '  0 = GREEN (no changes), 1 = changes require review,\n' +
+      '  2 = build/system error, 3 = timeout (block, never pass)',
+  ],
+  [WAIT_TIMEOUT_OPTION]: [
+    '--wait-timeout <minutes>',
+    'Max minutes to wait for results (default: 45). Exit code 3 on timeout.',
+  ],
 };
 
 function addInitCommand(program: Command) {
@@ -188,7 +200,12 @@ function addTestCommand(program: Command) {
   addCommand({
     program,
     command: TEST_COMMAND,
-    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      WAIT_TIMEOUT_OPTION,
+      ...devtoolsOptions,
+    ],
     action: test,
   });
 }
@@ -200,7 +217,12 @@ function addTestStandardCommand(program: Command) {
     program,
     command: TEST_STANDARD_COMMAND,
     oldCommand: 'local-builds',
-    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      WAIT_TIMEOUT_OPTION,
+      ...devtoolsOptions,
+    ],
     action: testStandard,
   });
 }
@@ -215,7 +237,13 @@ function addTestEasUpdateCommand(program: Command) {
     program,
     command: TEST_EAS_UPDATE_COMMAND,
     oldCommand: 'expo-update',
-    options: [BRANCH_OPTION, ...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [
+      BRANCH_OPTION,
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      WAIT_TIMEOUT_OPTION,
+      ...devtoolsOptions,
+    ],
     action: testEasUpdate,
   });
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,6 +24,8 @@ import {
   TEST_STANDARD_COMMAND,
   TOKEN_OPTION,
   WAIT_FOR_EAS_BUILD_OPTION,
+  WAIT_OPTION,
+  WAIT_TIMEOUT_OPTION,
 } from './constants';
 
 /* === GENERAL === */
@@ -76,6 +78,8 @@ type CommonOptions<M extends OptionsMode, F extends OptionsFormat> = {
   [GIT_BRANCH_OPTION]?: string;
   [INCLUDE_OPTION]?: F extends 'raw' ? string : string[];
   [DIAGNOSTICS_OPTION]?: F extends 'raw' ? string : string[];
+  [WAIT_OPTION]?: boolean;
+  [WAIT_TIMEOUT_OPTION]?: F extends 'raw' ? string : string;
 } & (M extends 'withDefaults'
   ? { [CONFIG_OPTION]: string; [PROJECT_ROOT_OPTION]: string }
   : { [CONFIG_OPTION]?: string; [PROJECT_ROOT_OPTION]?: string });


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-167

## SHERLO-167: `--wait` flag for CI gating on visual-test results

Adds a `--wait` mode so any CI pipeline can gate on Sherlo visual-test results using the process exit code alone - no GitHub App, no webhook. Without the flag, behavior is byte-identical to today (async, exit 0 after upload).

**Companion PR:** [sherlo-api#259](https://github.com/sherlo-io/sherlo-api/pull/259) adds the machine-auth `getBuildStatus` query this CLI polls (brought in by a Director scope decision - see below).

### Exit-code contract (stated once in `waitForBuildResult.ts`, tied to the `sherlo/visual-tests` GitHub check mapping)

| exit | meaning | GitHub check |
|------|---------|--------------|
| 0 | GREEN - build finished, every story `noChanges`/`approved` | `success` |
| 1 | BLOCK - finished with unreviewed or reported/denied changes | `action_required` |
| 2 | ERROR - build/system error, canceled, or auth/permission failure | `failure` |
| 3 | TIMEOUT - `--wait-timeout` (default 45min) elapsed before terminal | `action_required` |

Unreviewed = not green (no green-by-skip); timeout is conservatively a block.

### How it works
- After `openBuild`, polls `getBuildStatus` (fields `runStatus` + `viewStatusesCount`) on a fixed 15s interval, authenticating exactly like `@sherlo/sdk-client`/`openBuild` (project-token authorizer, `Authorization: JSON.stringify({authToken})`).
- Prints periodic progress (status label; a ~5-min heartbeat so CI no-output timeouts don't kill the job) and always prints the final outcome + dashboard URL.
- Network blips are retried; **auth/permission failures fail fast with exit 2** rather than retrying into a timeout.
- Warns when an invalid `--wait-timeout` value is discarded.
- Exposed only on flows that honor it: `test-standard`, `test-eas-update`, and interactive `test` (which forwards to them). NOT on `test-eas-cloud-build`.

### Why the api companion (scope note)
The CLI first tried to poll the existing `Query.getBuild`, but that resolver is behind the Cognito user authorizer - the CLI's machine token can never authorize it. Per a Director scope decision, sherlo-api#259 adds a minimal machine-auth `getBuildStatus(index, projectIndex, teamId)` on the same project-token authorizer that already serves `openBuild`, scoped strictly to the token's own team/project.

### Tests
`packages/cli`: 223 tests pass, typecheck clean, `ncc` bundle builds. `waitForBuildResult.test.ts` covers every exit code (0/1/2/3), retry-then-succeed, fail-fast on 401/403/GraphQL-auth, state transitions, and pins the `getBuildStatus` query + Authorization header.

---

## Integration evidence (real `--wait` against the deployed TEST AppSync API)

Ran end-to-end against the deployed test environment (not mocks). Project token obtained via organic Cognito + IMAP signup (no injected credentials); build processed by a live test-env runner.

**Verbatim `--wait` output** (feature-branch CLI, `SHERLO_API_URL` = test AppSync endpoint, `--wait-timeout 3`):
```
🔗 https://app.sherlo.io/build?t=P80RqWRL&p=1&b=2

⏳ Waiting for build results (timeout: 3min)...
   🟡 Queued
   🔵 Running
   🔴 Error

❌ Build ended in "error" state.
   Error: "user_runner"
   https://app.sherlo.io/build?t=P80RqWRL&p=1&b=2
```
**Exit code: 2**

**Proves:** the deployed `getBuildStatus` wire is live and correctly mapped (the `appsync.yml` fix in api#259 works - poll got real status, not `getBuildStatus: null`); project-token auth works end-to-end (no 401/403); real status transitions `queued → running → error` from a live runner; `--wait` detected the terminal state and exited **2** per the contract. The error is expected - the run used deliberately-minimal fake binaries so the runner reported `user_runner`, exercising the build-error -> exit-2 path. `--wait-timeout` honored, 15s interval, dashboard URL correct.

**Bug this run caught (now fixed on this branch):** the CLI's `getBuildStatus` query still requested `startedAt`/`queuedAt`/`finishedAt` (carried over from `getBuild`), which the minimal `GetBuildStatusReturn` does not expose - a GraphQL `FieldUndefined` error the poll retried into a timeout. Dropped those three fields from the CLI query/type/progress-line to match the minimal api surface. This is exactly the class of gap the required real run exists to catch (and unit mocks could not).

Exit 0 (green) / exit 1 (changes) need a real passing/changed build; those code paths are covered by the unit tests. This run exercises the full deployed wire + auth + terminal-state detection + exit code.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
