### PR TITLE
feat: CLI: handle the new bundleFormat gate-diff dimension (exhaus…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/stagedGateRefusal.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/stagedGateRefusal.test.ts
@@ -108,6 +108,17 @@ describe('formatStagedGateRefusal - user-facing message', () => {
     expect(message).toContain('test:standard');
   });
 
+  it('names the bundleFormat diff source', () => {
+    const message = formatStagedGateRefusal({
+      outcome: 'full-build-needed',
+      platform: 'android',
+      diff: ['bundleFormat'],
+    });
+
+    expect(message).toContain('JS bundle format (hbc/plain-js/ram)');
+    expect(message).toContain('test:standard');
+  });
+
   it('omits the changed-sources line for a not-stageable refusal (empty diff)', () => {
     const message = formatStagedGateRefusal({
       outcome: 'not-stageable',

--- a/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
+++ b/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
@@ -81,6 +81,7 @@ const DIFF_LABELS: Record<GateDiffSource, string> = {
   expoUpdatesEnabled: 'expo-updates configuration',
   sdkProtocolVersion: 'Sherlo SDK protocol version',
   buildMetadata: 'native build metadata',
+  bundleFormat: 'JS bundle format (HBC/plain JS/RAM)',
 };
 
 /** Human-readable reason per non-fast outcome. */

--- a/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
+++ b/packages/cli/src/commands/testBundled/stagedGateRefusal.ts
@@ -81,7 +81,7 @@ const DIFF_LABELS: Record<GateDiffSource, string> = {
   expoUpdatesEnabled: 'expo-updates configuration',
   sdkProtocolVersion: 'Sherlo SDK protocol version',
   buildMetadata: 'native build metadata',
-  bundleFormat: 'JS bundle format (HBC/plain JS/RAM)',
+  bundleFormat: 'JS bundle format (hbc/plain-js/ram)',
 };
 
 /** Human-readable reason per non-fast outcome. */

--- a/packages/cli/src/helpers/stagedGate.ts
+++ b/packages/cli/src/helpers/stagedGate.ts
@@ -72,6 +72,7 @@ export const GATE_DIFF_LABELS: Record<GateDiffSource, string> = {
   expoUpdatesEnabled: 'expo-updates configuration',
   sdkProtocolVersion: 'Sherlo SDK protocol version',
   buildMetadata: 'native build metadata',
+  bundleFormat: 'JS bundle format (HBC/plain JS/RAM)',
 };
 
 /**

--- a/packages/cli/src/helpers/stagedGate.ts
+++ b/packages/cli/src/helpers/stagedGate.ts
@@ -72,7 +72,7 @@ export const GATE_DIFF_LABELS: Record<GateDiffSource, string> = {
   expoUpdatesEnabled: 'expo-updates configuration',
   sdkProtocolVersion: 'Sherlo SDK protocol version',
   buildMetadata: 'native build metadata',
-  bundleFormat: 'JS bundle format (HBC/plain JS/RAM)',
+  bundleFormat: 'JS bundle format (hbc/plain-js/ram)',
 };
 
 /**


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1723

## TL;DR

SHERLO-1721 (merged, sherlo-api#273) added 'bundleFormat' to the GateDiffSource union in @sherlo/types. The CLI's exhaustive Record<GateDiffSource, ...> refusal-message maps now fail to compile against the freshly published tarballs: TS2741 'Property bundleFormat is missing' at packages/cli/src/commands/testBundled/stagedGateRefusal.ts:78 and packages/cli/src/helpers/stagedGate.ts:69 - this broke the test-channel CLI republish (sherlo run 29096361325) and will break the dev republish identically. Add the bundleFormat entry to both maps with a user-facing refusal message consistent with the feature's named-diff style (e.g. 'JS bundle format changed (hbc/plain-js/ram)'), matching how the other dimensions read.

## Acceptance Criteria

- Both exhaustive maps handle the bundleFormat GateDiffSource with a clear, user-facing message in the same voice as the existing dimensions (the refusal output tells the user WHAT drifted and that test:standard is the fallback)
- yarn build (ncc + tsc) succeeds in packages/cli against the current published @sherlo tarballs - verify with the same init-env flow the release workflows use
- If any test snapshots/unit tests pin the refusal message catalogue, they are updated (cli stagedGateRefusal tests exist per the staged handoff)
- All pr_checks green
- Validation note in the PR: after merge the Director republishes both CLI dist-tags from main - this ticket's build success IS the gate for that, no e2e run required here

## Additional Context

## Evidence

sherlo release_to_test run 29096361325 (main, 13:31Z): Lerna build failed with TS2741 at the two files above - 'Property bundleFormat is missing in type { engineClass: ...; assetInventory: ...; expoUpdatesEnabled: ...; sdkProtocolVersion: ...; buildMetadata: ... }'. Root cause: sherlo-api#273 extended GateDiffSource (types tarball published to the test stage by the branch deploy 29094953323); the CLI maps are exhaustively typed - by design - so the compiler demands the new dimension.

## Why this is the intended mechanism working

The exhaustive Record over GateDiffSource is exactly the type-level contract pin the testing strategy calls for: the api grew a diff dimension and the CLI refused to build until it can EXPLAIN that dimension to users. Do not weaken the exhaustiveness (no Partial, no default-case fallthrough) - add the entry.

## Context for message wording

The comparator emits 'bundleFormat' when: authoritative formats differ (hbc vs plain-js vs ram), or mixed-era signals cannot prove equality (old CLI registered the base, new CLI consuming, or vice versa). The message should read naturally for both: the bundle format changed or could not be verified against the stored base; full build re-registers and self-heals.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
