### PR TITLE
feat: test:bundled wiring: send staged config, parse gate refusal,…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/stagedFastPath.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/stagedFastPath.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Staged fast-path guarantee (SHERLO-1707 / SHERLO-1688).
+ *
+ * A staged run resolves "fast" only when its base fingerprint matches the
+ * registered base. The whole point of `baseFingerprint` is that a pure
+ * version / build-number bump (CFBundleVersion, MARKETING_VERSION, versionName,
+ * versionCode) must NOT change it - otherwise a routine version bump would kick
+ * every JS-only change onto the slow full-build path.
+ *
+ * These tests pin that invariance at two levels:
+ *   1. The version-stripping transform itself (stripVersionLines).
+ *   2. computeBaseFingerprint end-to-end, with the @expo/fingerprint layer
+ *      wired to hash the TRANSFORMED file content so the transform actually
+ *      participates in the result.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-staged-fp-'));
+}
+
+function writeFile(dir: string, relativePath: string, content: string): void {
+  const fullPath = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+const GRADLE_V1 =
+  'android {\n    defaultConfig {\n        applicationId "com.example"\n        versionCode 1\n        versionName "1.0.0"\n    }\n}';
+const GRADLE_V2 =
+  'android {\n    defaultConfig {\n        applicationId "com.example"\n        versionCode 42\n        versionName "9.9.9"\n    }\n}';
+
+// ---------------------------------------------------------------------------
+// @expo/fingerprint mock - runs the provided fileHookTransform over the bare
+// project's build.gradle and hashes the TRANSFORMED bytes. This makes the mock
+// result depend on version stripping: if stripping were removed, a versionCode
+// bump would change the hash and this test would fail.
+// ---------------------------------------------------------------------------
+
+const mockCreateFingerprintAsync = vi.fn();
+
+vi.mock('@expo/fingerprint', () => ({
+  createFingerprintAsync: (...args: any[]) => mockCreateFingerprintAsync(...args),
+  SourceSkips: {
+    None: 0,
+    ExpoConfigVersions: 1,
+    ExpoConfigRuntimeVersionIfString: 2,
+  },
+}));
+
+// Keep autolinked-module resolution from spawning real processes.
+vi.mock('../../../helpers/runShellCommand', () => ({
+  default: vi.fn().mockRejectedValue(new Error('not available in test')),
+}));
+
+/**
+ * Drive a fileHookTransform the way baseFingerprint does: feed the whole file as
+ * one chunk, then an end-of-file marker, and concatenate the returned content.
+ */
+function runTransform(transform: any, filePath: string, content: string): string {
+  const source = { type: 'file', filePath } as const;
+  let out = '';
+  const mid = transform(source, content, false, 'utf8');
+  if (mid) out += typeof mid === 'string' ? mid : mid.toString('utf8');
+  const end = transform(source, null, true, 'utf8');
+  if (end) out += typeof end === 'string' ? end : end.toString('utf8');
+  return out;
+}
+
+describe('staged fast path - version/build-number bump keeps the base identical', () => {
+  let computeBaseFingerprint: typeof import('../../../helpers/fingerprint').computeBaseFingerprint;
+  let stripVersionLines: typeof import('../../../helpers/fingerprint/baseFingerprint').stripVersionLines;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Hash the version-stripped build.gradle so the mock reflects stripping.
+    mockCreateFingerprintAsync.mockImplementation(async (projectRoot: string, options: any) => {
+      const gradlePath = path.join(projectRoot, 'android/app/build.gradle');
+      let content = '';
+      try {
+        content = fs.readFileSync(gradlePath, 'utf8');
+      } catch {
+        /* no gradle - hash empty */
+      }
+      const transformed = options?.fileHookTransform
+        ? runTransform(options.fileHookTransform, gradlePath, content)
+        : content;
+      return { hash: crypto.createHash('sha256').update(transformed).digest('hex') };
+    });
+
+    const fpMod = await import('../../../helpers/fingerprint');
+    computeBaseFingerprint = fpMod.computeBaseFingerprint;
+    const baseMod = await import('../../../helpers/fingerprint/baseFingerprint');
+    stripVersionLines = baseMod.stripVersionLines;
+  });
+
+  // Level 1: the transform is version-invariant for gradle + plist.
+  it('stripVersionLines produces identical output across a gradle version bump', () => {
+    expect(stripVersionLines('android/app/build.gradle', GRADLE_V1)).toBe(
+      stripVersionLines('android/app/build.gradle', GRADLE_V2)
+    );
+  });
+
+  it('stripVersionLines produces identical output across a plist CFBundleVersion bump', () => {
+    const plistV1 =
+      '<dict>\n\t<key>CFBundleVersion</key>\n\t<string>1</string>\n\t<key>Keep</key>\n\t<string>x</string>\n</dict>';
+    const plistV99 =
+      '<dict>\n\t<key>CFBundleVersion</key>\n\t<string>99</string>\n\t<key>Keep</key>\n\t<string>x</string>\n</dict>';
+    expect(stripVersionLines('ios/App/Info.plist', plistV1)).toBe(
+      stripVersionLines('ios/App/Info.plist', plistV99)
+    );
+  });
+
+  // Level 2: computeBaseFingerprint end-to-end is invariant to the bump, so the
+  // staged gate resolves fast (base matches) instead of forcing a full build.
+  it('computeBaseFingerprint is unchanged by a versionCode/versionName-only bump', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'package.json', JSON.stringify({ name: 'app', version: '1.0.0' }));
+      writeFile(dir, 'yarn.lock', '# yarn lockfile\n');
+      writeFile(dir, 'android/app/build.gradle', GRADLE_V1);
+
+      const before = await computeBaseFingerprint(dir);
+
+      // Pure build-number / version bump - nothing else changes.
+      writeFile(dir, 'android/app/build.gradle', GRADLE_V2);
+
+      const after = await computeBaseFingerprint(dir);
+
+      expect(before.hash).toBeTruthy();
+      expect(after.hash).toBe(before.hash);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('computeBaseFingerprint DOES change for a non-version native edit (sanity)', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'package.json', JSON.stringify({ name: 'app', version: '1.0.0' }));
+      writeFile(dir, 'yarn.lock', '# yarn lockfile\n');
+      writeFile(dir, 'android/app/build.gradle', GRADLE_V1);
+
+      const before = await computeBaseFingerprint(dir);
+
+      // A real native change (new applicationId) is NOT a version bump - the
+      // base must change so the gate correctly refuses the fast path.
+      writeFile(
+        dir,
+        'android/app/build.gradle',
+        GRADLE_V1.replace('com.example', 'com.example.renamed')
+      );
+
+      const after = await computeBaseFingerprint(dir);
+
+      expect(after.hash).not.toBe(before.hash);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/packages/cli/src/commands/testBundled/__tests__/stagedGateRefusal.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/stagedGateRefusal.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the STAGED_GATE_REFUSAL wire-format parser + formatter (SHERLO-1707).
+ *
+ * The parser is PINNED to the exact format emitted by the openBuild resolver:
+ *   STAGED_GATE_REFUSAL|<outcome>|<platform>|<comma-separated-diff>
+ * Keep these expectations in lock-step with @sherlo/api-types StagedGateRefusal.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  FALLBACK_LINE,
+  formatStagedGateRefusal,
+  parseStagedGateRefusal,
+  STAGED_GATE_REFUSAL_PREFIX,
+} from '../stagedGateRefusal';
+
+describe('parseStagedGateRefusal - exact wire format', () => {
+  it('parses the canonical full-build-needed refusal with a multi-source diff', () => {
+    // The exact example documented on the resolver.
+    const error = {
+      message: 'STAGED_GATE_REFUSAL|full-build-needed|android|engineClass,assetInventory',
+    };
+
+    const refusal = parseStagedGateRefusal(error);
+
+    expect(refusal).toEqual({
+      outcome: 'full-build-needed',
+      platform: 'android',
+      diff: ['engineClass', 'assetInventory'],
+    });
+  });
+
+  it('parses a single-source diff', () => {
+    const refusal = parseStagedGateRefusal({
+      message: 'STAGED_GATE_REFUSAL|full-build-needed|ios|sdkProtocolVersion',
+    });
+
+    expect(refusal).toEqual({
+      outcome: 'full-build-needed',
+      platform: 'ios',
+      diff: ['sdkProtocolVersion'],
+    });
+  });
+
+  it('parses a not-stageable refusal with an empty diff (trailing pipe)', () => {
+    const refusal = parseStagedGateRefusal({
+      message: 'STAGED_GATE_REFUSAL|not-stageable|android|',
+    });
+
+    expect(refusal).toEqual({
+      outcome: 'not-stageable',
+      platform: 'android',
+      diff: [],
+    });
+  });
+
+  it('parses a not-stageable refusal with the diff field entirely absent', () => {
+    const refusal = parseStagedGateRefusal({
+      message: 'STAGED_GATE_REFUSAL|not-stageable|ios',
+    });
+
+    expect(refusal).toEqual({
+      outcome: 'not-stageable',
+      platform: 'ios',
+      diff: [],
+    });
+  });
+
+  it('accepts a raw string message (not just an Error-like object)', () => {
+    const refusal = parseStagedGateRefusal(
+      'STAGED_GATE_REFUSAL|full-build-needed|android|buildMetadata'
+    );
+
+    expect(refusal?.diff).toEqual(['buildMetadata']);
+  });
+
+  it('exposes the prefix constant used to detect a refusal', () => {
+    expect(STAGED_GATE_REFUSAL_PREFIX).toBe('STAGED_GATE_REFUSAL');
+  });
+
+  it('returns null for a non-refusal error message', () => {
+    expect(parseStagedGateRefusal({ message: 'snapshotsLimitIsExceeded' })).toBeNull();
+    expect(parseStagedGateRefusal({ message: 'Something|else|with|pipes' })).toBeNull();
+    expect(parseStagedGateRefusal(new Error('network error'))).toBeNull();
+  });
+
+  it('returns null for non-error-shaped inputs', () => {
+    expect(parseStagedGateRefusal(undefined)).toBeNull();
+    expect(parseStagedGateRefusal(null)).toBeNull();
+    expect(parseStagedGateRefusal({})).toBeNull();
+    expect(parseStagedGateRefusal(42)).toBeNull();
+  });
+});
+
+describe('formatStagedGateRefusal - user-facing message', () => {
+  it('names each diff source and appends the test:standard fallback line', () => {
+    const message = formatStagedGateRefusal({
+      outcome: 'full-build-needed',
+      platform: 'android',
+      diff: ['engineClass', 'assetInventory'],
+    });
+
+    // Named-diff refusal.
+    expect(message).toContain('Android');
+    expect(message).toContain('JS engine (Hermes/JSC)');
+    expect(message).toContain('bundled assets');
+    // test:standard fallback line.
+    expect(message).toContain(FALLBACK_LINE);
+    expect(message).toContain('test:standard');
+  });
+
+  it('omits the changed-sources line for a not-stageable refusal (empty diff)', () => {
+    const message = formatStagedGateRefusal({
+      outcome: 'not-stageable',
+      platform: 'ios',
+      diff: [],
+    });
+
+    expect(message).toContain('iOS');
+    expect(message).not.toContain('Changed since the base build');
+    expect(message).toContain('test:standard');
+  });
+
+  it('round-trips a parsed refusal into a formatted message', () => {
+    const refusal = parseStagedGateRefusal({
+      message: 'STAGED_GATE_REFUSAL|full-build-needed|android|engineClass,assetInventory',
+    });
+    expect(refusal).not.toBeNull();
+
+    const message = formatStagedGateRefusal(refusal!);
+    expect(message).toContain('JS engine (Hermes/JSC)');
+    expect(message).toContain('bundled assets');
+    expect(message).toContain('test:standard');
+  });
+});

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -1,29 +1,62 @@
 /**
- * Tests for the testBundled command - exit-code contract and refusal paths.
+ * Tests for the testBundled command - staged wiring + exit-code contract.
  *
- * Covers the reshape requirements:
- *  - Readiness gate (SHERLO_DEVTOOLS unset) prints the SHERLO-1707 message
- *    and exits non-zero.
+ * Covers:
  *  - "No devices configured" path exits non-zero.
- *  - Fingerprint-unavailable path prints the test:standard fallback line
- *    and exits non-zero.
+ *  - Fingerprint-unavailable path prints the test:standard fallback line and
+ *    exits non-zero.
+ *  - gitInfo parity: test:bundled captures git info with the SAME getGitInfo
+ *    call as test:standard and forwards that exact object to openBuild.
+ *
+ * The SHERLO_DEVTOOLS readiness gate has been removed - staged consume-mode is
+ * live (SHERLO-1707), so there is no gate to test.
  *
  * Does NOT re-test buildBundle refusal paths (HBC / RAM / version-floor) -
- * those are covered by buildBundle.test.ts.
+ * those are covered by buildBundle.test.ts. The STAGED_GATE_REFUSAL wire format
+ * is covered by stagedGateRefusal.test.ts.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ASYNC_UPLOAD_S3_KEY_PLACEHOLDER } from '@sherlo/shared';
+
+// ---------------------------------------------------------------------------
+// Hoisted SDK-client mock handles (shared across the factory + assertions).
+// ---------------------------------------------------------------------------
+
+const { mockGetStagedUploadUrls, mockOpenBuild } = vi.hoisted(() => ({
+  mockGetStagedUploadUrls: vi.fn(),
+  mockOpenBuild: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Module mocks (hoisted by vitest above all imports)
 // ---------------------------------------------------------------------------
 
+vi.mock('@sherlo/sdk-client', () => ({
+  default: vi.fn(() => ({
+    getStagedUploadUrls: mockGetStagedUploadUrls,
+    openBuild: mockOpenBuild,
+  })),
+}));
+
 vi.mock('../../../helpers', () => ({
+  getAppBuildUrl: vi.fn(),
+  getBuildRunConfig: vi.fn(),
+  getGitInfo: vi.fn(),
   getPlatformsToTest: vi.fn(),
+  getTokenParts: vi.fn(),
   getValidatedCommandParams: vi.fn(),
+  handleClientError: vi.fn((error) => {
+    throw error;
+  }),
+  logWarning: vi.fn(),
+  printResultsUrl: vi.fn(),
   printSherloIntro: vi.fn(),
   reporting: {
     flush: vi.fn().mockResolvedValue(undefined),
+    addBreadcrumb: vi.fn(),
+    setTag: vi.fn(),
   },
+  waitForBuildResult: vi.fn(),
 }));
 
 vi.mock('../../../helpers/fingerprint', () => ({
@@ -32,25 +65,46 @@ vi.mock('../../../helpers/fingerprint', () => ({
 
 vi.mock('../buildBundle', () => ({
   buildBundleForPlatform: vi.fn(),
+  buildGateMetadata: vi.fn(),
+}));
+
+vi.mock('../uploadStagedArtifacts', () => ({
+  default: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
-// Mocked dependency accessors (vi.mocked gives proper Mock types)
+// Mocked dependency accessors
 // ---------------------------------------------------------------------------
 
 import {
+  getAppBuildUrl as _getAppBuildUrl,
+  getBuildRunConfig as _getBuildRunConfig,
+  getGitInfo as _getGitInfo,
   getPlatformsToTest as _getPlatformsToTest,
+  getTokenParts as _getTokenParts,
   getValidatedCommandParams as _getValidatedCommandParams,
+  printResultsUrl as _printResultsUrl,
   printSherloIntro as _printSherloIntro,
 } from '../../../helpers';
 import { computeBaseFingerprint as _computeBaseFingerprint } from '../../../helpers/fingerprint';
-import { buildBundleForPlatform as _buildBundleForPlatform } from '../buildBundle';
+import {
+  buildBundleForPlatform as _buildBundleForPlatform,
+  buildGateMetadata as _buildGateMetadata,
+} from '../buildBundle';
+import _uploadStagedArtifacts from '../uploadStagedArtifacts';
 
+const mockGetAppBuildUrl = vi.mocked(_getAppBuildUrl);
+const mockGetBuildRunConfig = vi.mocked(_getBuildRunConfig);
+const mockGetGitInfo = vi.mocked(_getGitInfo);
 const mockGetPlatformsToTest = vi.mocked(_getPlatformsToTest);
+const mockGetTokenParts = vi.mocked(_getTokenParts);
 const mockGetValidatedCommandParams = vi.mocked(_getValidatedCommandParams);
+const mockPrintResultsUrl = vi.mocked(_printResultsUrl);
 const mockPrintSherloIntro = vi.mocked(_printSherloIntro);
 const mockComputeBaseFingerprint = vi.mocked(_computeBaseFingerprint);
 const mockBuildBundleForPlatform = vi.mocked(_buildBundleForPlatform);
+const mockBuildGateMetadata = vi.mocked(_buildGateMetadata);
+const mockUploadStagedArtifacts = vi.mocked(_uploadStagedArtifacts);
 
 // ---------------------------------------------------------------------------
 // Subject under test
@@ -60,82 +114,35 @@ let testBundled: (passedOptions: any) => Promise<{ url: string }>;
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mockPrintSherloIntro.mockImplementation(() => {});
   const mod = await import('../testBundled');
   testBundled = mod.default;
 });
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function mockOptions(): any {
   return {};
 }
 
-// ---------------------------------------------------------------------------
-// Readiness gate - SHERLO_DEVTOOLS unset
-// ---------------------------------------------------------------------------
+const IOS_DEVICE = {
+  id: 'test-iphone',
+  osVersion: '17.0',
+  theme: 'light',
+  locale: 'en',
+  fontScale: '1.0',
+};
 
-describe('readiness gate', () => {
-  let exitSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
-      throw new Error(`process.exit(${code})`);
-    });
-
-    delete process.env.SHERLO_DEVTOOLS;
-
-    // Type casts are intentional - mock return values are stand-ins that
-    // only need to satisfy the code paths under test.
-    mockGetValidatedCommandParams.mockReturnValue({
-      projectRoot: '/tmp/test-project',
-      devices: [
-        { id: 'test-iphone', osVersion: '17.0', theme: 'light', locale: 'en', fontScale: '1.0' },
-      ],
-    } as any);
-    mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
-    mockPrintSherloIntro.mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    exitSpy.mockRestore();
-  });
-
-  it('prints the SHERLO-1707 message and exits non-zero when SHERLO_DEVTOOLS is unset', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    await expect(testBundled(mockOptions())).rejects.toThrow('process.exit(1)');
-
-    const allCalls = logSpy.mock.calls.map((c) => c.join(' '));
-    expect(allCalls.some((call) => call.includes('SHERLO-1707'))).toBe(true);
-    expect(allCalls.some((call) => call.includes('test:standard'))).toBe(true);
-    expect(exitSpy).toHaveBeenCalledWith(1);
-
-    logSpy.mockRestore();
-  });
-
-  it('does NOT hit the readiness gate when SHERLO_DEVTOOLS=1', async () => {
-    process.env.SHERLO_DEVTOOLS = '1';
-
-    mockComputeBaseFingerprint.mockResolvedValue({
-      hash: 'abc123def456',
-      debugMessage: undefined,
-    } as any);
-    mockBuildBundleForPlatform.mockResolvedValue({
-      bundlePath: '/tmp/bundle.js',
-      bundleSizeMb: 2.0,
-      bundleFormat: 'plain-js',
-      bundleHash: 'abc123',
-      bundler: 'metro',
-      assetInventory: [],
-      assetsDest: undefined,
-    } as any);
-    const result = await testBundled(mockOptions());
-    expect(result).toEqual({ url: '' });
-    expect(exitSpy).not.toHaveBeenCalled();
-  });
-});
+function bundleResult(overrides: Record<string, unknown> = {}): any {
+  return {
+    bundlePath: '/tmp/bundle.ios.js',
+    bundleFormat: 'plain-js',
+    bundleSizeMb: 1.5,
+    bundleHash: 'abc123',
+    assetsDest: undefined,
+    assetInventory: [],
+    bundler: 'expo',
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // No devices configured - exit non-zero
@@ -154,22 +161,17 @@ describe('no devices configured', () => {
       devices: [],
     } as any);
     mockGetPlatformsToTest.mockReturnValue([] as any);
-    mockPrintSherloIntro.mockImplementation(() => {});
   });
 
   afterEach(() => {
     exitSpy.mockRestore();
   });
 
-  it('exits non-zero when no devices are configured', async () => {
-    await expect(testBundled(mockOptions())).rejects.toThrow('process.exit(1)');
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it('prints the no-devices guidance message', async () => {
+  it('exits non-zero and prints guidance when no devices are configured', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(testBundled(mockOptions())).rejects.toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
 
     const allCalls = logSpy.mock.calls.map((c) => c.join(' '));
     expect(allCalls.some((call) => call.includes('No devices configured'))).toBe(true);
@@ -190,34 +192,18 @@ describe('fingerprint unavailable', () => {
       throw new Error(`process.exit(${code})`);
     });
 
-    process.env.SHERLO_DEVTOOLS = '1';
-
     mockGetValidatedCommandParams.mockReturnValue({
       projectRoot: '/tmp/test-project',
-      devices: [
-        { id: 'test-iphone', osVersion: '17.0', theme: 'light', locale: 'en', fontScale: '1.0' },
-      ],
+      devices: [IOS_DEVICE],
     } as any);
     mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
-    mockPrintSherloIntro.mockImplementation(() => {});
   });
 
   afterEach(() => {
     exitSpy.mockRestore();
-    delete process.env.SHERLO_DEVTOOLS;
   });
 
-  it('exits non-zero when fingerprint computation returns no hash', async () => {
-    mockComputeBaseFingerprint.mockResolvedValue({
-      hash: '',
-      debugMessage: 'No base binary found',
-    } as any);
-
-    await expect(testBundled(mockOptions())).rejects.toThrow('process.exit(1)');
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it('prints the test:standard fallback line when fingerprint is unavailable', async () => {
+  it('prints the test:standard fallback line and exits non-zero', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     mockComputeBaseFingerprint.mockResolvedValue({
@@ -226,6 +212,7 @@ describe('fingerprint unavailable', () => {
     } as any);
 
     await expect(testBundled(mockOptions())).rejects.toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
 
     const allCalls = logSpy.mock.calls.map((c) => c.join(' '));
     expect(allCalls.some((call) => call.includes('test:standard'))).toBe(true);
@@ -233,23 +220,97 @@ describe('fingerprint unavailable', () => {
 
     logSpy.mockRestore();
   });
+});
 
-  it('does not exit when fingerprint is available', async () => {
-    mockComputeBaseFingerprint.mockResolvedValue({
-      hash: 'abc123def456',
-      debugMessage: undefined,
+// ---------------------------------------------------------------------------
+// gitInfo parity - identical to test:standard
+// ---------------------------------------------------------------------------
+
+describe('gitInfo parity with test:standard', () => {
+  // A sentinel object we can assert identity on: whatever getGitInfo returns
+  // must be forwarded verbatim to openBuild.
+  const GIT_INFO = {
+    commitName: 'feat: x',
+    commitHash: 'deadbeef',
+    branchName: 'my-branch',
+    isDirty: false,
+  };
+
+  beforeEach(() => {
+    mockGetValidatedCommandParams.mockReturnValue({
+      projectRoot: '/proj',
+      token: 'token-value',
+      devices: [IOS_DEVICE],
+      gitBranch: 'flag-branch',
+      message: 'a message',
+      wait: false,
     } as any);
-    mockBuildBundleForPlatform.mockResolvedValue({
-      bundlePath: '/tmp/bundle.js',
-      bundleSizeMb: 2.0,
-      bundleFormat: 'plain-js',
-      bundleHash: 'abc123',
-      bundler: 'metro',
-      assetInventory: [],
-      assetsDest: undefined,
+    mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
+    mockComputeBaseFingerprint.mockResolvedValue({ hash: 'BASE_FP' } as any);
+    mockBuildBundleForPlatform.mockResolvedValue(bundleResult());
+    mockBuildGateMetadata.mockResolvedValue({ engineClass: 'hermes' } as any);
+    mockGetTokenParts.mockReturnValue({
+      apiToken: 'api',
+      projectIndex: 3,
+      teamId: 'team',
+    });
+    mockGetStagedUploadUrls.mockResolvedValue({
+      stagedPresignedUploadUrls: {
+        ios: {
+          jsBundle: { s3Key: 'js-s3-key', url: 'http://s3/js' },
+          assets: { s3Key: 'assets-s3-key', url: 'http://s3/assets' },
+        },
+      },
+    });
+    mockUploadStagedArtifacts.mockResolvedValue({ jsBundleS3Key: 'js-s3-key' });
+    mockGetBuildRunConfig.mockReturnValue({
+      ios: { devices: [], s3Key: 'unset' },
     } as any);
+    mockGetGitInfo.mockResolvedValue(GIT_INFO as any);
+    mockOpenBuild.mockResolvedValue({ build: { index: 7 } });
+    mockGetAppBuildUrl.mockReturnValue('http://app/build?x=1');
+    mockPrintResultsUrl.mockImplementation(() => {});
+  });
+
+  it('calls getGitInfo with projectRoot + branchOverride (same signature as test:standard)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await testBundled(mockOptions());
+
+    expect(mockGetGitInfo).toHaveBeenCalledTimes(1);
+    expect(mockGetGitInfo).toHaveBeenCalledWith('/proj', { branchOverride: 'flag-branch' });
+
+    logSpy.mockRestore();
+  });
+
+  it('forwards the exact getGitInfo result to openBuild (verbatim - no reshaping)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
     const result = await testBundled(mockOptions());
-    expect(result).toEqual({ url: '' });
-    expect(exitSpy).not.toHaveBeenCalled();
+
+    expect(mockOpenBuild).toHaveBeenCalledTimes(1);
+    const openBuildArg = mockOpenBuild.mock.calls[0][0];
+    // Identity check: parity means the SAME object test:standard would send.
+    expect(openBuildArg.gitInfo).toBe(GIT_INFO);
+    expect(openBuildArg.baseFingerprint).toBe('BASE_FP');
+    expect(openBuildArg.gateMetadata.ios).toEqual({ engineClass: 'hermes' });
+    expect(result).toEqual({ url: 'http://app/build?x=1' });
+
+    logSpy.mockRestore();
+  });
+
+  it('mirrors the staged S3 keys + placeholder onto the per-platform build config', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await testBundled(mockOptions());
+
+    const openBuildArg = mockOpenBuild.mock.calls[0][0];
+    expect(openBuildArg.buildRunConfig.ios.s3Key).toBe(ASYNC_UPLOAD_S3_KEY_PLACEHOLDER);
+    expect(openBuildArg.buildRunConfig.ios.jsBundleS3Key).toBe('js-s3-key');
+    expect(openBuildArg.buildRunConfig.ios.bundleSizeMb).toBe(1.5);
+    // No assets produced (assetsDest undefined) -> no assetsS3Key.
+    expect(openBuildArg.buildRunConfig.ios.assetsS3Key).toBeUndefined();
+
+    logSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
+++ b/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
@@ -1,0 +1,113 @@
+/**
+ * Staged gate-refusal parsing for the test:bundled command (SHERLO-1707).
+ *
+ * When a staged openBuild's server-side gate resolves to anything other than
+ * "fast" it throws a graphQL error whose MESSAGE carries a machine-parseable
+ * payload:
+ *
+ *   STAGED_GATE_REFUSAL|<outcome>|<platform>|<comma-separated-diff>
+ *   e.g. STAGED_GATE_REFUSAL|full-build-needed|android|engineClass,assetInventory
+ *
+ * The wire format is defined by the openBuild resolver (@sherlo/api-types,
+ * `StagedGateRefusal`). This module extracts it back into a typed struct and
+ * renders the user-facing refusal (named diff sources + the test:standard
+ * fallback line). Keep the prefix + field order in lock-step with the resolver.
+ */
+import { GateDiffSource, GateOutcome } from '@sherlo/api-types';
+import { TEST_STANDARD_COMMAND } from '../../constants';
+
+/** Machine-parseable prefix emitted by the openBuild resolver on refusal. */
+export const STAGED_GATE_REFUSAL_PREFIX = 'STAGED_GATE_REFUSAL';
+
+/**
+ * The test:standard fallback line appended to every refusal. Kept identical to
+ * buildBundle's FALLBACK_LINE wording so the "run a full build" guidance is
+ * consistent across every test:bundled exit path.
+ */
+export const FALLBACK_LINE = `Run \`sherlo ${TEST_STANDARD_COMMAND}\` for a full build with the same options.`;
+
+export type StagedGateRefusal = {
+  /** Machine-readable gate outcome (never "fast" - that path doesn't refuse). */
+  outcome: GateOutcome;
+  /** The platform whose gate refused. */
+  platform: 'android' | 'ios';
+  /** Named diff sources (empty for not-stageable). */
+  diff: GateDiffSource[];
+};
+
+/**
+ * Parse a caught error into a {@link StagedGateRefusal}, or return null when the
+ * error is NOT a staged gate refusal (network error, auth error, …).
+ *
+ * Pinned to the exact wire format
+ * `STAGED_GATE_REFUSAL|<outcome>|<platform>|<comma-separated-diff>`. The diff is
+ * the final field, so a diff value can never contain a `|`; commas separate the
+ * individual diff sources.
+ */
+export function parseStagedGateRefusal(error: unknown): StagedGateRefusal | null {
+  const message = extractMessage(error);
+  if (!message) return null;
+
+  const parts = message.split('|');
+  if (parts[0] !== STAGED_GATE_REFUSAL_PREFIX) return null;
+  // Require at least prefix|outcome|platform. The diff field is optional
+  // (empty for not-stageable).
+  if (parts.length < 3) return null;
+
+  const outcome = parts[1] as GateOutcome;
+  const platform = parts[2] as 'android' | 'ios';
+  const diff = (parts[3] ?? '')
+    .split(',')
+    .map((source) => source.trim())
+    .filter(Boolean) as GateDiffSource[];
+
+  return { outcome, platform, diff };
+}
+
+/** Best-effort extraction of a string message from any caught value. */
+function extractMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : undefined;
+  }
+  return undefined;
+}
+
+/** Human-readable labels for the machine-readable diff sources. */
+const DIFF_LABELS: Record<GateDiffSource, string> = {
+  engineClass: 'JS engine (Hermes/JSC)',
+  assetInventory: 'bundled assets',
+  expoUpdatesEnabled: 'expo-updates configuration',
+  sdkProtocolVersion: 'Sherlo SDK protocol version',
+  buildMetadata: 'native build metadata',
+};
+
+/** Human-readable reason per non-fast outcome. */
+const OUTCOME_REASON: Record<Exclude<GateOutcome, 'fast'>, string> = {
+  'full-build-needed': 'the native binary needs to be rebuilt',
+  'not-stageable': "this project can't use the staged fast path",
+};
+
+/**
+ * Render a refusal into the user-facing message: a one-line reason, the named
+ * diff sources that changed (when present), and the test:standard fallback line.
+ */
+export function formatStagedGateRefusal(refusal: StagedGateRefusal): string {
+  const platformLabel = refusal.platform === 'android' ? 'Android' : 'iOS';
+  const reason =
+    refusal.outcome === 'fast'
+      ? 'the staged gate refused'
+      : OUTCOME_REASON[refusal.outcome] ?? 'the staged gate refused';
+
+  const lines = [`✗ Staged upload not possible for ${platformLabel}: ${reason}.`];
+
+  if (refusal.diff.length > 0) {
+    const named = refusal.diff.map((source) => DIFF_LABELS[source] ?? source).join(', ');
+    lines.push(`Changed since the base build: ${named}.`);
+  }
+
+  lines.push(FALLBACK_LINE);
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -2,26 +2,47 @@
  * test:bundled command - the bundle-only fast path for staged builds.
  *
  * Builds a production plain-JS bundle + assets via the project's canonical
- * bundler, computes the base fingerprint, and constructs per-platform staged
- * run configs.  Server-side consume-mode is not yet available (SHERLO-1707),
- * so this command is gated behind SHERLO_DEVTOOLS=1 for internal testing.
+ * bundler, computes the base fingerprint and per-platform gate metadata,
+ * uploads the bundle (and assets) to staged S3 slots, then opens a staged
+ * build. The server-side gate decides whether the staged run can proceed on
+ * the fast path; when it can't it refuses with a machine-parseable
+ * STAGED_GATE_REFUSAL payload that we translate into a named-diff message plus
+ * the test:standard fallback line.
  *
- * When SHERLO-1707 lands, the readiness gate is removed and the staged run
- * configs are wired into the openBuild call.
+ * Upload-slot decision: staged runs use getStagedUploadUrls (NOT
+ * getBuildUploadUrls) - a bundled run has no native binary, so the per-platform
+ * config carries the ASYNC_UPLOAD_S3_KEY_PLACEHOLDER for `s3Key` (mirrored
+ * server-side) alongside the real jsBundleS3Key / assetsS3Key.
  */
+import sdkClient from '@sherlo/sdk-client';
+import { GateMetadataByPlatform, Platform } from '@sherlo/api-types';
+import { ASYNC_UPLOAD_S3_KEY_PLACEHOLDER } from '@sherlo/shared';
 import chalk from 'chalk';
 import path from 'path';
-import { TEST_STANDARD_COMMAND } from '../../constants';
 import { Options } from '../../types';
 import {
+  getAppBuildUrl,
+  getBuildRunConfig,
+  getGitInfo,
   getPlatformsToTest,
+  getTokenParts,
   getValidatedCommandParams,
+  handleClientError,
+  logWarning,
+  printResultsUrl,
   printSherloIntro,
   reporting,
+  waitForBuildResult,
 } from '../../helpers';
-import { computeBaseFingerprint } from '../../helpers/fingerprint';
+import { computeBaseFingerprint, type GateMetadataInput } from '../../helpers/fingerprint';
 import { THIS_COMMAND } from './constants';
-import { buildBundleForPlatform } from './buildBundle';
+import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from './buildBundle';
+import {
+  formatStagedGateRefusal,
+  parseStagedGateRefusal,
+  FALLBACK_LINE,
+} from './stagedGateRefusal';
+import uploadStagedArtifacts, { type StagedUploadKeys } from './uploadStagedArtifacts';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -47,22 +68,10 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
     await reporting.flush().finally(() => process.exit(1));
   }
 
