### PR TITLE
feat: Composite GitHub Action — two-job staged router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ testing/react-native/sherlo-lib/*
 !testing/react-native/sherlo-lib/react-native-storybook.tgz
 .env
 sherlo.config.json
+!examples/*/sherlo.config.json
 
 *storybook.log
 storybook-static

--- a/actions/staged-gate/README.md
+++ b/actions/staged-gate/README.md
@@ -1,0 +1,215 @@
+# Sherlo Staged Gate action
+
+A composite GitHub Action that runs the Sherlo staged routing probe
+(`sherlo staged:check`) and exposes the routing decision as action outputs, so a
+caller workflow can route two jobs off a single gate: a JS-only fast path on
+Linux, or a full native build path.
+
+> **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
+
+<br />
+
+## What it does
+
+`sherlo staged:check` is a CI routing probe, not a pass/fail gate. It runs right
+after dependency install with no build artifacts, computes a source fingerprint,
+asks the Sherlo gate, and decides one of three routing modes:
+
+| `mode`           | Meaning                                                      | What to run                                        |
+| ---------------- | ----------------------------------------------------------- | -------------------------------------------------- |
+| `fast`           | Native inputs unchanged; a registered base matches source   | `test:bundled` (JS-only, runs on Linux)            |
+| `full`           | Native inputs moved since the base build                    | Native build, then `test:standard`                 |
+| `not-stageable`  | Project can't use the staged path (no devices, no fingerprint) | Treat like `full`: native build, then `test:standard` |
+
+`test:standard` registers a fresh native base, so after a `full` run the next
+push with native unchanged routes `fast`.
+
+<br />
+
+## Usage
+
+```yaml
+uses: sherlo-io/sherlo/actions/staged-gate@v1
+```
+
+Pin to a released tag (as above) or a commit SHA in your own repository.
+
+### Inputs
+
+| Input               | Required | Default              | Description                                           |
+| ------------------- | -------- | -------------------- | ----------------------------------------------------- |
+| `sherlo-token`      | yes      | -                    | Sherlo project token (`SHERLO_TOKEN`)                 |
+| `working-directory` | no       | `.`                  | Directory to run `staged:check` in (project root)     |
+| `config`            | no       | `sherlo.config.json` | Path to the Sherlo config file                        |
+
+### Outputs
+
+| Output             | Description                                                            |
+| ------------------ | --------------------------------------------------------------------- |
+| `mode`             | Routing mode: `fast`, `full`, or `not-stageable`                      |
+| `reason`           | Single-line human explanation of the routing decision                 |
+| `base-fingerprint` | Source base fingerprint (maps the CLI's `baseFingerprint`; may be empty) |
+
+<br />
+
+## The exit-code trap (handled for you)
+
+`staged:check` exits `0` = fast, `1` = full, `2` = not-stageable. The `1` and `2`
+exits are expected routing outcomes, not failures - a naive gate step would fail
+the whole workflow on any native change. But a genuine tool error (bad token,
+network failure) also exits `1`, so the exit code alone cannot tell `full`
+routing from a real error.
+
+The reliable discriminator is the output, not the exit code: on a real routing
+decision the CLI writes `mode=...` to `$GITHUB_OUTPUT` before exiting; on a
+genuine error it throws and never writes `mode`. This action therefore tolerates
+the non-zero exit and branches on the `mode` output:
+
+- `mode` is set -> a real routing decision -> exposed as the `mode` output.
+- `mode` is empty -> a genuine tool error -> the action fails loudly and surfaces
+  the CLI stderr.
+
+Route your downstream jobs on `needs.<gate>.outputs.mode`, never on an exit code.
+
+<br />
+
+## Pattern A: the two-job router (recommended)
+
+One gate job routes to a JS-only fast job on Linux or a full native-build job.
+This is the primary pattern - it keeps the common case (native unchanged) on the
+fast, Linux-only lane and only pays for a native build when native inputs move.
+
+```yaml
+name: Sherlo Test - Staged
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  gate:
+    name: Staged Gate
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.gate.outputs.mode }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+      - run: yarn install
+      - id: gate
+        uses: sherlo-io/sherlo/actions/staged-gate@v1
+        with:
+          sherlo-token: ${{ secrets.SHERLO_TOKEN }}
+
+  fast-test:
+    name: Fast Test
+    runs-on: ubuntu-latest
+    needs: gate
+    if: needs.gate.outputs.mode == 'fast'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+      - run: yarn install
+      # JS-only fast path, no native build.
+      - run: npx sherlo test:bundled --token ${{ secrets.SHERLO_TOKEN }}
+
+  full-test:
+    name: Full Test
+    runs-on: macos-latest
+    needs: gate
+    if: needs.gate.outputs.mode == 'full' || needs.gate.outputs.mode == 'not-stageable'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn install
+      # Your native build steps (this example uses eas build --local).
+      - run: eas build --non-interactive --local --platform android --profile preview-simulator --output android.apk
+      - run: eas build --non-interactive --local --platform ios --profile preview-simulator --output ios.tar.gz
+      # test:standard registers a fresh base -> the next push routes 'fast'.
+      - run: npx sherlo test:standard --android android.apk --ios ios.tar.gz --token ${{ secrets.SHERLO_TOKEN }}
+```
+
+A full runnable example lives in
+[`examples/staged`](../../examples/staged).
+
+<br />
+
+## Pattern B: the single-job `--on-stale=build` alternative
+
+If you prefer one job over the gate-plus-two-jobs split, run `test:bundled` with
+`--on-stale=build`. It takes the fast path when the base matches, and when the
+base is stale it rebuilds natively via your `staged.fullBuild` config and falls
+back to a full, base-registering run - all in one job.
+
+```yaml
+name: Sherlo Test - Staged (single job)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  staged-test:
+    name: Staged Test
+    # macOS so the fallback iOS native build can run when the base is stale.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn install
+      # Fast path when the base matches; on a stale base it runs the
+      # `staged.fullBuild` commands from sherlo.config.json, then a full
+      # test:standard run that registers a fresh base.
+      - run: npx sherlo test:bundled --on-stale=build --token ${{ secrets.SHERLO_TOKEN }}
+```
+
+This needs a `staged.fullBuild` block in `sherlo.config.json`:
+
+```json
+{
+  "devices": [{ "id": "iphone.15.pro", "osVersion": "17" }],
+  "staged": {
+    "fullBuild": {
+      "android": ["eas build --non-interactive --local --platform android --profile preview-simulator --output android.apk"],
+      "ios": ["eas build --non-interactive --local --platform ios --profile preview-simulator --output ios.tar.gz"]
+    }
+  }
+}
+```
+
+**Trade-off.** Pattern B is simpler (one job, one config-driven fallback), but it
+has no Linux-only fast lane: because the job must be able to run the native
+fallback build, it runs on macOS even when the base matches and the run stays
+JS-only. Pattern A keeps the fast case on cheaper Linux runners and only spends a
+macOS runner when a native build is actually required. `--on-stale` defaults to
+`fail`, which refuses with a diff naming the changed sources instead of
+rebuilding; tests are never silently skipped.
+
+<br />
+
+## Learn more
+
+To learn more about the staged testing method, visit our
+[documentation](https://sherlo.io/docs).

--- a/actions/staged-gate/action.yml
+++ b/actions/staged-gate/action.yml
@@ -1,0 +1,137 @@
+name: Sherlo Staged Gate
+description: >-
+  Runs the Sherlo staged routing probe (`sherlo staged:check`) and exposes the
+  routing mode so a caller workflow can send the run down a JS-only fast path or
+  a full native-build path.
+
+# ══════════════════════════════════════════════════════════════════════════════
+# WHAT THIS ACTION DOES
+#
+# `sherlo staged:check` is a CI ROUTING PROBE, not a pass/fail gate. It runs
+# post-install with no build artifacts, computes a source fingerprint, asks the
+# Sherlo gate, and decides one of three routing modes:
+#
+#   mode=fast           -> native inputs unchanged; reuse the registered base and
+#                          run `test:bundled` (JS-only, on Linux). No native build.
+#   mode=full           -> native inputs moved; do a full native build, then
+#                          `test:standard` (which registers a fresh base).
+#   mode=not-stageable  -> project can't use the staged path; treat like `full`.
+#
+# This action exposes `mode` (plus `reason` and `base-fingerprint`) as action
+# outputs so a caller can route two jobs off `needs.<gate>.outputs.mode`.
+#
+# THE EXIT-CODE TRAP (handled below):
+#   staged:check exits 0=fast, 1=full, 2=not-stageable. The 1 and 2 exits are
+#   EXPECTED routing outcomes, NOT failures - a naive gate would fail the whole
+#   workflow on a native change. BUT a GENUINE tool error (bad token, network)
+#   ALSO exits 1. Exit code alone cannot tell `full` routing from a real error.
+#
+#   The reliable discriminator: on a real routing decision the CLI writes
+#   `mode=...` to $GITHUB_OUTPUT BEFORE exiting; on a genuine error it throws and
+#   NEVER writes `mode`. So we tolerate the non-zero exit (set +e) and branch on
+#   the `mode` OUTPUT, never on the raw exit status:
+#     - `mode` empty -> genuine tool error -> fail the gate loudly.
+#     - `mode` set   -> real routing decision -> expose it for downstream jobs.
+# ══════════════════════════════════════════════════════════════════════════════
+
+inputs:
+  sherlo-token:
+    description: "Sherlo project token (SHERLO_TOKEN)"
+    required: true
+  working-directory:
+    description: "Directory to run `sherlo staged:check` in (project root)"
+    required: false
+    default: "."
+  config:
+    description: "Path to the Sherlo config file (default: sherlo.config.json)"
+    required: false
+    default: ""
+
+outputs:
+  mode:
+    description: "Routing mode: fast | full | not-stageable"
+    # Mapped straight from the CLI-written $GITHUB_OUTPUT value. The guard step
+    # below has already failed the action if this was empty (genuine error).
+    value: ${{ steps.staged-check.outputs.mode }}
+  reason:
+    description: "Single-line human explanation of the routing decision"
+    value: ${{ steps.staged-check.outputs.reason }}
+  base-fingerprint:
+    description: "Source base fingerprint (maps the CLI's baseFingerprint output; may be empty)"
+    value: ${{ steps.staged-check.outputs.baseFingerprint }}
+
+runs:
+  using: composite
+  steps:
+    # ────────────────────────────────────────────────────────────────────────
+    # Run the routing probe. The CLI writes mode/reason/baseFingerprint to this
+    # step's $GITHUB_OUTPUT file ITSELF (do NOT echo them here). We tolerate a
+    # non-zero exit because full(1)/not-stageable(2) are EXPECTED - the genuine
+    # error check happens in the next step by testing whether `mode` was written.
+    # ────────────────────────────────────────────────────────────────────────
+    - name: ⚡ Run Sherlo staged routing probe
+      id: staged-check
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SHERLO_TOKEN: ${{ inputs.sherlo-token }}
+        CONFIG: ${{ inputs.config }}
+      run: |
+        set +e
+
+        CONFIG_ARG=()
+        if [ -n "$CONFIG" ]; then
+          CONFIG_ARG=(--config "$CONFIG")
+        fi
+
+        echo "⚡ Running sherlo staged:check (routing probe)..."
+        echo "────────────────────────────────────"
+
+        # The CLI appends mode=/reason=/baseFingerprint= to $GITHUB_OUTPUT before
+        # exiting. Capture stderr to a file so a genuine tool error can be
+        # surfaced by the guard step, then re-emit it into the live log.
+        # Redirecting stderr does NOT affect the $GITHUB_OUTPUT file.
+        npx sherlo staged:check \
+          --token "$SHERLO_TOKEN" \
+          "${CONFIG_ARG[@]}" \
+          2> staged-check.stderr
+        CLI_EXIT=$?
+
+        cat staged-check.stderr >&2
+
+        echo "────────────────────────────────────"
+        echo "staged:check exited with code ${CLI_EXIT} (0=fast, 1=full, 2=not-stageable)"
+
+        # NEVER fail here on the exit code - 1/2 are expected routing outcomes.
+        # The genuine-error discriminator runs in the next step.
+        exit 0
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Discriminate a real routing decision from a genuine tool error. Branch on
+    # the `mode` OUTPUT, never on the raw exit code above.
+    # ────────────────────────────────────────────────────────────────────────
+    - name: 🧭 Validate routing decision
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        MODE: ${{ steps.staged-check.outputs.mode }}
+        REASON: ${{ steps.staged-check.outputs.reason }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$MODE" ]; then
+          echo ""
+          echo "❌ Sherlo staged:check did not produce a routing mode."
+          echo ""
+          echo "This means the probe threw a GENUINE error (e.g. bad token, network"
+          echo "failure) rather than making a routing decision - a real routing"
+          echo "decision always writes a mode. CLI stderr:"
+          echo "────────────────────────────────────"
+          if [ -f staged-check.stderr ]; then cat staged-check.stderr; fi
+          echo "────────────────────────────────────"
+          echo "::error title=Sherlo staged:check failed::staged:check produced no routing mode - treated as a genuine tool error (see stderr above)"
+          exit 1
+        fi
+
+        echo "✅ Routing mode: ${MODE}"
+        if [ -n "$REASON" ]; then echo "   ${REASON}"; fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,6 @@ Working examples of Sherlo running automated [visual regression testing for Reac
 | Example                                     | Description                                             |
 | ------------------------------------------- | ------------------------------------------------------- |
 | 📦 [**Standard**](./standard)               | Test app builds with bundled JavaScript                 |
+| ⚡ [**Staged**](./staged)                   | Route CI to a JS-only fast lane when native is unchanged |
 | ⚡ [**EAS Update**](./eas-update)           | Test builds with OTA JavaScript updates - skip rebuilds |
 | ☁️ [**EAS Cloud Build**](./eas-cloud-build) | Automatically test builds created on Expo servers       |

--- a/examples/staged/.github/workflows/staged.yml
+++ b/examples/staged/.github/workflows/staged.yml
@@ -1,0 +1,163 @@
+name: Sherlo Test - Staged
+
+# ══════════════════════════════════════════════════════════════════════════════
+# WORKFLOW: two-job staged router
+#
+#                            [ ⚡ Staged Gate ]
+#                          (sherlo staged:check)
+#                                    │
+#                     mode? ─────────┼─────────────────┐
+#                       │                              │
+#              mode == 'fast'            mode == 'full' | 'not-stageable'
+#                       │                              │
+#                       ▼                              ▼
+#              [ ⚡ Fast Test ]              [ 🔨 Full Test ]
+#           test:bundled (Linux)      native build + test:standard
+#            no native build          REGISTERS a fresh base
+#
+# The gate routes ONE of the two downstream jobs. On a native change the full
+# job registers a fresh base, so the NEXT push (native unchanged) routes fast.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Triggers on:
+# - Push to main branch
+# - Manual trigger from GitHub UI
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────────────
+  # ⚡ STAGED GATE
+  #
+  # Runs the routing probe and exposes `mode` as a job output. Downstream jobs
+  # route on `needs.gate.outputs.mode` - NEVER on an exit code (the gate action
+  # handles the exit-code trap internally).
+  # ────────────────────────────────────────────────────────────────────────────
+  gate:
+    name: Staged Gate
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.gate.outputs.mode }}
+      reason: ${{ steps.gate.outputs.reason }}
+
+    steps:
+      - name: 📦 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+
+      - name: 📥 Install dependencies
+        run: yarn install
+
+      # The gate action runs `sherlo staged:check` and exposes mode/reason.
+      # Pin to a released tag (or a commit SHA) in your own repository.
+      - name: ⚡ Run staged routing probe
+        id: gate
+        uses: sherlo-io/sherlo/actions/staged-gate@v1
+        with:
+          sherlo-token: ${{ secrets.SHERLO_TOKEN }}
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # ⚡ FAST TEST (JS-only, on Linux)
+  #
+  # Native inputs unchanged -> reuse the registered base. Builds a plain-JS
+  # bundle and runs the staged test. NO native build, so it runs on ubuntu.
+  # ────────────────────────────────────────────────────────────────────────────
+  fast-test:
+    name: Fast Test
+    runs-on: ubuntu-latest
+    needs: gate
+    if: needs.gate.outputs.mode == 'fast'
+
+    steps:
+      - name: 📦 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+
+      - name: 📥 Install dependencies
+        run: yarn install
+
+      # Uses 'test:bundled' - JS-only fast path, no native rebuild.
+      - name: ⚡ Run Sherlo bundled test
+        run: |
+          npx sherlo test:bundled \
+            --token ${{ secrets.SHERLO_TOKEN }}
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # 🔨 FULL TEST (native build + base registration)
+  #
+  # Native inputs moved (or the project can't stage) -> do a full native build,
+  # then run 'test:standard'. test:standard REGISTERS A FRESH BASE, so the NEXT
+  # push on this branch (with native unchanged) will route to the fast job above.
+  #
+  # Builds run here with `eas build --local` (mirror the standard example). iOS
+  # requires macOS, so this job runs on macos-latest and builds both platforms.
+  # To parallelise, split into separate build jobs + artifact upload/download
+  # like examples/standard - the routing contract is unchanged.
+  # ────────────────────────────────────────────────────────────────────────────
+  full-test:
+    name: Full Test
+    runs-on: macos-latest
+    needs: gate
+    if: needs.gate.outputs.mode == 'full' || needs.gate.outputs.mode == 'not-stageable'
+
+    steps:
+      - name: 📦 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+
+      - name: 🏗 Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📥 Install dependencies
+        run: yarn install
+
+      # ▼▼▼ USER-SUPPLIED native build steps ▼▼▼
+      # Uses 'preview-simulator' profile from eas.json.
+      - name: 🤖 Build Android Simulator
+        run: |
+          eas build \
+            --non-interactive \
+            --local \
+            --platform android \
+            --profile preview-simulator \
+            --output android.apk
+
+      - name: 🍎 Build iOS Simulator
+        run: |
+          eas build \
+            --non-interactive \
+            --local \
+            --platform ios \
+            --profile preview-simulator \
+            --output ios.tar.gz
+      # ▲▲▲ USER-SUPPLIED native build steps ▲▲▲
+
+      # 'test:standard' registers the freshly built native binaries as the new
+      # base. After this run the base fingerprint matches source again, so the
+      # next push (native unchanged) is routed 'fast' by the gate.
+      - name: 🧪 Run Sherlo test (registers fresh base)
+        run: |
+          npx sherlo test:standard \
+            --android android.apk \
+            --ios ios.tar.gz \
+            --token ${{ secrets.SHERLO_TOKEN }}

--- a/examples/staged/README.md
+++ b/examples/staged/README.md
@@ -1,0 +1,102 @@
+# ⚡ Staged Example • Sherlo
+
+An example showing Sherlo's staged fast path: a single gate routes CI to a
+JS-only fast lane on Linux when native inputs are unchanged, and to a full
+native build only when they move. Fewer native builds, faster feedback on the
+common case.
+
+- Sherlo integration
+- GitHub Actions workflow (two-job staged router)
+
+<br />
+
+## 🔄 Workflow
+
+A gate runs `sherlo staged:check` and routes ONE of two downstream jobs:
+
+```mermaid
+flowchart TB
+   UI(🧑‍💻 Code Changes)
+   Gate(⚡ Staged Gate)
+   Fast("⚡ Fast Test<br/>JS-only on Linux")
+   Full("🔨 Full Test<br/>native rebuild")
+   Review(👀 Review Results)
+
+   UI --> Gate
+   Gate -->|fast| Fast
+   Gate -->|full| Full
+   Fast --> Review
+   Full --> Review
+```
+
+The full job's `test:standard` run registers a fresh native base, so the next
+push with native unchanged is routed to the fast lane.
+
+<br />
+
+## 🧭 How routing works
+
+`sherlo staged:check` decides a routing `mode`:
+
+- **`fast`** - native inputs unchanged; reuse the registered base and run
+  `test:bundled` (JS-only, on Linux). No native build.
+- **`full`** - native inputs moved; do a full native build, then `test:standard`
+  (which registers a fresh base).
+- **`not-stageable`** - the project can't use the staged path; treated like
+  `full`.
+
+The [`staged-gate`](../../actions/staged-gate) action wraps the probe and exposes
+`mode` as an output. Jobs route on `needs.gate.outputs.mode`, never on an exit
+code - see the action README for how the exit-code trap is handled.
+
+<br />
+
+## 🛠️ Prerequisites
+
+- [**Sherlo Account**](https://app.sherlo.io) – Required for visual testing
+- [**Expo Account**](https://expo.dev/signup) – Required for EAS (native builds)
+- Node.js 18+
+
+<br />
+
+## ⚙️ Setup
+
+Add repository secrets in **Settings → Secrets and variables → Actions**:
+
+- `SHERLO_TOKEN` – Your Sherlo project token
+- `EXPO_TOKEN` – Your [Expo access token](https://expo.dev/accounts/[your-account]/settings/access-tokens)
+
+Then push to `main` to trigger the workflow.
+
+<br />
+
+## 📁 Key Files
+
+- **[`.github/workflows/staged.yml`](./.github/workflows/staged.yml)** – Two-job staged router workflow
+- **[`sherlo.config.json`](./sherlo.config.json)** – Devices plus a `staged.fullBuild` block (used by the single-job `--on-stale=build` alternative)
+- **[`../../actions/staged-gate`](../../actions/staged-gate)** – The gate action and full docs for both patterns
+
+<br />
+
+## 🔀 Single-job alternative
+
+Prefer one job? Run `npx sherlo test:bundled --on-stale=build`: fast path when the
+base matches, and a config-driven native rebuild plus base-registering full run
+when it is stale. See the
+[gate action README](../../actions/staged-gate#pattern-b-the-single-job---on-stalebuild-alternative)
+for the trade-off (simpler, but no Linux-only fast lane).
+
+<br />
+
+## 📚 Learn More
+
+To learn more about Sherlo testing methods, visit our
+[documentation](https://sherlo.io/docs).
+
+<br />
+
+## 🔗 Other Examples
+
+- 📦 **[Standard](../standard)** – Test app builds with bundled JavaScript
+- ⚡ **[EAS Update](../eas-update)** – Test builds with OTA JavaScript updates - skip rebuilds
+- ☁️ **[EAS Cloud Build](../eas-cloud-build)** – Automatically test builds created on Expo servers

--- a/examples/staged/sherlo.config.json
+++ b/examples/staged/sherlo.config.json
@@ -1,0 +1,22 @@
+{
+  "devices": [
+    {
+      "id": "iphone.15.pro",
+      "osVersion": "17"
+    },
+    {
+      "id": "pixel.7.pro",
+      "osVersion": "13"
+    }
+  ],
+  "staged": {
+    "fullBuild": {
+      "android": [
+        "eas build --non-interactive --local --platform android --profile preview-simulator --output android.apk"
+      ],
+      "ios": [
+        "eas build --non-interactive --local --platform ios --profile preview-simulator --output ios.tar.gz"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1697

## SHERLO-1697: Composite GitHub Action - two-job staged router

Wraps the staged CI pattern in an official composite action, plus an example workflow and docs.

### What ships
- **actions/staged-gate/action.yml** - composite gate action running `sherlo staged:check`, exposing `mode` / `reason` / `base-fingerprint` outputs so a caller routes two jobs off `needs.gate.outputs.mode`.
- **actions/staged-gate/README.md** - documents both patterns (AC 3): the two-job router and the single-job `--on-stale=build` alternative, with the trade-off.
- **examples/staged/** - two-job router workflow (gate then fast `test:bundled` on Linux, or full native build then `test:standard`), a `sherlo.config.json` with a `staged.fullBuild` block, and a README.
- **.gitignore** - un-ignores per-example `sherlo.config.json` so the staged example ships its config like the sibling examples.

### The exit-code trap (handled)
`staged:check` exits 1 for the normal `full` routing outcome and 2 for `not-stageable` - both expected, not failures. A genuine tool error also exits 1, so exit code alone cannot tell `full` from a real error. The action tolerates the non-zero exit and branches on the `mode` OUTPUT: empty mode means a genuine error so the gate fails loudly; a set mode is a real routing decision exposed to downstream jobs. Callers route on the output, never the exit status.

### Behavioral ACs
- JS-only change routes fast (`test:bundled`, Linux); native change routes full (build then `test:standard`).
- The full job's `test:standard` registers a fresh native base, so the next push with native unchanged routes fast.

### Scope boundary
End-to-end validation against the sherlo-fixtures repo via the github-harness E2E suites is tracked separately (SHERLO-1695 staged E2E fixtures, SHERLO-1696 staged E2E suite; both tester-owned, Backlog). This PR delivers the action, the demonstrative example, and the docs in the sherlo repo. No new repository is created.

Ticket: SHERLO-1697

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
