### PR TITLE
feat: CLI core-flow unit tests: upload pipeline, Expo metadata par…

### DIFF
--- a/packages/cli/src/commands/easBuildOnComplete/__tests__/easBuildOnComplete.test.ts
+++ b/packages/cli/src/commands/easBuildOnComplete/__tests__/easBuildOnComplete.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the easBuildOnComplete hook entry.
+ *
+ * The hook is driven by EAS_BUILD_* env vars and the .sherlo temp-data read.
+ * We stub the temp-data read, the upload orchestrator, and the sdk-client so
+ * no real network / fs / upload runs. We assert:
+ *  - happy path: forwards buildIndex/profile/token to asyncUploadBuildAndRunTests
+ *  - loud failure: EAS_BUILD_STATUS === 'errored' -> client.closeBuild + throw
+ *  - early-return guards (built locally / profile mismatch / no temp data)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const closeBuild = vi.fn().mockResolvedValue(undefined);
+  return {
+    closeBuild,
+    sdkClient: vi.fn().mockReturnValue({ closeBuild }),
+    asyncUploadBuildAndRunTests: vi.fn().mockResolvedValue(undefined),
+    getSherloTempData: vi.fn(),
+    getTokenParts: vi
+      .fn()
+      .mockReturnValue({ apiToken: 'api-tok', projectIndex: 7, teamId: 'team1234' }),
+    handleClientError: vi.fn(),
+    logInfo: vi.fn(),
+    printSherloIntro: vi.fn(),
+    throwError: vi.fn((params: any) => {
+      throw new Error(params?.message ?? params?.error?.message ?? 'throwError');
+    }),
+  };
+});
+
+vi.mock('@sherlo/sdk-client', () => ({ default: mocks.sdkClient }));
+
+vi.mock('../helpers', () => ({
+  asyncUploadBuildAndRunTests: mocks.asyncUploadBuildAndRunTests,
+  getSherloTempData: mocks.getSherloTempData,
+}));
+
+vi.mock('../../../helpers', () => ({
+  getTokenParts: mocks.getTokenParts,
+  handleClientError: mocks.handleClientError,
+  logInfo: mocks.logInfo,
+  printSherloIntro: mocks.printSherloIntro,
+  throwError: mocks.throwError,
+}));
+
+import easBuildOnComplete from '../easBuildOnComplete';
+
+// ---------------------------------------------------------------------------
+// Env save / restore
+// ---------------------------------------------------------------------------
+
+const ENV_KEYS = ['EAS_BUILD_RUNNER', 'EAS_BUILD_PROFILE', 'EAS_BUILD_STATUS'] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  // Default: a cloud EAS build for the "preview" profile that succeeded.
+  process.env.EAS_BUILD_RUNNER = 'eas-build';
+  process.env.EAS_BUILD_PROFILE = 'preview';
+  delete process.env.EAS_BUILD_STATUS;
+  mocks.getSherloTempData.mockReturnValue({ buildIndex: 5, token: 'the-token' });
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('easBuildOnComplete - happy path', () => {
+  it('forwards buildIndex, profile and token to asyncUploadBuildAndRunTests', async () => {
+    await easBuildOnComplete({ profile: 'preview' } as any);
+
+    expect(mocks.asyncUploadBuildAndRunTests).toHaveBeenCalledTimes(1);
+    expect(mocks.asyncUploadBuildAndRunTests).toHaveBeenCalledWith({
+      buildIndex: 5,
+      easBuildProfile: 'preview',
+      token: 'the-token',
+    });
+    expect(mocks.closeBuild).not.toHaveBeenCalled();
+  });
+
+  it('matches when the current EAS profile is one of a comma-separated list', async () => {
+    process.env.EAS_BUILD_PROFILE = 'preview';
+
+    await easBuildOnComplete({ profile: 'production,preview' } as any);
+
+    expect(mocks.asyncUploadBuildAndRunTests).toHaveBeenCalledWith({
+      buildIndex: 5,
+      easBuildProfile: 'preview',
+      token: 'the-token',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loud failure - EAS build errored on Expo servers
+// ---------------------------------------------------------------------------
+
+describe('easBuildOnComplete - EAS build errored', () => {
+  beforeEach(() => {
+    process.env.EAS_BUILD_STATUS = 'errored';
+  });
+
+  it('closes the build as errored and throws, without uploading', async () => {
+    await expect(easBuildOnComplete({ profile: 'preview' } as any)).rejects.toThrow(
+      "Sherlo test can't be executed"
+    );
+
+    expect(mocks.closeBuild).toHaveBeenCalledWith({
+      buildIndex: 5,
+      projectIndex: 7,
+      teamId: 'team1234',
+      runError: 'user_easCloudBuild',
+    });
+    expect(mocks.asyncUploadBuildAndRunTests).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Early-return guards
+// ---------------------------------------------------------------------------
+
+describe('easBuildOnComplete - early returns', () => {
+  it('does nothing when the build ran locally (EAS_BUILD_RUNNER !== eas-build)', async () => {
+    process.env.EAS_BUILD_RUNNER = 'local';
+
+    await easBuildOnComplete({ profile: 'preview' } as any);
+
+    expect(mocks.asyncUploadBuildAndRunTests).not.toHaveBeenCalled();
+    expect(mocks.getSherloTempData).not.toHaveBeenCalled();
+  });
+
+  it('skips when the current EAS profile does not match the requested profile', async () => {
+    process.env.EAS_BUILD_PROFILE = 'production';
+
+    await easBuildOnComplete({ profile: 'preview' } as any);
+
+    expect(mocks.asyncUploadBuildAndRunTests).not.toHaveBeenCalled();
+  });
+
+  it('returns early when no sherlo temp data is present', async () => {
+    mocks.getSherloTempData.mockReturnValue(undefined);
+
+    await easBuildOnComplete({ profile: 'preview' } as any);
+
+    expect(mocks.asyncUploadBuildAndRunTests).not.toHaveBeenCalled();
+    expect(mocks.closeBuild).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/easBuildOnComplete/helpers/asyncUploadBuildAndRunTests/__tests__/getBuildPath.test.ts
+++ b/packages/cli/src/commands/easBuildOnComplete/helpers/asyncUploadBuildAndRunTests/__tests__/getBuildPath.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for getBuildPath.
+ *
+ * getBuildPath resolves the on-disk build artifact for a platform:
+ *  - it reads `eas.json` (relative to getCwd()) for a profile's
+ *    `applicationArchivePath` override, and
+ *  - falls back to the Android default apk path or an iOS `*.app` scan.
+ *
+ * We drive it with real fs fixtures in a tmp dir and point the process cwd at
+ * that dir (getCwd() === process.cwd()), so both the eas.json lookup AND the
+ * relative default-path existence checks resolve inside the fixture.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import getBuildPath from '../getBuildPath';
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-getbuildpath-'));
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers (all paths relative to tmpDir == cwd)
+// ---------------------------------------------------------------------------
+
+function writeEasJson(content: object) {
+  fs.writeFileSync(path.join(tmpDir, 'eas.json'), JSON.stringify(content, null, 2));
+}
+
+function touch(relativePath: string) {
+  const full = path.join(tmpDir, relativePath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, '');
+}
+
+function mkdirp(relativePath: string) {
+  fs.mkdirSync(path.join(tmpDir, relativePath), { recursive: true });
+}
+
+const ANDROID_DEFAULT = 'android/app/build/outputs/apk/release/app-release.apk';
+const IOS_SCAN_DIR = 'ios/build/Build/Products/Release-iphonesimulator';
+
+// ---------------------------------------------------------------------------
+// Android
+// ---------------------------------------------------------------------------
+
+describe('getBuildPath - android', () => {
+  it('uses the profile applicationArchivePath override from eas.json', () => {
+    writeEasJson({
+      builds: { android: { preview: { applicationArchivePath: 'custom/out/my-app.apk' } } },
+    });
+    touch('custom/out/my-app.apk');
+
+    expect(getBuildPath({ easBuildProfile: 'preview', platform: 'android' as any })).toBe(
+      'custom/out/my-app.apk'
+    );
+  });
+
+  it('falls back to the default apk path when the profile has no override', () => {
+    // eas.json exists (it is always read) but carries no override for this profile.
+    writeEasJson({ builds: { android: { preview: {} } } });
+    touch(ANDROID_DEFAULT);
+
+    expect(getBuildPath({ easBuildProfile: 'preview', platform: 'android' as any })).toBe(
+      ANDROID_DEFAULT
+    );
+  });
+
+  it('falls back to the default apk path when eas.json has no builds section', () => {
+    writeEasJson({ cli: { version: '>= 5.0.0' } });
+    touch(ANDROID_DEFAULT);
+
+    expect(getBuildPath({ easBuildProfile: 'production', platform: 'android' as any })).toBe(
+      ANDROID_DEFAULT
+    );
+  });
+
+  it('throws when the resolved build file does not exist', () => {
+    writeEasJson({ builds: { android: { preview: {} } } });
+    // No apk written on disk.
+
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'android' as any })).toThrow(
+      'Build file does not exist at path'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// iOS
+// ---------------------------------------------------------------------------
+
+describe('getBuildPath - ios', () => {
+  it('uses the profile applicationArchivePath override from eas.json', () => {
+    writeEasJson({
+      builds: { ios: { preview: { applicationArchivePath: 'custom/out/MyApp.app' } } },
+    });
+    mkdirp('custom/out/MyApp.app');
+
+    expect(getBuildPath({ easBuildProfile: 'preview', platform: 'ios' as any })).toBe(
+      'custom/out/MyApp.app'
+    );
+  });
+
+  it('scans the default iphonesimulator dir for a *.app when no override is set', () => {
+    writeEasJson({ builds: { ios: { preview: {} } } });
+    mkdirp(path.join(IOS_SCAN_DIR, 'MyApp.app'));
+
+    expect(getBuildPath({ easBuildProfile: 'preview', platform: 'ios' as any })).toBe(
+      path.join(IOS_SCAN_DIR, 'MyApp.app')
+    );
+  });
+
+  it('throws when neither an override nor a scanned *.app exists', () => {
+    writeEasJson({ builds: { ios: { preview: {} } } });
+    // The scan dir does not exist -> findDefaultIosAppPath returns null.
+
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'ios' as any })).toThrow(
+      'Could not find build path for platform: ios'
+    );
+  });
+
+  it('throws when the scan dir exists but contains no *.app', () => {
+    writeEasJson({ builds: { ios: { preview: {} } } });
+    mkdirp(IOS_SCAN_DIR);
+    touch(path.join(IOS_SCAN_DIR, 'not-an-app.txt'));
+
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'ios' as any })).toThrow(
+      'Could not find build path for platform: ios'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eas.json validity + unsupported platform
+// ---------------------------------------------------------------------------
+
+describe('getBuildPath - error cases', () => {
+  it('throws an "Invalid" message when eas.json is malformed JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'eas.json'), '{ not valid json');
+
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'android' as any })).toThrow(
+      'Invalid'
+    );
+  });
+
+  it('throws an "Invalid" message when eas.json is missing entirely', () => {
+    // getBuildPathFromEasJson reads eas.json unconditionally.
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'android' as any })).toThrow(
+      'Invalid'
+    );
+  });
+
+  it('throws for an unsupported platform', () => {
+    expect(() => getBuildPath({ easBuildProfile: 'preview', platform: 'windows' as any })).toThrow(
+      'Unsupported platform: windows'
+    );
+  });
+});

--- a/packages/cli/src/commands/testEasUpdate/helpers/getValidatedEasUpdateData/__tests__/getExpoMetadata.test.ts
+++ b/packages/cli/src/commands/testEasUpdate/helpers/getValidatedEasUpdateData/__tests__/getExpoMetadata.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for getExpoMetadata.
+ *
+ * getExpoMetadata shells out to `npx --yes expo config --json`, JSON-parses the
+ * stdout, and returns `{ slug, baseUpdateUrl }`. We stub `runShellCommand` (the
+ * only I/O boundary) and feed it fixture strings representative of real
+ * `expo config --json` output across Expo SDK 50/51/52, plus the failure modes.
+ *
+ * Failure-mode tests assert the USER-FACING error message produced by
+ * throwError - never a raw JSON.parse stack leaking through.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runShellCommand: vi.fn(),
+}));
+
+// Replace only runShellCommand in the helpers barrel; keep the real throwError
+// and getErrorWithCustomMessage so we assert the genuine user-facing messages.
+vi.mock('../../../../../helpers', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../../helpers')>();
+  return { ...actual, runShellCommand: mocks.runShellCommand };
+});
+
+import getExpoMetadata from '../getExpoMetadata';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const COMMAND_PARAMS = { projectRoot: '/tmp/project' } as any;
+
+// ---------------------------------------------------------------------------
+// Representative `expo config --json` fixtures per SDK version
+// ---------------------------------------------------------------------------
+
+const SDK_50_CONFIG = JSON.stringify({
+  name: 'MyApp',
+  slug: 'my-app-sdk50',
+  version: '1.0.0',
+  sdkVersion: '50.0.0',
+  platforms: ['ios', 'android'],
+  runtimeVersion: { policy: 'sdkVersion' },
+  updates: { url: 'https://u.expo.dev/00000000-0000-0000-0000-000000000050' },
+});
+
+const SDK_51_CONFIG = JSON.stringify({
+  name: 'MyApp',
+  slug: 'my-app-sdk51',
+  version: '1.0.0',
+  sdkVersion: '51.0.0',
+  platforms: ['ios', 'android'],
+  runtimeVersion: '1.0.0',
+  updates: { url: 'https://u.expo.dev/11111111-1111-1111-1111-000000000051' },
+});
+
+const SDK_52_CONFIG = JSON.stringify({
+  name: 'MyApp',
+  slug: 'my-app-sdk52',
+  version: '1.0.0',
+  sdkVersion: '52.0.0',
+  platforms: ['ios', 'android'],
+  runtimeVersion: { policy: 'fingerprint' },
+  updates: {
+    url: 'https://u.expo.dev/22222222-2222-2222-2222-000000000052',
+    fallbackToCacheTimeout: 0,
+  },
+  extra: { eas: { projectId: '22222222-2222-2222-2222-000000000052' } },
+});
+
+// ---------------------------------------------------------------------------
+// Happy path - table driven across SDK shapes
+// ---------------------------------------------------------------------------
+
+describe('getExpoMetadata - happy path', () => {
+  const cases: Array<{
+    name: string;
+    output: string;
+    expected: { slug: string; baseUpdateUrl: string };
+  }> = [
+    {
+      name: 'Expo SDK 50 config',
+      output: SDK_50_CONFIG,
+      expected: {
+        slug: 'my-app-sdk50',
+        baseUpdateUrl: 'https://u.expo.dev/00000000-0000-0000-0000-000000000050',
+      },
+    },
+    {
+      name: 'Expo SDK 51 config',
+      output: SDK_51_CONFIG,
+      expected: {
+        slug: 'my-app-sdk51',
+        baseUpdateUrl: 'https://u.expo.dev/11111111-1111-1111-1111-000000000051',
+      },
+    },
+    {
+      name: 'Expo SDK 52 config',
+      output: SDK_52_CONFIG,
+      expected: {
+        slug: 'my-app-sdk52',
+        baseUpdateUrl: 'https://u.expo.dev/22222222-2222-2222-2222-000000000052',
+      },
+    },
+  ];
+
+  for (const { name, output, expected } of cases) {
+    it(`returns { slug, baseUpdateUrl } for ${name}`, async () => {
+      mocks.runShellCommand.mockResolvedValue(output);
+
+      await expect(getExpoMetadata(COMMAND_PARAMS)).resolves.toEqual(expected);
+    });
+  }
+
+  it('runs `npx --yes expo config --json` in the command projectRoot', async () => {
+    mocks.runShellCommand.mockResolvedValue(SDK_51_CONFIG);
+
+    await getExpoMetadata(COMMAND_PARAMS);
+
+    expect(mocks.runShellCommand).toHaveBeenCalledWith({
+      command: 'npx --yes expo config --json',
+      projectRoot: '/tmp/project',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure modes - assert the user-facing message, not a raw throw
+// ---------------------------------------------------------------------------
+
+describe('getExpoMetadata - failure modes', () => {
+  it('surfaces an UNEXPECTED ERROR when the shell command exits non-zero', async () => {
+    const shellError: Error & { stderr?: string } = new Error(
+      'Command failed: npx --yes expo config --json'
+    );
+    shellError.stderr = 'expo: command not found';
+    mocks.runShellCommand.mockRejectedValue(shellError);
+
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow('UNEXPECTED ERROR');
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow(
+      'Command failed: npx --yes expo config --json'
+    );
+  });
+
+  it('reports a clear "Invalid ... output" message for non-JSON stdout (no parse leak)', async () => {
+    mocks.runShellCommand.mockResolvedValue('this is not json at all');
+
+    // The primary message is our own wrapper, not a raw "Unexpected token" throw.
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow(
+      'Invalid `npx --yes expo config --json` output'
+    );
+  });
+
+  it('reports a clear message when stdout is empty', async () => {
+    mocks.runShellCommand.mockResolvedValue('');
+
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow(
+      'Invalid `npx --yes expo config --json` output'
+    );
+  });
+
+  it('reports "`slug` property is missing" when slug is absent', async () => {
+    mocks.runShellCommand.mockResolvedValue(
+      JSON.stringify({ updates: { url: 'https://u.expo.dev/abc' } })
+    );
+
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow('`slug` property is missing');
+  });
+
+  it('reports "`updates.url` property is missing" when updates.url is absent', async () => {
+    mocks.runShellCommand.mockResolvedValue(JSON.stringify({ slug: 'my-app' }));
+
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow(
+      '`updates.url` property is missing'
+    );
+  });
+
+  it('reports "`updates.url` property is missing" when updates exists but url does not', async () => {
+    mocks.runShellCommand.mockResolvedValue(
+      JSON.stringify({ slug: 'my-app', updates: { fallbackToCacheTimeout: 0 } })
+    );
+
+    await expect(getExpoMetadata(COMMAND_PARAMS)).rejects.toThrow(
+      '`updates.url` property is missing'
+    );
+  });
+});

--- a/packages/cli/src/helpers/__tests__/getTokenParts.test.ts
+++ b/packages/cli/src/helpers/__tests__/getTokenParts.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Security-critical parsing tests for getTokenParts.
+ *
+ * getTokenParts is pure positional string slicing: the first
+ * PROJECT_API_TOKEN_LENGTH (32) chars are the apiToken, the next
+ * TEAM_ID_LENGTH (8) chars are the teamId, and everything after is the
+ * numeric projectIndex. A parsing bug here is cross-tenant data leakage, so we
+ * assert two properties:
+ *
+ *  1. Valid tokens slice to the CORRECT apiToken / teamId / projectIndex.
+ *  2. Truncated / malformed / boundary inputs FAIL CLOSED at the real
+ *     downstream gate (isValidToken) - they never route to a valid-looking
+ *     team/project. getTokenParts itself does not throw (it is pure slicing),
+ *     so we assert the observable field values plus isValidToken's verdict
+ *     rather than inventing a throw the code does not perform.
+ *
+ * The anti-mis-route property is also checked directly: appending garbage to a
+ * valid token must NOT shift the apiToken/teamId windows onto different bytes.
+ */
+import { describe, expect, it } from 'vitest';
+import { PROJECT_API_TOKEN_LENGTH, TEAM_ID_LENGTH } from '@sherlo/shared';
+import getTokenParts from '../getTokenParts';
+import isValidToken from '../isValidToken';
+
+// Distinct, single-char segments make any mis-slice visually obvious.
+const API = 'A'.repeat(PROJECT_API_TOKEN_LENGTH); // 32 × 'A'
+const TEAM = 'B'.repeat(TEAM_ID_LENGTH); //          8 × 'B'
+
+function makeToken(apiToken: string, teamId: string, index: string): string {
+  return `${apiToken}${teamId}${index}`;
+}
+
+// ---------------------------------------------------------------------------
+// Valid tokens route to the correct parts
+// ---------------------------------------------------------------------------
+
+describe('getTokenParts - valid tokens route correctly', () => {
+  const validCases: Array<{
+    name: string;
+    token: string;
+    expected: { apiToken: string; teamId: string; projectIndex: number };
+  }> = [
+    {
+      name: 'single-digit project index',
+      token: makeToken(API, TEAM, '1'),
+      expected: { apiToken: API, teamId: TEAM, projectIndex: 1 },
+    },
+    {
+      name: 'multi-digit project index',
+      token: makeToken(API, TEAM, '999'),
+      expected: { apiToken: API, teamId: TEAM, projectIndex: 999 },
+    },
+    {
+      name: 'real-world team id with underscore',
+      token: makeToken('abcdefghijklmnopqrstuvwxyzABCDEF', 'qA7_qHJ4', '30'),
+      expected: {
+        apiToken: 'abcdefghijklmnopqrstuvwxyzABCDEF',
+        teamId: 'qA7_qHJ4',
+        projectIndex: 30,
+      },
+    },
+    {
+      name: 'team id with dash',
+      token: makeToken('0123456789012345678901234567890X', 'Ab-Cd_Ef', '7'),
+      expected: {
+        apiToken: '0123456789012345678901234567890X',
+        teamId: 'Ab-Cd_Ef',
+        projectIndex: 7,
+      },
+    },
+  ];
+
+  for (const { name, token, expected } of validCases) {
+    it(`slices ${name} into the exact expected parts`, () => {
+      expect(getTokenParts(token)).toEqual(expected);
+    });
+
+    it(`accepts ${name} as a valid token (routable)`, () => {
+      expect(isValidToken(token)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Malformed / truncated tokens fail closed
+// ---------------------------------------------------------------------------
+
+describe('getTokenParts - malformed tokens fail closed (no silent mis-route)', () => {
+  const invalidCases: Array<{ name: string; token: string }> = [
+    { name: 'empty string', token: '' },
+    { name: 'truncated below apiToken length', token: 'A'.repeat(20) },
+    { name: 'exactly apiToken length (no teamId, no index)', token: API },
+    { name: 'apiToken + teamId but no project index', token: API + TEAM },
+    { name: 'non-numeric project index', token: makeToken(API, TEAM, 'xyz') },
+    { name: 'zero project index', token: makeToken(API, TEAM, '0') },
+    { name: 'negative project index', token: makeToken(API, TEAM, '-5') },
+    { name: 'decimal project index', token: makeToken(API, TEAM, '1.5') },
+    { name: 'non-numeric extra-long garbage', token: 'A'.repeat(120) },
+  ];
+
+  for (const { name, token } of invalidCases) {
+    it(`rejects ${name} at the isValidToken gate`, () => {
+      expect(isValidToken(token)).toBe(false);
+    });
+  }
+
+  it('empty string yields empty segments and a non-routable index (not NaN-accepted)', () => {
+    const parts = getTokenParts('');
+    expect(parts.apiToken).toBe('');
+    expect(parts.teamId).toBe('');
+    // Number('') === 0, which is < 1 and thus rejected by isValidToken.
+    expect(parts.projectIndex).toBe(0);
+    expect(isValidToken('')).toBe(false);
+  });
+
+  it('non-numeric project index parses to NaN and is never silently accepted', () => {
+    const token = makeToken(API, TEAM, 'xyz');
+    const parts = getTokenParts(token);
+    expect(Number.isNaN(parts.projectIndex)).toBe(true);
+    expect(isValidToken(token)).toBe(false);
+  });
+
+  it('missing project index leaves a valid apiToken/teamId but a zero (rejected) index', () => {
+    const token = API + TEAM;
+    const parts = getTokenParts(token);
+    expect(parts.apiToken).toBe(API);
+    expect(parts.teamId).toBe(TEAM);
+    expect(parts.projectIndex).toBe(0);
+    expect(isValidToken(token)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anti-mis-route: extra input never shifts the apiToken / teamId windows
+// ---------------------------------------------------------------------------
+
+describe('getTokenParts - windows never shift onto foreign bytes', () => {
+  const base = makeToken(API, TEAM, '7');
+
+  it('truncation keeps the apiToken window anchored at byte 0', () => {
+    // A short token can only ever expose a PREFIX of the apiToken window - it
+    // can never surface another tenant's teamId bytes.
+    const parts = getTokenParts('A'.repeat(20));
+    expect(parts.apiToken).toBe('A'.repeat(20));
+    expect(parts.teamId).toBe('');
+  });
+
+  it('appending garbage does not move the apiToken/teamId windows', () => {
+    const withJunk = base + 'GARBAGE';
+    const parts = getTokenParts(withJunk);
+
+    // The teamId window stays fixed on bytes 32-40 - appended bytes only ever
+    // corrupt the trailing projectIndex, never the tenant identity.
+    expect(parts.apiToken).toBe(API);
+    expect(parts.teamId).toBe(TEAM);
+    expect(Number.isNaN(parts.projectIndex)).toBe(true);
+    expect(isValidToken(withJunk)).toBe(false);
+  });
+
+  it('the teamId is always exactly bytes 32-40 of the input', () => {
+    const parts = getTokenParts(base);
+    expect(parts.teamId).toBe(
+      base.slice(PROJECT_API_TOKEN_LENGTH, PROJECT_API_TOKEN_LENGTH + TEAM_ID_LENGTH)
+    );
+  });
+});

--- a/packages/cli/src/helpers/__tests__/openBuildPayload.contract.test.ts
+++ b/packages/cli/src/helpers/__tests__/openBuildPayload.contract.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Contract tests for the openBuild payload assembled by
+ * uploadOrReuseBuildsAndRunTests - the CLI -> api "front door".
+ *
+ * Everything below the decision spine is stubbed (sdk-client, each helper
+ * module, diffScope, fingerprint) so we exercise ONLY the payload assembly and
+ * branch selection - no git, no S3, no network, no hashing.
+ *
+ * This file is deliberately named `openBuildPayload.contract.test.ts` so the
+ * future contract-fixtures ticket can find the exact openBuild wire shape here.
+ *
+ * getGitInfo is NOT re-tested here (it has a real-git suite); we stub it and
+ * assert its output flows verbatim into the payload.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted spies
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => {
+  const openBuild = vi.fn();
+  return {
+    openBuild,
+    sdkClient: vi.fn().mockReturnValue({ openBuild }),
+    getTokenParts: vi.fn(),
+    getValidatedBinariesInfoAndNextBuildIndex: vi.fn(),
+    uploadOrPrintBinaryReuse: vi.fn(),
+    getGitInfo: vi.fn(),
+    getBuildRunConfig: vi.fn(),
+    getAppBuildUrl: vi.fn(),
+    printBuildIntroMessage: vi.fn(),
+    printResultsUrl: vi.fn(),
+    handleClientError: vi.fn((error: unknown) => {
+      // Mirror the real helper's contract: it never swallows an error.
+      throw error;
+    }),
+    reporting: { addBreadcrumb: vi.fn(), setTag: vi.fn(), flush: vi.fn() },
+    computeChangedFiles: vi.fn(),
+    computeNativeFingerprint: vi.fn(),
+    computeBaseFingerprint: vi.fn(),
+    registerBase: vi.fn(),
+    waitForBuildResult: vi.fn(),
+    logWarning: vi.fn(),
+  };
+});
+
+vi.mock('@sherlo/sdk-client', () => ({ default: mocks.sdkClient }));
+vi.mock('../getTokenParts', () => ({ default: mocks.getTokenParts }));
+vi.mock('../getValidatedBinariesInfoAndNextBuildIndex', () => ({
+  default: mocks.getValidatedBinariesInfoAndNextBuildIndex,
+}));
+vi.mock('../uploadOrPrintBinaryReuse', () => ({ default: mocks.uploadOrPrintBinaryReuse }));
+vi.mock('../getGitInfo', () => ({ default: mocks.getGitInfo }));
+vi.mock('../getBuildRunConfig', () => ({ default: mocks.getBuildRunConfig }));
+vi.mock('../getAppBuildUrl', () => ({ default: mocks.getAppBuildUrl }));
+vi.mock('../printBuildIntroMessage', () => ({ default: mocks.printBuildIntroMessage }));
+vi.mock('../printResultsUrl', () => ({ default: mocks.printResultsUrl }));
+vi.mock('../handleClientError', () => ({ default: mocks.handleClientError }));
+vi.mock('../reporting', () => ({ default: mocks.reporting }));
+vi.mock('../logWarning', () => ({ default: mocks.logWarning }));
+vi.mock('../waitForBuildResult', () => ({ default: mocks.waitForBuildResult }));
+vi.mock('../diffScope', () => ({
+  computeChangedFiles: mocks.computeChangedFiles,
+  computeNativeFingerprint: mocks.computeNativeFingerprint,
+}));
+vi.mock('../fingerprint', () => ({
+  computeBaseFingerprint: mocks.computeBaseFingerprint,
+  registerBase: mocks.registerBase,
+}));
+
+import uploadOrReuseBuildsAndRunTests from '../uploadOrReuseBuildsAndRunTests';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Sentinels we assert flow through verbatim (identity where possible).
+const GIT_INFO = {
+  branchName: 'feature/my-pr',
+  commitHash: 'prhead1234',
+  commitName: 'feat: my changes',
+  isShallow: false,
+  isDirty: false,
+  mergeBaseSha: 'forkpoint789',
+};
+const BUILD_RUN_CONFIG = { __buildRunConfig: true } as any;
+
+const BINARIES_INFO = {
+  android: {
+    hash: 'android-hash',
+    fileName: 'app.apk',
+    s3Key: 'android-s3-key',
+    buildType: 'preview',
+  },
+  ios: { hash: 'ios-hash', fileName: 'app.app', s3Key: 'ios-s3-key', buildType: 'preview' },
+  sdkVersion: '2.0.0',
+};
+
+const COMMAND_PARAMS = {
+  projectRoot: '/proj',
+  token: 'the-token',
+  android: '/builds/app.apk',
+  ios: '/builds/app.app',
+  message: 'my build message',
+  gitBranch: 'flag-branch',
+  fullRun: false,
+  wait: false,
+  waitTimeout: undefined,
+  devices: [],
+} as any;
+
+function callSubject(overrides: { easUpdateData?: any } = {}) {
+  return uploadOrReuseBuildsAndRunTests({
+    commandParams: COMMAND_PARAMS,
+    easUpdateData: overrides.easUpdateData,
+  });
+}
+
+function lastOpenBuildPayload() {
+  return mocks.openBuild.mock.calls[0][0];
+}
+
+// ---------------------------------------------------------------------------
+// Default happy-path wiring (each test may override individual stubs)
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mocks.getTokenParts.mockReturnValue({ apiToken: 'api-tok', projectIndex: 7, teamId: 'team1234' });
+  mocks.getValidatedBinariesInfoAndNextBuildIndex.mockResolvedValue({
+    binariesInfo: BINARIES_INFO,
+    nextBuildIndex: 3,
+  });
+  mocks.uploadOrPrintBinaryReuse.mockResolvedValue(undefined);
+  mocks.getGitInfo.mockResolvedValue(GIT_INFO);
+  mocks.getBuildRunConfig.mockReturnValue(BUILD_RUN_CONFIG);
+  mocks.computeChangedFiles.mockResolvedValue({ changedFiles: ['src/Button.tsx'] });
+  mocks.computeNativeFingerprint.mockResolvedValue('native-fp');
+  mocks.computeBaseFingerprint.mockResolvedValue({ hash: null });
+  mocks.registerBase.mockResolvedValue({ gateMetadata: undefined });
+  mocks.getAppBuildUrl.mockReturnValue('https://app.sherlo.io/team1234/7/build/42');
+  mocks.openBuild.mockResolvedValue({ build: { index: 42 } });
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// openBuild payload shape
+// ---------------------------------------------------------------------------
+
+describe('openBuild payload - core shape', () => {
+  it('assembles the exact payload from token parts, binaries, git and diff scope', async () => {
+    await callSubject();
+
+    expect(mocks.openBuild).toHaveBeenCalledTimes(1);
+    const payload = lastOpenBuildPayload();
+
+    expect(payload).toMatchObject({
+      teamId: 'team1234',
+      projectIndex: 7,
+      binaryHashes: { android: 'android-hash', ios: 'ios-hash' },
+      binaryFileNames: { android: 'app.apk', ios: 'app.app' },
+      sdkVersion: '2.0.0',
+      message: 'my build message',
+      changedFiles: ['src/Button.tsx'],
+      nativeFingerprint: 'native-fp',
+    });
+    // buildRunConfig + gitInfo flow through by identity (no reshaping).
+    expect(payload.buildRunConfig).toBe(BUILD_RUN_CONFIG);
+    expect(payload.gitInfo).toBe(GIT_INFO);
+  });
+
+  it('forwards the full GitInfo object verbatim (passthrough, no reshaping)', async () => {
+    await callSubject();
+    expect(lastOpenBuildPayload().gitInfo).toBe(GIT_INFO);
+  });
+
+  it('returns the app build url from getAppBuildUrl', async () => {
+    await expect(callSubject()).resolves.toEqual({
+      url: 'https://app.sherlo.io/team1234/7/build/42',
+    });
+    expect(mocks.getAppBuildUrl).toHaveBeenCalledWith({
+      buildIndex: 42,
+      projectIndex: 7,
+      teamId: 'team1234',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional baseFingerprint / gateMetadata spread - BOTH branches
+// ---------------------------------------------------------------------------
+
+describe('openBuild payload - baseFingerprint/gateMetadata spread', () => {
+  it('OMITS baseFingerprint and gateMetadata when no base fingerprint is available', async () => {
+    mocks.computeBaseFingerprint.mockResolvedValue({ hash: null });
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect(payload).not.toHaveProperty('baseFingerprint');
+    expect(payload).not.toHaveProperty('gateMetadata');
+  });
+
+  it('INCLUDES baseFingerprint and per-platform gateMetadata when a base fingerprint exists', async () => {
+    mocks.computeBaseFingerprint.mockResolvedValue({ hash: 'base-fp-hash' });
+    mocks.registerBase.mockResolvedValue({ gateMetadata: { engineClass: 'hermes' } });
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect(payload.baseFingerprint).toBe('base-fp-hash');
+    // Both platforms are present + requested, so both carry gate metadata.
+    expect(payload.gateMetadata).toEqual({
+      android: { engineClass: 'hermes' },
+      ios: { engineClass: 'hermes' },
+    });
+  });
+
+  it('still includes baseFingerprint with empty gateMetadata when registerBase yields none', async () => {
+    mocks.computeBaseFingerprint.mockResolvedValue({ hash: 'base-fp-hash' });
+    mocks.registerBase.mockResolvedValue({ gateMetadata: undefined });
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect(payload.baseFingerprint).toBe('base-fp-hash');
+    expect(payload.gateMetadata).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Diff scope pass-through
+// ---------------------------------------------------------------------------
+
+describe('openBuild payload - diff scope', () => {
+  it('omits changedFiles (bail-to-full) but still sends nativeFingerprint', async () => {
+    mocks.computeChangedFiles.mockResolvedValue({
+      fullRun: true,
+      reason: 'shallow clone: ancestry is grafted',
+    });
+    mocks.computeNativeFingerprint.mockResolvedValue('native-fp');
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect(payload.changedFiles).toBeUndefined();
+    expect(payload.nativeFingerprint).toBe('native-fp');
+  });
+
+  it('sends undefined nativeFingerprint when fingerprint is unavailable', async () => {
+    mocks.computeNativeFingerprint.mockResolvedValue(null);
+
+    await callSubject();
+    expect(lastOpenBuildPayload().nativeFingerprint).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reuse-vs-upload decision + s3 key wiring
+// ---------------------------------------------------------------------------
+
+describe('reuse-vs-upload branch selection', () => {
+  it('delegates the reuse/upload decision to uploadOrPrintBinaryReuse with binaries + platform paths', async () => {
+    await callSubject();
+
+    expect(mocks.uploadOrPrintBinaryReuse).toHaveBeenCalledWith({
+      binariesInfo: BINARIES_INFO,
+      projectRoot: '/proj',
+      android: '/builds/app.apk',
+      ios: '/builds/app.app',
+    });
+  });
+
+  it('wires the per-platform binary s3 keys into getBuildRunConfig', async () => {
+    await callSubject();
+
+    expect(mocks.getBuildRunConfig).toHaveBeenCalledWith({
+      commandParams: COMMAND_PARAMS,
+      binaryS3Keys: { android: 'android-s3-key', ios: 'ios-s3-key' },
+      easUpdateData: undefined,
+    });
+  });
+
+  it('carries the binary hashes (the reuse key) into the openBuild payload', async () => {
+    await callSubject();
+    expect(lastOpenBuildPayload().binaryHashes).toEqual({
+      android: 'android-hash',
+      ios: 'ios-hash',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error propagation from each stubbed stage
+// ---------------------------------------------------------------------------
+
+describe('error propagation', () => {
+  it('propagates a failure from getValidatedBinariesInfoAndNextBuildIndex', async () => {
+    mocks.getValidatedBinariesInfoAndNextBuildIndex.mockRejectedValue(
+      new Error('binaries validation failed')
+    );
+
+    await expect(callSubject()).rejects.toThrow('binaries validation failed');
+    expect(mocks.openBuild).not.toHaveBeenCalled();
+  });
+
+  it('propagates a failure from getGitInfo', async () => {
+    mocks.getGitInfo.mockRejectedValue(new Error('git info failed'));
+
+    await expect(callSubject()).rejects.toThrow('git info failed');
+    expect(mocks.openBuild).not.toHaveBeenCalled();
+  });
+
+  it('routes an openBuild rejection through handleClientError (which rethrows)', async () => {
+    mocks.openBuild.mockRejectedValue(new Error('openBuild network error'));
+
+    await expect(callSubject()).rejects.toThrow('openBuild network error');
+    expect(mocks.handleClientError).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1729

## TL;DR

The testing audit's Gap 4: the CLI's front door has zero tests below e2e. uploadOrReuseBuildsAndRunTests (binary hashing, S3 multipart upload/reuse, openBuild payload assembly, getGitInfo), getExpoMetadata (the EXACT function class behind SHERLO-1680 - npx expo config --json parsing that broke every dev push for a night), the eas-build-on-complete hook (getBuildPath reading eas.json, asyncUploadBuildAndRunTests), and getTokenParts (composite token -> team/project routing where a parsing bug is cross-tenant data leakage). Add deterministic vitest coverage with stubbed shell/network: fixture outputs for expo config across multiple expo versions, recorded openBuild payload shapes, tmp-dir filesystem fixtures per the repo's existing test conventions.

## Acceptance Criteria

- getExpoMetadata: table-driven tests against FIXTURE outputs of npx expo config --json from at least expo SDK 50/51/52 shapes plus the failure modes (non-zero exit, malformed JSON, missing slug, missing updates.url) - each failure mode asserting the user-facing error, not a stack trace; the ExpoConfigLoader invocation itself stubbed
- uploadOrReuseBuildsAndRunTests: unit coverage of the decision spine with stubbed S3/network - binary hashing determinism, reuse-vs-upload branch on matching hashes, openBuild payload assembly (gitInfo, binaryHashes, sdkVersion, baseFingerprint/gateMetadata pass-through), and error propagation from each stage; assert the exact payload shape sent (this is the CLI->api contract surface)
- eas-build-on-complete: getBuildPath against fixture eas.json shapes (profile present/absent, custom paths) + the hook's happy path and its loud-failure paths with stubbed upload
- getTokenParts: table-driven matrix - valid tokens route to the right team/project, truncated/malformed/wrong-segment-count tokens fail CLOSED with clear errors, and boundary cases (empty segments, non-base64 garbage) never mis-route
- All tests deterministic (no network, no real expo/eas invocations, tmp-dir fixtures per the showError.test.ts conventions); pr_checks (cli) green
- No production code changes unless a test reveals an actual defect - if one is found, STOP and file it separately with the failing case (getTokenParts especially: any mis-route finding is a Highest security ticket)

## Additional Context

## Context (strategy audit Gap 4 - artifact aed24972; ledger: SHERLO-1680 cost a full overnight)

A bad CLI publish breaks every customer's CI at once, and the publish workflow runs only the unit suites - so what the unit suites cover IS the publish gate. Today the covered set excludes the entire core flow. This ticket makes the front door publish-gated.

## Notes

- Follow packages/cli's existing test conventions (vitest, __tests__ dirs, tmp-dir fixtures as in writeMetroConfigUpdate.test.ts)
- The openBuild payload-shape assertions double as the CLI side of the future contract-fixtures work - name the test file so the contract ticket can find it (e.g. openBuildPayload.contract.test.ts)
- Do NOT touch the staged-feature fingerprint modules beyond what payload pass-through requires - that surface is owned by SHERLO-1682's tests

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