-  // 2. Readiness gate - staged uploads need server-side consume-mode which is
-  //    still rolling out (SHERLO-1707).  Internal testing can bypass this gate
-  //    with SHERLO_DEVTOOLS=1 to exercise the local pipeline.
-  if (process.env.SHERLO_DEVTOOLS !== '1') {
-    console.log(
-      chalk.yellow(
-        'Staged uploads require server support that is still rolling out (SHERLO-1707).\n' +
-          `Run \`sherlo ${TEST_STANDARD_COMMAND}\` for a full build.`
-      )
-    );
-    await reporting.flush().finally(() => process.exit(1));
-  }
+  console.log(chalk.bold('\n📦 Bundling for staged upload...\n'));
 
-  console.log(chalk.bold('\n📦 Bundling for staged upload (devtools mode)...\n'));
-
-  // 3. Compute base fingerprint - identifies which base binary to stage against.
+  // 2. Compute base fingerprint - identifies which base binary to stage against.
+  //    A null hash means the staged flow is unavailable for this project.
   const fpResult = await computeBaseFingerprint(commandParams.projectRoot);
   if (!fpResult.hash) {
     console.log(
@@ -70,14 +79,15 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
         'Staged upload unavailable - ' + (fpResult.debugMessage ?? 'fingerprint computation failed')
       )
     );
