### PR TITLE
feat: Add CLI vitest coverage for the ABI preflight matrix (reloca…

### DIFF
--- a/packages/cli/src/helpers/__tests__/validateBinariesInfo.test.ts
+++ b/packages/cli/src/helpers/__tests__/validateBinariesInfo.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import validateBinariesInfo from '../getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo';
+import { BinariesInfo, BinaryInfo } from '../../types';
+import { TEST_STANDARD_COMMAND } from '../../constants';
+
+/**
+ * Minimal valid android BinaryInfo that passes all non-ABI validations
+ * (hasSherlo, buildType = preview for standard test). Tests overlay only the
+ * ABI-related fields they care about.
+ */
+const validAndroidBinary: BinaryInfo = {
+  hash: 'abc123',
+  buildType: 'preview',
+  fileName: 'app-release.apk',
+  s3Key: 'builds/abc123/app-release.apk',
+  sdkVersion: '2.0.0',
+};
+
+const command = TEST_STANDARD_COMMAND;
+
+// ---------------------------------------------------------------------------
+// ABI preflight – rejection
+// ---------------------------------------------------------------------------
+
+describe('ABI preflight – rejection', () => {
+  it('rejects an APK missing arm64-v8a with the Expo fix hint (expo-build-properties)', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: ['x86_64'],
+        expoSdkVersion: '52.0.0',
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).toThrow();
+
+    try {
+      validateBinariesInfo({ binariesInfo: binaries, command });
+    } catch (error: any) {
+      const message = error.message;
+      expect(message).toContain('missing arm64-v8a');
+      expect(message).toContain('expo-build-properties');
+      expect(message).not.toContain('reactNativeArchitectures');
+    }
+  });
+
+  it('rejects an APK missing arm64-v8a with the bare-RN fix hint (reactNativeArchitectures)', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: ['x86_64'],
+        // No expoSdkVersion → bare RN path
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).toThrow();
+
+    try {
+      validateBinariesInfo({ binariesInfo: binaries, command });
+    } catch (error: any) {
+      const message = error.message;
+      expect(message).toContain('missing arm64-v8a');
+      expect(message).toContain('reactNativeArchitectures');
+      expect(message).not.toContain('expo-build-properties');
+    }
+  });
+
+  it('includes the detected ABI list and file name in the error message', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: ['x86_64', 'armeabi-v7a'],
+        fileName: 'my-custom-build.apk',
+        expoSdkVersion: '52.0.0',
+      },
+    };
+
+    try {
+      validateBinariesInfo({ binariesInfo: binaries, command });
+      expect.unreachable('Expected validateBinariesInfo to throw');
+    } catch (error: any) {
+      expect(error.message).toContain('x86_64, armeabi-v7a');
+      expect(error.message).toContain('my-custom-build.apk');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ABI preflight – accept
+// ---------------------------------------------------------------------------
+
+describe('ABI preflight – accept', () => {
+  it('accepts an APK whose androidAbis includes arm64-v8a', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: ['arm64-v8a', 'x86_64'],
+      },
+    };
+
+    // Must not throw for ABI reasons. Other validations (hasSherlo, buildType)
+    // are satisfied by validAndroidBinary, so the call should succeed.
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).not.toThrow();
+  });
+
+  it('accepts an APK with only arm64-v8a in its ABI list', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: ['arm64-v8a'],
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).not.toThrow();
+  });
+
+  it('skips ABI validation when androidAbis is undefined (non-APK or no android binary)', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: undefined,
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).not.toThrow();
+  });
+
+  it('accepts an APK with an empty ABI list (no native libraries – installs on any ABI)', () => {
+    const binaries: BinariesInfo = {
+      android: {
+        ...validAndroidBinary,
+        androidAbis: [],
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).not.toThrow();
+  });
+
+  it('skips ABI validation when there is no android binary at all', () => {
+    const binaries: BinariesInfo = {
+      ios: {
+        hash: 'def456',
+        buildType: 'preview',
+        fileName: 'app.ipa',
+        s3Key: 'builds/def456/app.ipa',
+        sdkVersion: '2.0.0',
+      },
+    };
+
+    expect(() => validateBinariesInfo({ binariesInfo: binaries, command })).not.toThrow();
+  });
+});


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1698

## What

Adds CLI vitest coverage for the Android ABI preflight matrix, relocating logic coverage that currently lives only in the sherlo-tester e2e suite down to the CLI test layer where the failure locus actually is (cli-only runtime).

Purely additive: one new test file, no production code changes, sherlo-tester untouched.

- `packages/cli/src/helpers/__tests__/validateBinariesInfo.test.ts` (new)

The tests exercise `validateBinariesInfo` directly with constructed `BinariesInfo` inputs and assert the same user-facing outcome the e2e asserts (the thrown error message / no-throw acceptance). They are deterministic: no network, no real builds, no device binaries.

## e2e -> vitest mapping (for the follow-up e2e removal ticket)

Source spec: `sherlo-tester e2e/suites/cli/errors/04-abi-preflight.spec.ts` (3 variants).
Replacement file: `packages/cli/src/helpers/__tests__/validateBinariesInfo.test.ts`.

| e2e test (04-abi-preflight.spec.ts) | Replacing vitest test | Asserted outcome |
|---|---|---|
| `rejects x86_64-only Expo APK with Expo fix hint` | `ABI preflight - rejection > rejects an APK missing arm64-v8a with the Expo fix hint (expo-build-properties)` | throws; message contains `missing arm64-v8a` + `expo-build-properties`, not `reactNativeArchitectures` |
| `rejects x86_64-only bare-RN APK with bare-RN fix hint` | `ABI preflight - rejection > rejects an APK missing arm64-v8a with the bare-RN fix hint (reactNativeArchitectures)` | throws; message contains `missing arm64-v8a` + `reactNativeArchitectures`, not `expo-build-properties` |
| `arm64-v8a APK passes ABI preflight` | `ABI preflight - accept > accepts an APK whose androidAbis includes arm64-v8a` (plus `accepts an APK with only arm64-v8a in its ABI list`) | does not throw; no `missing arm64-v8a` |

All three e2e variants are covered. Once this merges, the e2e matrix in `04-abi-preflight.spec.ts` can be reduced to a single representative preflight scene for the story.

### Additional coverage (beyond the e2e matrix)

Derived from the CLI validation logic, not present in the e2e spec:

- `includes the detected ABI list and file name in the error message`
- `accepts an APK with an empty ABI list (no native libraries - installs on any ABI)`
- `skips ABI validation when androidAbis is undefined (non-APK or no android binary)`
- `skips ABI validation when there is no android binary at all`

## Testing

`yarn test` in `packages/cli`: 15 files, 231 tests passing (8 new).

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