-    console.log(
-      chalk.yellow(
-        `Run \`sherlo ${TEST_STANDARD_COMMAND}\` for a full build with the same options.`
-      )
-    );
+    console.log(chalk.yellow(FALLBACK_LINE));
     await reporting.flush().finally(() => process.exit(1));
   }
-  // 4. Build bundle + assets for each platform.
+  const baseFingerprint = fpResult.hash!;
+
+  // 3. Build bundle + assets and construct gate metadata for each platform.
+  const bundles: Partial<Record<Platform, BundleResult>> = {};
+  const gateMetadata: { android?: GateMetadataInput; ios?: GateMetadataInput } = {};
+
   for (const platform of platformsToTest) {
     const emoji = platform === 'android' ? '🤖' : '🍎';
     console.log(chalk.cyan(`\n${emoji} Building ${platform} bundle...`));
@@ -87,6 +97,8 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
         projectRoot: commandParams.projectRoot,
         platform,
       });
+      bundles[platform] = result;
+
       console.log(
         chalk.green(`  ✓ Bundle: ${path.basename(result.bundlePath)}`) +
           ` (${result.bundleSizeMb} MB, ${result.bundleFormat}, ${result.bundler})`
@@ -94,15 +106,150 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
       if (result.assetsDest) {
         console.log(chalk.green(`  ✓ Assets: ${result.assetInventory.length} files`));
       }
+
+      gateMetadata[platform] = await buildGateMetadata({
+        projectRoot: commandParams.projectRoot,
+        platform,
+        bundleResult: result,
+      });
     } catch (err) {
+      // buildBundleForPlatform throws user-facing messages that already include
+      // the test:standard fallback line.
       const message = err instanceof Error ? err.message : String(err);
       console.log(chalk.red(`\n  ✗ ${message}`));
       await reporting.flush().finally(() => process.exit(1));
     }
   }
 
-  console.log(chalk.green('\n✓ Local pipeline complete (no server send - SHERLO-1707 pending)\n'));
-  return { url: '' };
+  // 4. Resolve token + SDK client.
+  const { apiToken, projectIndex, teamId } = getTokenParts(commandParams.token);
+  const client = sdkClient({ authToken: apiToken });
+
+  // 5. Request staged upload slots (getStagedUploadUrls - NOT getBuildUploadUrls).
+  reporting.addBreadcrumb({
+    category: 'api',
+    message: 'Calling getStagedUploadUrls API',
+    data: { teamId, projectIndex, platforms: platformsToTest },
+    level: 'info',
+  });
+
+  const { stagedPresignedUploadUrls } = await client
+    .getStagedUploadUrls({ platforms: platformsToTest, projectIndex, teamId })
+    .catch(handleClientError);
+
+  // 6. Upload the bundle (+ assets) for each platform and collect its S3 keys.
+  const stagedKeys: Partial<Record<Platform, StagedUploadKeys>> = {};
+
+  for (const platform of platformsToTest) {
+    const urls = stagedPresignedUploadUrls[platform];
+    const bundleResult = bundles[platform];
+
+    if (!urls || !bundleResult) {
+      console.log(chalk.red(`\nStaged upload slot missing for ${platform}.`));
+      console.log(chalk.yellow(FALLBACK_LINE));
+      await reporting.flush().finally(() => process.exit(1));
+      return { url: '' }; // unreachable - satisfies control flow when exit is stubbed
+    }
+
+    console.log(chalk.cyan(`\n⬆️  Uploading ${platform} bundle...`));
+    stagedKeys[platform] = await uploadStagedArtifacts({ platform, bundleResult, urls });
+  }
+
+  // 7. Capture git info - IDENTICAL to test:standard (same helper, same override).
+  const gitInfo = await getGitInfo(commandParams.projectRoot, {
+    branchOverride: commandParams.gitBranch,
+  });
+
+  // 8. Build the run config and mirror the staged S3 keys / bundle size onto each
+  //    platform. getBuildRunConfig already sets `s3Key` to the async-upload
+  //    placeholder (no binary S3 keys passed); the server mirrors it back.
+  const buildRunConfig = getBuildRunConfig({ commandParams });
+
+  for (const platform of platformsToTest) {
+    const platformConfig = buildRunConfig[platform];
+    const keys = stagedKeys[platform];
+    const bundleResult = bundles[platform];
+    if (!platformConfig || !keys || !bundleResult) continue;
+
+    platformConfig.s3Key = ASYNC_UPLOAD_S3_KEY_PLACEHOLDER;
+    platformConfig.jsBundleS3Key = keys.jsBundleS3Key;
+    platformConfig.bundleSizeMb = bundleResult.bundleSizeMb;
+    if (keys.assetsS3Key) {
+      platformConfig.assetsS3Key = keys.assetsS3Key;
+    }
+  }
+
+  // 9. Open the staged build. The server gate may refuse with a
+  //    STAGED_GATE_REFUSAL payload we translate for the user.
+  reporting.addBreadcrumb({
+    category: 'api',
+    message: 'Calling openBuild API (staged)',
+    data: { teamId, projectIndex, command: THIS_COMMAND },
+    level: 'info',
+  });
+
+  let openBuildReturn;
+  try {
+    openBuildReturn = await client.openBuild({
+      teamId,
+      projectIndex,
+      buildRunConfig,
+      gitInfo,
+      message: commandParams.message,
+      baseFingerprint,
+      gateMetadata: gateMetadata as GateMetadataByPlatform,
+    });
+  } catch (error) {
+    const refusal = parseStagedGateRefusal(error);
+    if (refusal) {
+      console.log(chalk.red(`\n${formatStagedGateRefusal(refusal)}`));
+      await reporting.flush().finally(() => process.exit(1));
+      throw error; // unreachable - satisfies control flow when exit is stubbed
+    }
+    handleClientError(error); // always throws
+    throw error; // unreachable - satisfies control flow / typing
+  }
+
+  const { build } = openBuildReturn;
+  const buildIndex = build.index;
+  // Sentry tags must be strings; buildIndex is a number from the API response.
+  reporting.setTag('build_index', String(buildIndex));
+  reporting.setTag('platform', platformsToTest.length === 2 ? 'both' : platformsToTest[0]);
+
+  const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
+
+  printResultsUrl(url);
+
+  if (commandParams.wait) {
+    const exitCode = await waitForBuildResult({
+      token: commandParams.token,
+      buildIndex,
+      projectIndex,
+      teamId,
+      waitTimeoutMinutes: parseWaitTimeout(commandParams.waitTimeout),
+    });
+
+    // --wait mode: the exit code IS the contract. Flush telemetry then exit.
+    await reporting.flush().finally(() => {
+      process.exit(exitCode);
+    });
+  }
+
+  return { url };
 }
 
 export default testBundled;
+
+/* ========================================================================== */
+
+function parseWaitTimeout(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const minutes = parseInt(raw, 10);
+  if (isNaN(minutes) || minutes < 1) {
+    logWarning({
+      message: `Invalid --wait-timeout "${raw}"; using default 45 minutes.`,
+    });
+    return undefined;
+  }
+  return minutes;
+}

--- a/packages/cli/src/commands/testBundled/uploadStagedArtifacts.ts
+++ b/packages/cli/src/commands/testBundled/uploadStagedArtifacts.ts
@@ -1,0 +1,144 @@
+/**
+ * Uploads the staged JS bundle (and, when present, the assets archive) to the
+ * presigned S3 URLs returned by getStagedUploadUrls, and returns the S3 keys
+ * to mirror into the openBuild buildRunConfig (SHERLO-1707).
+ *
+ * - jsBundle: the single plain-JS bundle file is PUT verbatim.
+ * - assets:   the Metro --assets-dest output directory is packed into a single
+ *             gzipped tar (one S3 object) and PUT. Only when the bundler
+ *             actually produced assets (bundleResult.assetsDest is set).
+ *
+ * Uses the same protocol-appropriate keep-alive agent + retry loop as the
+ * binary uploadBuild helper so local-S3 (http) and AWS (https) both work.
+ */
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import http from 'http';
+import https from 'https';
+import os from 'os';
+import path from 'path';
+import { Platform, StagedPlatformUploadUrls } from '@sherlo/api-types';
+import fetch from 'node-fetch';
+import { PLATFORM_LABEL } from '../../constants';
+import reporting from '../../helpers/reporting';
+import throwError from '../../helpers/throwError';
+import type { BundleResult } from './buildBundle';
+
+const MAX_RETRIES = 3;
+const TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+export type StagedUploadKeys = {
+  jsBundleS3Key: string;
+  assetsS3Key?: string;
+};
+
+async function uploadStagedArtifacts({
+  platform,
+  bundleResult,
+  urls,
+}: {
+  platform: Platform;
+  bundleResult: BundleResult;
+  urls: StagedPlatformUploadUrls;
+}): Promise<StagedUploadKeys> {
+  // 1. Upload the JS bundle verbatim.
+  const bundleBuffer = fs.readFileSync(bundleResult.bundlePath);
+  await putBuffer({
+    platform,
+    label: 'JS bundle',
+    uploadUrl: urls.jsBundle.url,
+    buffer: bundleBuffer,
+  });
+
+  const keys: StagedUploadKeys = { jsBundleS3Key: urls.jsBundle.s3Key };
+
+  // 2. Upload the assets archive - only when the bundler produced assets.
+  if (bundleResult.assetsDest) {
+    const archivePath = path.join(os.tmpdir(), `sherlo-staged-assets-${platform}.tar.gz`);
+    try {
+      // Pack the assets dir into a single gzipped tar (one S3 object). Use the
+      // system tar via execFileSync (no shell) - the same approach buildBundle
+      // uses to shell out to the bundler.
+      execFileSync('tar', ['-czf', archivePath, '-C', bundleResult.assetsDest, '.'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const assetsBuffer = fs.readFileSync(archivePath);
+      await putBuffer({
+        platform,
+        label: 'assets',
+        uploadUrl: urls.assets.url,
+        buffer: assetsBuffer,
+      });
+
+      keys.assetsS3Key = urls.assets.s3Key;
+    } finally {
+      fs.rmSync(archivePath, { force: true });
+    }
+  }
+
+  return keys;
+}
+
+export default uploadStagedArtifacts;
+
+/* ========================================================================== */
+
+async function putBuffer({
+  platform,
+  label,
+  uploadUrl,
+  buffer,
+}: {
+  platform: Platform;
+  label: string;
+  uploadUrl: string;
+  buffer: Buffer;
+}): Promise<void> {
+  reporting.addBreadcrumb({
+    category: 'api',
+    message: 'Uploading staged artifact to S3',
+    data: { platform, label, bytes: buffer.length },
+    level: 'info',
+  });
+
+  // Protocol-appropriate agent (HTTP for local S3, HTTPS for AWS).
+  const agent = uploadUrl.startsWith('https')
+    ? new https.Agent({ keepAlive: true, timeout: TIMEOUT })
+    : new http.Agent({ keepAlive: true, timeout: TIMEOUT });
+
+  let attempt = 0;
+  while (attempt < MAX_RETRIES) {
+    try {
+      const response = await fetch(uploadUrl, {
+        method: 'PUT',
+        body: buffer,
+        headers: {
+          'Content-Length': buffer.length.toString(),
+          'Content-Type': 'application/octet-stream',
+        },
+        timeout: TIMEOUT,
+        agent,
+      });
+
+      if (!response.ok) {
+        const responseText = await response.text();
+        throw new Error(`Server responded with ${response.status}: ${responseText}`);
+      }
+
+      return;
+    } catch (error: any) {
+      attempt++;
+
+      if (attempt === MAX_RETRIES) {
+        throwError({
+          type: 'unexpected',
+          error: new Error(
+            `Failed to upload ${PLATFORM_LABEL[platform]} ${label} after ${MAX_RETRIES} attempts. ` +
+              `Last error (${error.code}): ${error.message}`
+          ),
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1708

## What

Completes `test:bundled` (SHERLO-1708) - the bundle-only staged fast path - now that the API consume-mode (SHERLO-1707) and the staged upload slots + package bump (SHERLO-1709, sherlo-api #267) are in place. The command now runs for real instead of being gated behind `SHERLO_DEVTOOLS`.

## Changes

- **Upload via `getStagedUploadUrls`** (new staged-only mutation from #267) - NOT `getBuildUploadUrls`. Per platform it vends `{ jsBundle: {s3Key,url}, assets: {s3Key,url} }` in a distinct `staged/` keyspace. The JS bundle is PUT verbatim; the Metro `--assets-dest` output is packed into a single `tar.gz` and PUT only when the bundler actually produced assets.
- **Send the staged per-platform config through `openBuild`**: `jsBundleS3Key` + `bundleSizeMb` (+ `assetsS3Key` when present), plus top-level `baseFingerprint` and per-platform `gateMetadata`.
- **`s3Key` handling**: a bundled run has no native binary, so each staged platform sends the `ASYNC_UPLOAD_S3_KEY_PLACEHOLDER` for the (still-required) `s3Key`; the server mirrors `jsBundleS3Key` over it. Staged fields are validated as a per-platform unit (partial = hard error).
- **gitInfo parity**: uses the exact same `getGitInfo(projectRoot, { branchOverride })` call as `test:standard` and forwards the result to `openBuild` verbatim (asserted by an identity test).
- **Gate refusal**: parses the `STAGED_GATE_REFUSAL|<outcome>|<platform>|<comma-separated-diff>` error into a named-diff refusal message + the `test:standard` fallback line, and exits non-zero. Parser is pinned to the format cemented server-side in `openBuild.stagedGateRefusal.unit.test.ts`.
- **Removed the `SHERLO_DEVTOOLS` readiness gate** and the "rolling out" copy. The `SHERLO_DEVTOOLS`-gated `DIAGNOSTICS_OPTION` is unchanged.

## Upload-slot decision (per ticket)

Uses the dedicated `getStagedUploadUrls` mutation, not the binary `getBuildUploadUrls` slot. A bundled run has no binary, and the JS bundle + assets need distinct staged slots; #267 added `getStagedUploadUrls` for exactly this. `s3Key` is sent as the async-upload placeholder and mirrored server-side.

## ⚠️ CI is expected RED until #267's packages reach the dev-stage store

This code compiles and its full suite passes **locally** against a regenerated vendored `@sherlo/*` snapshot at **0.1.132** (the version #267 bumped to). CI runs `scripts/init-env.sh`, which pulls the `@sherlo/*` tarballs from the **dev-stage package store**, which is still stale (`v0.1.1-...`, no `getStagedUploadUrls`). **CI will fail to compile until an operator deploys/publishes #267's `@sherlo/*` packages (0.1.132) to the dev stage** - this is the operator-gated release step, not a defect in this PR. Once those packages are available, CI goes green with no code change here.

## Tests

Full CLI suite green locally (339/339), typecheck + lint clean. New unit tests:
- `stagedGateRefusal.test.ts` - wire-format parser + formatter (both outcomes, empty/absent diff, multi-source diff, non-refusal errors ignored).
- gitInfo parity - `test:bundled` sends the exact `getGitInfo` object `test:standard` would (identity assertion).
- `stagedFastPath.test.ts` - a version / build-number-only bump does NOT change `baseFingerprint` (so the gate stays fast), with a real-native-change sanity check that it DOES change.

## Out of scope / follow-ups

- **E2E ACs** (a JS-only bundled run producing snapshots on both platforms, for an Expo-managed and a bare-RN fixture) require real fixtures + devices - deferred to tester/manual validation.
- **llms.txt / llms-full.txt** (sherlo-www) update for `test:bundled` should ride with the feature's user-facing GA (post-publish); the llms drift check was skipped for this internal-wiring PR since the command is not yet user-consumable.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
