### PR TITLE
feat: [Phase 2] Metro layer: mock key scan, shim emission, resolve…

### DIFF
--- a/packages/react-native-storybook/metro/applySherloTransforms.js
+++ b/packages/react-native-storybook/metro/applySherloTransforms.js
@@ -3,6 +3,8 @@
 var fs = require('fs');
 var path = require('path');
 
+var mockShims = require('./mockShims');
+
 // ---------------------------------------------------------------------------
 // Dependency graph sidecar (Diff Scope Phase 2)
 // ---------------------------------------------------------------------------
@@ -173,25 +175,72 @@ function applySherloTransforms(result, opts) {
   // cacheDir is the same directory that wrapperPath lives in; already created by generateWrapper().
   var cacheDir = path.dirname(wrapperPath);
 
+  // ---- Module Mocking (SHERLO-1734 Phase 2) ----
+  // Gated entirely behind enabled !== false (EB-01): when disabled we scan
+  // nothing, emit no shims, and install no resolver branch.
+  var mockingEnabled = !(opts && opts.enabled === false);
+  var mocksDir = null;
+  var mockedPathToShim = null;
+  if (mockingEnabled) {
+    var mockSetup = mockShims.setupMocks({
+      projectRoot: projectRoot,
+      cacheDir: cacheDir,
+      mockModules: opts && opts.mockModules,
+    });
+    mocksDir = mockSetup.mocksDir;
+    mockedPathToShim = mockSetup.mockedPathToShim;
+  }
+
+  // True when a module path lives inside the emitted mocks directory. Requests
+  // originating from a shim must NEVER be redirected back into a shim, otherwise
+  // the shim's own require(real) would loop onto itself.
+  function isShimPath(absPath) {
+    return !!absPath && !!mocksDir && absPath.indexOf(mocksDir + path.sep) === 0;
+  }
+
   var existingResolveRequest =
     result && result.resolver && result.resolver.resolveRequest
       ? result.resolver.resolveRequest
       : null;
 
+  function delegateResolve(context, moduleName, platform) {
+    return existingResolveRequest
+      ? existingResolveRequest(context, moduleName, platform)
+      : context.resolveRequest(context, moduleName, platform);
+  }
+
   function resolveRequest(context, moduleName, platform) {
     if (context.originModulePath === wrapperPath) {
-      return existingResolveRequest
-        ? existingResolveRequest(context, moduleName, platform)
-        : context.resolveRequest(context, moduleName, platform);
+      return delegateResolve(context, moduleName, platform);
     }
 
     if (moduleName === '@storybook/react-native') {
       return { type: 'sourceFile', filePath: wrapperPath };
     }
 
-    return existingResolveRequest
-      ? existingResolveRequest(context, moduleName, platform)
-      : context.resolveRequest(context, moduleName, platform);
+    var resolution = delegateResolve(context, moduleName, platform);
+
+    // Delegate-first mock redirect: once the real request has resolved, redirect
+    // to the shim when the resolved absolute path belongs to a mocked module and
+    // the importer is not itself a shim (MK-01..04, MK-08).
+    if (
+      mockingEnabled &&
+      mockedPathToShim &&
+      mockedPathToShim.size > 0 &&
+      resolution &&
+      resolution.type === 'sourceFile' &&
+      resolution.filePath &&
+      !isShimPath(context.originModulePath)
+    ) {
+      var shimPath = mockedPathToShim.get(
+        mockShims.canonicalizeModulePath(resolution.filePath)
+      );
+      if (shimPath && shimPath !== resolution.filePath) {
+        return { type: 'sourceFile', filePath: shimPath };
+      }
+    }
+
+    return resolution;
   }
 
   var polyfillPath = path.join(__dirname, 'polyfill.js');

--- a/packages/react-native-storybook/metro/mockScan.js
+++ b/packages/react-native-storybook/metro/mockScan.js
@@ -1,0 +1,229 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Module Mocking - config-time scan (SHERLO-1734 Phase 2, MK-09)
+// ---------------------------------------------------------------------------
+//
+// A single, self-contained module that answers one question: which module keys
+// does the app declare under `parameters.sherlo.mocks`?
+//
+// It does two things and nothing more:
+//   1. findScanFiles(projectRoot)  - locate story files and preview.* files.
+//   2. collectMockKeysFromSource() - shallow-parse one file with the Babel
+//      parser Metro already ships and return the STRING-LITERAL keys declared
+//      under any `sherlo: { mocks: { ... } }` object.
+//
+// Deliberately narrow: it extracts string-literal KEYS only. It never reads,
+// evaluates, or otherwise touches the mock VALUES - those live entirely in the
+// Phase 1 runtime. Tolerant of TypeScript `as`/`satisfies` annotations wrapped
+// around the parameters object (or any node on the way down).
+
+var fs = require('fs');
+var path = require('path');
+
+// The Babel parser Metro already depends on. Fall back across the couple of
+// module ids it has shipped under so we never take a hard dependency Metro
+// itself does not already satisfy.
+function getBabelParser() {
+  try {
+    return require('@babel/parser');
+  } catch (_) {
+    return require('metro-babel-transformer/node_modules/@babel/parser');
+  }
+}
+
+// Directories that never contain first-party story/preview sources. Skipping
+// them keeps the scan fast and avoids descending into installed packages.
+var IGNORED_DIRS = {
+  node_modules: true,
+  '.git': true,
+  '.cache': true,
+  dist: true,
+  build: true,
+  ios: true,
+  android: true,
+  '.expo': true,
+};
+
+var SOURCE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
+
+// A file is a scan target when it is a Storybook story (`*.stories.<ext>`) or a
+// Storybook preview entry (`preview.<ext>`, e.g. .storybook/preview.tsx).
+function isScanTarget(fileName) {
+  var ext = path.extname(fileName);
+  if (SOURCE_EXTENSIONS.indexOf(ext) === -1) return false;
+  var base = fileName.slice(0, -ext.length);
+  return base === 'preview' || base.slice(-8) === '.stories';
+}
+
+// Recursively collect absolute paths of every story/preview file under
+// projectRoot, skipping IGNORED_DIRS. Filesystem errors on a single entry are
+// swallowed so one unreadable directory never fails the whole build.
+function findScanFiles(projectRoot) {
+  var found = [];
+
+  function walk(dir) {
+    var entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (_) {
+      return;
+    }
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      var full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS[entry.name]) walk(full);
+      } else if (entry.isFile() && isScanTarget(entry.name)) {
+        found.push(full);
+      }
+    }
+  }
+
+  walk(projectRoot);
+  return found;
+}
+
+// Strip TypeScript-only expression wrappers so we can see the ObjectExpression
+// underneath `x satisfies T`, `x as T`, `<T>x`, `x!`, and `(x)`.
+function unwrapExpression(node) {
+  while (
+    node &&
+    (node.type === 'TSAsExpression' ||
+      node.type === 'TSSatisfiesExpression' ||
+      node.type === 'TSNonNullExpression' ||
+      node.type === 'TSTypeAssertion' ||
+      node.type === 'ParenthesizedExpression')
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+// The static name of an object property key, for Identifier and StringLiteral
+// keys only. Computed / numeric keys return null.
+function propertyName(prop) {
+  if (!prop.key) return null;
+  if (prop.key.type === 'Identifier' && !prop.computed) return prop.key.name;
+  if (prop.key.type === 'StringLiteral') return prop.key.value;
+  return null;
+}
+
+// Collect the STRING-LITERAL keys of a `mocks: { ... }` object. Identifier,
+// numeric, computed, and spread keys are intentionally ignored - module
+// specifiers are always string literals, and this keeps the contract simple.
+function collectKeysFromMocksObject(mocksObject, out) {
+  var props = mocksObject.properties || [];
+  for (var i = 0; i < props.length; i++) {
+    var prop = props[i];
+    if (
+      (prop.type === 'ObjectProperty' || prop.type === 'ObjectMethod') &&
+      prop.key &&
+      prop.key.type === 'StringLiteral' &&
+      !prop.computed
+    ) {
+      out.add(prop.key.value);
+    }
+  }
+}
+
+// Walk the AST looking for any `sherlo: { mocks: { ... } }` shape and harvest
+// the string-literal keys of every `mocks` object we find. Runs for both
+// meta-level and story-level parameter declarations because it visits the whole
+// tree; TS wrappers on any value are unwrapped on the way down.
+function walkForMockKeys(node, out) {
+  if (!node || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (var i = 0; i < node.length; i++) walkForMockKeys(node[i], out);
+    return;
+  }
+
+  if (typeof node.type !== 'string') return;
+
+  if (node.type === 'ObjectExpression') {
+    var props = node.properties || [];
+    for (var p = 0; p < props.length; p++) {
+      var prop = props[p];
+      if (prop.type !== 'ObjectProperty' || propertyName(prop) !== 'sherlo') continue;
+
+      var sherloObject = unwrapExpression(prop.value);
+      if (!sherloObject || sherloObject.type !== 'ObjectExpression') continue;
+
+      var sherloProps = sherloObject.properties || [];
+      for (var s = 0; s < sherloProps.length; s++) {
+        var sherloProp = sherloProps[s];
+        if (sherloProp.type !== 'ObjectProperty' || propertyName(sherloProp) !== 'mocks') continue;
+
+        var mocksObject = unwrapExpression(sherloProp.value);
+        if (mocksObject && mocksObject.type === 'ObjectExpression') {
+          collectKeysFromMocksObject(mocksObject, out);
+        }
+      }
+    }
+  }
+
+  // Recurse into every child node, skipping metadata that cannot hold keys.
+  for (var key in node) {
+    if (
+      key === 'loc' ||
+      key === 'start' ||
+      key === 'end' ||
+      key === 'range' ||
+      key === 'leadingComments' ||
+      key === 'trailingComments' ||
+      key === 'innerComments'
+    ) {
+      continue;
+    }
+    walkForMockKeys(node[key], out);
+  }
+}
+
+// Parse one file's source and return the distinct string-literal mock keys it
+// declares. Parse failures are non-fatal: a malformed file simply yields no
+// keys rather than breaking the Metro config.
+function collectMockKeysFromSource(source) {
+  var parser = getBabelParser();
+  var ast;
+  try {
+    ast = parser.parse(source, {
+      sourceType: 'unambiguous',
+      errorRecovery: true,
+      plugins: ['typescript', 'jsx'],
+    });
+  } catch (_) {
+    return [];
+  }
+  var out = new Set();
+  walkForMockKeys(ast.program || ast, out);
+  return Array.from(out);
+}
+
+// Scan every story/preview file under projectRoot and return a Map of
+// mockKey -> the first file that declared it (used for FG-01 error messages).
+function scanProjectForMockKeys(projectRoot) {
+  var keyToFile = new Map();
+  var files = findScanFiles(projectRoot);
+  for (var i = 0; i < files.length; i++) {
+    var file = files[i];
+    var source;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch (_) {
+      continue;
+    }
+    var keys = collectMockKeysFromSource(source);
+    for (var k = 0; k < keys.length; k++) {
+      if (!keyToFile.has(keys[k])) keyToFile.set(keys[k], file);
+    }
+  }
+  return keyToFile;
+}
+
+module.exports = {
+  findScanFiles: findScanFiles,
+  isScanTarget: isScanTarget,
+  collectMockKeysFromSource: collectMockKeysFromSource,
+  scanProjectForMockKeys: scanProjectForMockKeys,
+};

--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -36,16 +36,15 @@ var CREATE_MOCKABLE_SPECIFIER = '@sherlo/react-native-storybook/mocking';
 var PLATFORM_SUFFIXES = ['ios', 'android', 'native', 'web'];
 
 // A deny-list entry is either an exact specifier ('react') or a scope glob
-// ('@storybook/*'). The glob matches the bare scope and anything under it.
+// ('@storybook/*'). Both forms deny the entry itself AND everything under it, so
+// 'react/jsx-runtime' and 'react-native/Libraries/Core/InitializeCore' are
+// denied via their 'react'/'react-native' roots (FG-02). A non-denied lookalike
+// like 'react-native-svg' is NOT matched because the '/' boundary is required.
 function isDeniedKey(key) {
   for (var i = 0; i < MOCK_DENY_LIST.length; i++) {
     var entry = MOCK_DENY_LIST[i];
-    if (entry.slice(-2) === '/*') {
-      var scope = entry.slice(0, -2);
-      if (key === scope || key.indexOf(scope + '/') === 0) return true;
-    } else if (key === entry) {
-      return true;
-    }
+    var base = entry.slice(-2) === '/*' ? entry.slice(0, -2) : entry;
+    if (key === base || key.indexOf(base + '/') === 0) return true;
   }
   return false;
 }
@@ -105,6 +104,17 @@ function resolveAppModuleFile(basePath) {
   return null;
 }
 
+// Build the app-module resolution result shared by the './'-prefixed and the
+// dotless project-root-relative branches: canonical identity and require
+// specifier are the same realpath-normalised, extensionless absolute path so
+// Metro re-resolves the platform-split file per platform.
+function appModuleResult(file) {
+  return {
+    canonicalRealPath: canonicalizeModulePath(file),
+    requireSpecifier: canonicalizeModulePath(file),
+  };
+}
+
 // Resolve one mock key to:
 //   - canonicalRealPath: the identity the resolver matches delegate output on,
 //   - requireSpecifier:  what the shim's inner require() targets. Bare package
@@ -113,21 +123,30 @@ function resolveAppModuleFile(basePath) {
 //     the platform-split file per platform.
 // Throws when the key cannot be resolved (FG-01).
 function resolveMockKey(key, projectRoot) {
+  // Explicit './'-prefixed or absolute keys are always app modules.
   if (isRelativeOrAbsolute(key)) {
     var basePath = path.resolve(projectRoot, key);
     var file = resolveAppModuleFile(basePath);
     if (!file) throw new Error('cannot resolve app module');
-    return {
-      canonicalRealPath: canonicalizeModulePath(file),
-      requireSpecifier: canonicalizeModulePath(file),
-    };
+    return appModuleResult(file);
   }
 
-  var resolved = require.resolve(key, { paths: [projectRoot] });
-  return {
-    canonicalRealPath: canonicalizeModulePath(resolved),
-    requireSpecifier: key,
-  };
+  // Otherwise the key is a bare specifier. Try node_modules resolution FIRST so
+  // MK-03 subpath packages ('pkg/submodule') keep their runtime bare-specifier
+  // semantics. Only when that fails do we treat the key as a DOTLESS
+  // project-root-relative app module ('src/api/client'), matching the epic's
+  // canonical app-module key form. FG-01 fires only when both routes fail.
+  try {
+    var resolved = require.resolve(key, { paths: [projectRoot] });
+    return {
+      canonicalRealPath: canonicalizeModulePath(resolved),
+      requireSpecifier: key,
+    };
+  } catch (_) {
+    var appFile = resolveAppModuleFile(path.resolve(projectRoot, key));
+    if (appFile) return appModuleResult(appFile);
+    throw new Error('cannot resolve mock key');
+  }
 }
 
 // Deterministic shim filename: a short hash of the key. Same key -> same file,

--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -1,0 +1,257 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Module Mocking - shim emission + resolver map (SHERLO-1734 Phase 2)
+// ---------------------------------------------------------------------------
+//
+// Given the set of mock keys (from mockScan + the `mockModules` escape hatch),
+// this module:
+//   1. rejects deny-listed keys (FG-02),
+//   2. resolves each key to an absolute real-module path (FG-01),
+//   3. writes one deterministic one-line shim per key under <cacheDir>/mocks/,
+//   4. returns an in-memory `canonical real path -> shim path` map that the
+//      resolver uses to redirect matched requests.
+//
+// The shim is exactly one `createMockable` call requiring the real module. It
+// requires createMockable from the installed/compiled Sherlo package (never the
+// TS source) so it runs correctly at bundle time.
+
+var crypto = require('crypto');
+var fs = require('fs');
+var path = require('path');
+
+var scan = require('./mockScan');
+
+// Mirror of src/mocking/denyList.ts MOCK_DENY_LIST. Kept as a literal here
+// because this file runs at Metro-config time (plain JS, before any tsc build);
+// a unit test asserts it stays in sync with the TypeScript source of truth.
+var MOCK_DENY_LIST = ['react', 'react-native', '@storybook/*', '@sherlo/*'];
+
+// The specifier the emitted shim uses to reach createMockable. Points at the
+// package's `./mocking` export (compiled dist), which resolves from anywhere in
+// the dependency tree - including from inside <cacheDir>/mocks/.
+var CREATE_MOCKABLE_SPECIFIER = '@sherlo/react-native-storybook/mocking';
+
+// Platform suffixes Metro layers on top of the base extension.
+var PLATFORM_SUFFIXES = ['ios', 'android', 'native', 'web'];
+
+// A deny-list entry is either an exact specifier ('react') or a scope glob
+// ('@storybook/*'). The glob matches the bare scope and anything under it.
+function isDeniedKey(key) {
+  for (var i = 0; i < MOCK_DENY_LIST.length; i++) {
+    var entry = MOCK_DENY_LIST[i];
+    if (entry.slice(-2) === '/*') {
+      var scope = entry.slice(0, -2);
+      if (key === scope || key.indexOf(scope + '/') === 0) return true;
+    } else if (key === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isRelativeOrAbsolute(key) {
+  return key.charAt(0) === '.' || path.isAbsolute(key);
+}
+
+// Reduce an absolute module path to a platform/extension-independent identity so
+// that Button.tsx, Button.ios.tsx, and Button.android.tsx all collapse to the
+// same key. This is what lets ONE shim match a module across every platform.
+//
+// The path is first passed through realpathSync so both sides of the resolver
+// comparison agree even when symlinks are involved (require.resolve follows
+// symlinks; a workspace/pnpm node_modules layout or a /tmp symlink would
+// otherwise make the config-time identity and the runtime identity diverge).
+// Non-existent paths fall back to the raw path unchanged.
+function canonicalizeModulePath(absPath) {
+  var real = absPath;
+  try {
+    real = fs.realpathSync(absPath);
+  } catch (_) {
+    /* path may not exist (e.g. unit tests on synthetic paths); use it as-is */
+  }
+  var ext = path.extname(real);
+  if (!ext) return real;
+  var base = real.slice(0, -ext.length);
+  var maybePlatform = path.extname(base);
+  if (maybePlatform && PLATFORM_SUFFIXES.indexOf(maybePlatform.slice(1)) !== -1) {
+    base = base.slice(0, -maybePlatform.length);
+  }
+  return base;
+}
+
+// Find a concrete file for a relative/absolute app-module base path, trying the
+// bare extensions, the platform-split variants, and the directory index form.
+// Returns the found absolute file path, or null when nothing exists.
+function resolveAppModuleFile(basePath) {
+  var extensions = ['.tsx', '.ts', '.jsx', '.js'];
+
+  var candidates = [];
+  for (var e = 0; e < extensions.length; e++) {
+    candidates.push(basePath + extensions[e]);
+    for (var p = 0; p < PLATFORM_SUFFIXES.length; p++) {
+      candidates.push(basePath + '.' + PLATFORM_SUFFIXES[p] + extensions[e]);
+    }
+    candidates.push(path.join(basePath, 'index' + extensions[e]));
+  }
+
+  for (var c = 0; c < candidates.length; c++) {
+    try {
+      if (fs.statSync(candidates[c]).isFile()) return candidates[c];
+    } catch (_) {
+      /* keep looking */
+    }
+  }
+  return null;
+}
+
+// Resolve one mock key to:
+//   - canonicalRealPath: the identity the resolver matches delegate output on,
+//   - requireSpecifier:  what the shim's inner require() targets. Bare package
+//     keys keep their specifier so Metro re-resolves per platform (MK-06);
+//     app-module keys use the extensionless absolute path so Metro re-resolves
+//     the platform-split file per platform.
+// Throws when the key cannot be resolved (FG-01).
+function resolveMockKey(key, projectRoot) {
+  if (isRelativeOrAbsolute(key)) {
+    var basePath = path.resolve(projectRoot, key);
+    var file = resolveAppModuleFile(basePath);
+    if (!file) throw new Error('cannot resolve app module');
+    return {
+      canonicalRealPath: canonicalizeModulePath(file),
+      requireSpecifier: canonicalizeModulePath(file),
+    };
+  }
+
+  var resolved = require.resolve(key, { paths: [projectRoot] });
+  return {
+    canonicalRealPath: canonicalizeModulePath(resolved),
+    requireSpecifier: key,
+  };
+}
+
+// Deterministic shim filename: a short hash of the key. Same key -> same file,
+// so shim content only changes when the key set changes.
+function shimFileName(key) {
+  var hash = crypto.createHash('sha1').update(key).digest('hex').slice(0, 16);
+  return 'mock-' + hash + '.js';
+}
+
+// The one-line shim body: a single createMockable call requiring the real
+// module. requireSpecifier is emitted as a require() so Metro (not us) does the
+// real resolution at bundle time - which re-resolves platform-split files.
+function generateShimContent(key, requireSpecifier) {
+  return (
+    "'use strict';\n" +
+    'module.exports = require(' +
+    JSON.stringify(CREATE_MOCKABLE_SPECIFIER) +
+    ').createMockable(' +
+    JSON.stringify(key) +
+    ', require(' +
+    JSON.stringify(requireSpecifier) +
+    '));\n'
+  );
+}
+
+// Build the complete mock setup for a config run.
+//
+// Returns { mocksDir, mockedPathToShim, shimPaths }:
+//   - mockedPathToShim: Map<canonicalRealPath, shimAbsolutePath> for the resolver.
+//   - shimPaths:        every emitted shim path (for tests / diagnostics).
+//
+// Side effect: the <cacheDir>/mocks/ directory is rewritten to contain exactly
+// the current key set's shims (stale shims from prior runs are removed).
+//
+// opts: { projectRoot, cacheDir, mockModules, scanFiles }
+//   - scanFiles is an optional explicit list of files to scan (tests); when
+//     omitted the whole project is scanned.
+function setupMocks(opts) {
+  var projectRoot = opts.projectRoot;
+  var cacheDir = opts.cacheDir;
+  var mockModules = Array.isArray(opts.mockModules) ? opts.mockModules : [];
+
+  // 1. Collect keys: static scan + the mockModules escape hatch (MK-10).
+  var keyToSource = opts.scanFiles
+    ? scanFilesToKeyMap(opts.scanFiles)
+    : scan.scanProjectForMockKeys(projectRoot);
+  for (var m = 0; m < mockModules.length; m++) {
+    if (!keyToSource.has(mockModules[m])) {
+      keyToSource.set(mockModules[m], '<mockModules option>');
+    }
+  }
+
+  // 2. Enforce the deny list (FG-02).
+  keyToSource.forEach(function (source, key) {
+    if (isDeniedKey(key)) {
+      throw new Error(
+        '[Sherlo] Cannot mock "' +
+          key +
+          '" (declared in ' +
+          source +
+          '): this module is on the mock deny list because mocking it would break ' +
+          "Storybook's own runtime. Mock a thin wrapper module you own that re-exports it instead."
+      );
+    }
+  });
+
+  // 3. Rewrite the mocks directory from scratch so no stale shims survive.
+  var mocksDir = path.join(cacheDir, 'mocks');
+  fs.rmSync(mocksDir, { recursive: true, force: true });
+  fs.mkdirSync(mocksDir, { recursive: true });
+
+  // 4. Resolve each key (FG-01) and emit its shim.
+  var mockedPathToShim = new Map();
+  var shimPaths = [];
+
+  keyToSource.forEach(function (source, key) {
+    var resolved;
+    try {
+      resolved = resolveMockKey(key, projectRoot);
+    } catch (_) {
+      throw new Error(
+        '[Sherlo] Cannot resolve mocked module "' +
+          key +
+          '" declared in ' +
+          source +
+          '. Check the module specifier is spelled correctly and installed.'
+      );
+    }
+
+    var shimPath = path.join(mocksDir, shimFileName(key));
+    fs.writeFileSync(shimPath, generateShimContent(key, resolved.requireSpecifier), 'utf8');
+
+    mockedPathToShim.set(resolved.canonicalRealPath, shimPath);
+    shimPaths.push(shimPath);
+  });
+
+  return { mocksDir: mocksDir, mockedPathToShim: mockedPathToShim, shimPaths: shimPaths };
+}
+
+// Scan an explicit list of files into a key -> source-file Map (test entry).
+function scanFilesToKeyMap(files) {
+  var keyToFile = new Map();
+  for (var i = 0; i < files.length; i++) {
+    var source;
+    try {
+      source = fs.readFileSync(files[i], 'utf8');
+    } catch (_) {
+      continue;
+    }
+    var keys = scan.collectMockKeysFromSource(source);
+    for (var k = 0; k < keys.length; k++) {
+      if (!keyToFile.has(keys[k])) keyToFile.set(keys[k], files[i]);
+    }
+  }
+  return keyToFile;
+}
+
+module.exports = {
+  MOCK_DENY_LIST: MOCK_DENY_LIST,
+  CREATE_MOCKABLE_SPECIFIER: CREATE_MOCKABLE_SPECIFIER,
+  isDeniedKey: isDeniedKey,
+  canonicalizeModulePath: canonicalizeModulePath,
+  resolveMockKey: resolveMockKey,
+  shimFileName: shimFileName,
+  generateShimContent: generateShimContent,
+  setupMocks: setupMocks,
+};

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -34,6 +34,12 @@
       "require": "./metro/withStorybook.js",
       "default": "./metro/withStorybook.js"
     },
+    "./mocking": {
+      "types": "./dist/mocking/index.d.ts",
+      "react-native": "./dist/mocking/index.js",
+      "require": "./dist/mocking/index.js",
+      "default": "./dist/mocking/index.js"
+    },
     "./metro/polyfill": {
       "require": "./metro/polyfill.js",
       "default": "./metro/polyfill.js"
@@ -57,7 +63,9 @@
     "metro/withStorybook.js",
     "metro/withStorybook.d.ts",
     "metro/polyfill.js",
-    "metro/applySherloTransforms.js"
+    "metro/applySherloTransforms.js",
+    "metro/mockScan.js",
+    "metro/mockShims.js"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p .",

--- a/packages/react-native-storybook/src/__tests__/bundle/mockBundle.test.ts
+++ b/packages/react-native-storybook/src/__tests__/bundle/mockBundle.test.ts
@@ -1,0 +1,167 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Bundle lane (SHERLO-1734 Phase 2)
+// ---------------------------------------------------------------------------
+//
+// JS-only lane (no device/emulator): it builds a tiny fixture app with REAL
+// Metro programmatically and asserts on the bundle output:
+//   - enabled: true  -> the mock shim is present (the mocked import was
+//                       redirected through createMockable).
+//   - enabled: false -> zero mocking artifacts (EB-01 at bundle level).
+//
+// This runs under `yarn test` alongside the unit tests, so a red bundle lane
+// fails the PR.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const Metro = require('metro');
+const { getDefaultConfig } = require('metro-config');
+const applySherloTransforms = require('../../../metro/applySherloTransforms');
+
+const MOCKS_DIR_FRAGMENT = path.join('.cache', 'sherlo', 'mocks');
+
+// Builds the fixture project on disk and returns its root directory.
+//
+// Layout:
+//   index.js                         entry - imports the mocked lib (CommonJS)
+//   src/Widget.stories.js            declares parameters.sherlo.mocks
+//   node_modules/mocked-lib          the module being mocked
+//   node_modules/@sherlo/...         a minimal stand-in for the SDK package that
+//                                    provides the `./mocking` export the shim needs
+function createFixture(): string {
+  // realpath so projectRoot matches the path Metro's file watcher indexes
+  // (macOS /var -> /private/var); otherwise Metro cannot SHA-1 the entry file.
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-bundle-fixture-')));
+
+  const write = (rel: string, content: string) => {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, 'utf8');
+  };
+
+  // Entry: CommonJS so no ESM transform is required for the fixture itself.
+  write('index.js', "const lib = require('mocked-lib');\nmodule.exports = lib.greeting();\n");
+
+  // Story file: only ever read from disk by the config-time scan.
+  write(
+    'src/Widget.stories.js',
+    "export const Basic = { parameters: { sherlo: { mocks: { 'mocked-lib': { greeting: () => 'mocked' } } } } };\n"
+  );
+
+  // The module being mocked - carries a distinctive marker so we can find it.
+  write(
+    'node_modules/mocked-lib/package.json',
+    JSON.stringify({ name: 'mocked-lib', version: '1.0.0', main: 'index.js' })
+  );
+  write(
+    'node_modules/mocked-lib/index.js',
+    "module.exports = { greeting: function () { return 'MOCKED_LIB_REAL_MODULE'; } };\n"
+  );
+
+  // Minimal stand-in for @sherlo/react-native-storybook providing createMockable
+  // via the ./mocking export the shim requires. Both the exports map and a
+  // physical subpath file are provided so it resolves whether or not Metro
+  // enforces package exports.
+  const sherloPkg = {
+    name: '@sherlo/react-native-storybook',
+    version: '1.0.0',
+    main: 'index.js',
+    exports: {
+      './mocking': {
+        'react-native': './dist/mocking/index.js',
+        require: './dist/mocking/index.js',
+        default: './dist/mocking/index.js',
+      },
+    },
+  };
+  write('node_modules/@sherlo/react-native-storybook/package.json', JSON.stringify(sherloPkg));
+  write('node_modules/@sherlo/react-native-storybook/index.js', 'module.exports = {};\n');
+  const createMockableStub =
+    'exports.createMockable = function createMockable(key, real) { return real; };\n';
+  write('node_modules/@sherlo/react-native-storybook/dist/mocking/index.js', createMockableStub);
+  write('node_modules/@sherlo/react-native-storybook/mocking/index.js', createMockableStub);
+
+  return root;
+}
+
+async function buildBundle(root: string, opts: { enabled: boolean }): Promise<string> {
+  const baseConfig = await getDefaultConfig(root);
+
+  // Metro's own runtime/polyfills and babel helpers live in the repo
+  // node_modules; the fixture only has the app-level packages. Watch and resolve
+  // against both. Use the node crawler (watchman does not cover the OS temp dir)
+  // and disable caches so each build is fresh.
+  const repoNodeModules = path.dirname(path.dirname(require.resolve('metro-runtime/package.json')));
+  // The @sherlo package dir, so the sherlo polyfill.js (added for enabled:true)
+  // is crawlable.
+  const packageRoot = path.resolve(__dirname, '../../..');
+  baseConfig.watchFolders = [root, repoNodeModules, packageRoot];
+  baseConfig.resolver.nodeModulesPaths = [path.join(root, 'node_modules'), repoNodeModules];
+  baseConfig.resolver.useWatchman = false;
+  baseConfig.cacheStores = [];
+  baseConfig.resetCache = true;
+
+  // applySherloTransforms is exactly what withStorybook() applies under the hood.
+  const config = applySherloTransforms(baseConfig, opts);
+
+  const { code } = await Metro.runBuild(config, {
+    entry: 'index.js',
+    platform: 'ios',
+    dev: false,
+    minify: false,
+  });
+  return code;
+}
+
+describe('bundle lane - module mocking shims in real Metro output', () => {
+  // Real Metro builds are slower than unit tests; give them room.
+  const TIMEOUT = 120_000;
+
+  it(
+    'enabled: true -> the mocked import is redirected through a createMockable shim',
+    async () => {
+      const root = createFixture();
+      try {
+        const code = await buildBundle(root, { enabled: true });
+
+        // The shim's body (a createMockable call for the mocked key) is bundled.
+        expect(code).toContain('createMockable');
+        expect(code).toContain('mocked-lib');
+        // The real module is still present (the shim requires it under the hood).
+        expect(code).toContain('MOCKED_LIB_REAL_MODULE');
+
+        // A shim file was physically emitted for the scanned key.
+        const mocksDir = path.join(root, 'node_modules', MOCKS_DIR_FRAGMENT);
+        const shims = fs.readdirSync(mocksDir).filter((f) => f.startsWith('mock-'));
+        expect(shims.length).toBe(1);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT
+  );
+
+  it(
+    'enabled: false -> the bundle contains zero mocking artifacts (EB-01)',
+    async () => {
+      const root = createFixture();
+      try {
+        const code = await buildBundle(root, { enabled: false });
+
+        // The real module is bundled directly, with no shim indirection.
+        expect(code).toContain('MOCKED_LIB_REAL_MODULE');
+        expect(code).not.toContain('createMockable');
+        expect(code).not.toContain(MOCKS_DIR_FRAGMENT);
+
+        // No shim directory was created at all.
+        expect(fs.existsSync(path.join(root, 'node_modules', MOCKS_DIR_FRAGMENT))).toBe(false);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT
+  );
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
@@ -1,0 +1,611 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// The Metro layer is plain CommonJS .js - require it the same way the existing
+// applySherloTransforms.test.ts does.
+const applySherloTransforms = require('../../../metro/applySherloTransforms');
+const mockScan = require('../../../metro/mockScan');
+const mockShims = require('../../../metro/mockShims');
+
+import { MOCK_DENY_LIST } from '../../mocking/denyList';
+
+// ---------------------------------------------------------------------------
+// Scaffolding helpers
+// ---------------------------------------------------------------------------
+
+function mkProject(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeFile(root: string, relPath: string, content: string): string {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+// Creates a fake installed npm package under <root>/node_modules/<name>.
+function writePackage(
+  root: string,
+  name: string,
+  mainFile: string,
+  files: Record<string, string>
+): void {
+  const pkgDir = path.join(root, 'node_modules', name);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version: '1.0.0', main: mainFile }),
+    'utf8'
+  );
+  for (const rel of Object.keys(files)) {
+    const f = path.join(pkgDir, rel);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, files[rel], 'utf8');
+  }
+}
+
+// Fake Metro resolver context whose delegate maps module names -> absolute paths.
+function makeContext(originModulePath: string, resolveMap: Record<string, string>) {
+  return {
+    originModulePath,
+    resolveRequest: (_ctx: unknown, name: string) => {
+      if (resolveMap[name]) return { type: 'sourceFile', filePath: resolveMap[name] };
+      return { type: 'sourceFile', filePath: `/unresolved/${name}` };
+    },
+  };
+}
+
+function cleanup(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// MK-09 - config-time scan of parameters.sherlo.mocks keys
+// ---------------------------------------------------------------------------
+
+describe('mockScan.collectMockKeysFromSource (MK-09)', () => {
+  it('collects meta-level and story-level string-literal keys', () => {
+    const src = `
+      const meta = {
+        title: 'Button',
+        parameters: { sherlo: { mocks: { 'expo-localization': {} } } },
+      };
+      export default meta;
+      export const Basic = {
+        parameters: { sherlo: { mocks: { '@scope/pkg': {}, 'pkg/submodule': {} } } },
+      };
+    `;
+    expect(mockScan.collectMockKeysFromSource(src).sort()).toEqual([
+      '@scope/pkg',
+      'expo-localization',
+      'pkg/submodule',
+    ]);
+  });
+
+  it('tolerates `satisfies` and `as` annotations around the parameters object', () => {
+    const src = `
+      import type { Meta } from '@storybook/react';
+      const meta = {
+        parameters: ({ sherlo: { mocks: { 'a-mod': {} } } } satisfies Record<string, unknown>),
+      } as Meta;
+      export const S = {
+        parameters: { sherlo: { mocks: { 'b-mod': {} } as any } },
+      };
+    `;
+    expect(mockScan.collectMockKeysFromSource(src).sort()).toEqual(['a-mod', 'b-mod']);
+  });
+
+  it('extracts KEYS only - never touches mock values (no value extraction)', () => {
+    const src = `
+      export const S = {
+        parameters: { sherlo: { mocks: {
+          'with-factory': (real) => ({ ...real, foo: 1 }),
+          'with-object': { bar: someRuntimeValue() },
+        } } },
+      };
+    `;
+    expect(mockScan.collectMockKeysFromSource(src).sort()).toEqual(['with-factory', 'with-object']);
+  });
+
+  it('ignores non-string-literal keys (identifier / computed)', () => {
+    const src = `
+      const dynamicKey = 'runtime';
+      export const S = {
+        parameters: { sherlo: { mocks: { 'quoted-key': {}, [dynamicKey]: {}, bareIdent: {} } } },
+      };
+    `;
+    expect(mockScan.collectMockKeysFromSource(src)).toEqual(['quoted-key']);
+  });
+
+  it('returns nothing for files without sherlo mocks', () => {
+    expect(mockScan.collectMockKeysFromSource('export const x = 1;')).toEqual([]);
+    expect(mockScan.collectMockKeysFromSource('this is not valid <<< js')).toEqual([]);
+  });
+});
+
+describe('mockScan.findScanFiles / scanProjectForMockKeys (MK-09 discovery)', () => {
+  it('finds *.stories.* and preview.* files, skipping node_modules', () => {
+    const root = mkProject('sherlo-scan-find-');
+    writeFile(root, 'src/Button.stories.tsx', 'export const A = {};');
+    writeFile(root, '.storybook/preview.ts', 'export const parameters = {};');
+    writeFile(root, 'src/Button.tsx', 'export default 1;');
+    writeFile(root, 'node_modules/dep/thing.stories.js', 'export const B = {};');
+
+    const files = mockScan
+      .findScanFiles(root)
+      .map((f: string) => path.relative(root, f))
+      .sort();
+    cleanup(root);
+
+    expect(files).toContain('src/Button.stories.tsx');
+    expect(files).toContain(path.join('.storybook', 'preview.ts'));
+    expect(files).not.toContain('src/Button.tsx');
+    expect(files.some((f: string) => f.indexOf('node_modules') !== -1)).toBe(false);
+  });
+
+  it('scanProjectForMockKeys maps each key to its declaring file', () => {
+    const root = mkProject('sherlo-scan-project-');
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+    const map = mockScan.scanProjectForMockKeys(root);
+    cleanup(root);
+
+    expect(map.get('expo-localization')).toContain('Comp.stories.tsx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deny list (FG-02) + sync with the TS source of truth
+// ---------------------------------------------------------------------------
+
+describe('mockShims deny list (FG-02)', () => {
+  it('the JS deny list mirrors src/mocking/denyList.ts', () => {
+    expect(mockShims.MOCK_DENY_LIST).toEqual([...MOCK_DENY_LIST]);
+  });
+
+  it('denies exact and scope-glob entries', () => {
+    expect(mockShims.isDeniedKey('react')).toBe(true);
+    expect(mockShims.isDeniedKey('react-native')).toBe(true);
+    expect(mockShims.isDeniedKey('@storybook/react-native')).toBe(true);
+    expect(mockShims.isDeniedKey('@sherlo/react-native-storybook')).toBe(true);
+    expect(mockShims.isDeniedKey('expo-localization')).toBe(false);
+    expect(mockShims.isDeniedKey('react-native-svg')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeModulePath - platform/extension identity (supports MK-06)
+// ---------------------------------------------------------------------------
+
+describe('mockShims.canonicalizeModulePath', () => {
+  it('strips extension and platform suffix so all platform variants collapse', () => {
+    expect(mockShims.canonicalizeModulePath('/a/b/Button.tsx')).toBe('/a/b/Button');
+    expect(mockShims.canonicalizeModulePath('/a/b/Button.ios.tsx')).toBe('/a/b/Button');
+    expect(mockShims.canonicalizeModulePath('/a/b/Button.android.js')).toBe('/a/b/Button');
+    expect(mockShims.canonicalizeModulePath('/a/b/index.native.ts')).toBe('/a/b/index');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shim emission + content
+// ---------------------------------------------------------------------------
+
+describe('mockShims.generateShimContent + shimFileName', () => {
+  it('emits exactly one createMockable call requiring the real module', () => {
+    const content = mockShims.generateShimContent('expo-localization', 'expo-localization');
+    expect(content).toContain('@sherlo/react-native-storybook/mocking');
+    expect(content).toContain('.createMockable("expo-localization", require("expo-localization"))');
+    // exactly one createMockable call
+    expect(content.match(/createMockable/g)?.length).toBe(1);
+  });
+
+  it('shim filenames are deterministic per key', () => {
+    expect(mockShims.shimFileName('expo-localization')).toBe(
+      mockShims.shimFileName('expo-localization')
+    );
+    expect(mockShims.shimFileName('a')).not.toBe(mockShims.shimFileName('b'));
+  });
+
+  it('shim content changes only when the key set changes', () => {
+    const root = mkProject('sherlo-shim-determinism-');
+    writePackage(root, 'alpha', 'index.js', { 'index.js': 'module.exports = {};' });
+    writePackage(root, 'beta', 'index.js', { 'index.js': 'module.exports = {};' });
+    const cacheDir = path.join(root, 'node_modules', '.cache', 'sherlo');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const alphaShim = path.join(cacheDir, 'mocks', mockShims.shimFileName('alpha'));
+
+    // First run with {alpha}.
+    mockShims.setupMocks({ projectRoot: root, cacheDir, mockModules: ['alpha'] });
+    const firstAlpha = fs.readFileSync(alphaShim, 'utf8');
+
+    // Re-run with the SAME key set -> byte-identical shim.
+    mockShims.setupMocks({ projectRoot: root, cacheDir, mockModules: ['alpha'] });
+    expect(fs.readFileSync(alphaShim, 'utf8')).toBe(firstAlpha);
+
+    // Adding a key leaves alpha's shim byte-identical and emits beta's shim.
+    mockShims.setupMocks({ projectRoot: root, cacheDir, mockModules: ['alpha', 'beta'] });
+    const betaShim = path.join(cacheDir, 'mocks', mockShims.shimFileName('beta'));
+    expect(fs.readFileSync(alphaShim, 'utf8')).toBe(firstAlpha);
+    expect(fs.existsSync(betaShim)).toBe(true);
+
+    // Removing beta prunes its stale shim (fresh rewrite each run).
+    mockShims.setupMocks({ projectRoot: root, cacheDir, mockModules: ['alpha'] });
+    expect(fs.existsSync(betaShim)).toBe(false);
+    cleanup(root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shim requires createMockable from the installed package export (proving it
+// resolves against package.json exports).
+// ---------------------------------------------------------------------------
+
+describe('shim createMockable specifier maps to a real, built entry point', () => {
+  // The shim requires createMockable from the package's `./mocking` export. This
+  // proves that specifier is (a) the one the shim uses, (b) declared in exports,
+  // and (c) that the source compiling to that export really exports createMockable.
+  // The bundle lane (mockBundle.test.ts) proves it resolves through real Metro.
+  it('generateShimContent uses the ./mocking package export specifier', () => {
+    expect(mockShims.CREATE_MOCKABLE_SPECIFIER).toBe('@sherlo/react-native-storybook/mocking');
+    const content = mockShims.generateShimContent('x', 'x');
+    expect(content).toContain('require("@sherlo/react-native-storybook/mocking")');
+  });
+
+  it('package.json declares the ./mocking export -> dist/mocking/index.js', () => {
+    const realPkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '../../../package.json'), 'utf8')
+    );
+    expect(realPkg.exports['./mocking'].require).toBe('./dist/mocking/index.js');
+    expect(realPkg.exports['./mocking']['react-native']).toBe('./dist/mocking/index.js');
+  });
+
+  it('src/mocking/index.ts (compiles to dist/mocking/index.js) exports createMockable', () => {
+    const indexSrc = fs.readFileSync(path.join(__dirname, '../../mocking/index.ts'), 'utf8');
+    expect(indexSrc).toMatch(/export\s+\{[^}]*createMockable/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveMockKey - resolution + require specifier (FG-01, MK-06 unit level)
+// ---------------------------------------------------------------------------
+
+describe('mockShims.resolveMockKey', () => {
+  it('MK-01: resolves a bare npm package; shim requires the bare specifier', () => {
+    const root = mkProject('sherlo-resolvekey-npm-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    const realRoot = fs.realpathSync(root);
+
+    const resolved = mockShims.resolveMockKey('expo-localization', root);
+    cleanup(root);
+
+    expect(resolved.requireSpecifier).toBe('expo-localization');
+    // canonicalRealPath is realpath-normalised and extension-stripped.
+    expect(resolved.canonicalRealPath).toBe(
+      path.join(realRoot, 'node_modules', 'expo-localization', 'index')
+    );
+  });
+
+  it('MK-04: resolves a project-root-relative app module; shim requires the extensionless path', () => {
+    const root = mkProject('sherlo-resolvekey-app-');
+    writeFile(root, 'src/utils/localization.ts', 'export default {};');
+    const realRoot = fs.realpathSync(root);
+
+    const resolved = mockShims.resolveMockKey('./src/utils/localization', root);
+    cleanup(root);
+
+    // For app modules the canonical identity and the shim's require specifier are
+    // the same realpath-normalised, extensionless path.
+    const expectedBase = path.join(realRoot, 'src', 'utils', 'localization');
+    expect(resolved.canonicalRealPath).toBe(expectedBase);
+    expect(resolved.requireSpecifier).toBe(expectedBase);
+  });
+
+  it('MK-06: platform-split app module resolves to one canonical identity + extensionless specifier', () => {
+    const root = mkProject('sherlo-resolvekey-plat-');
+    writeFile(root, 'src/Plat.ios.tsx', 'export default {};');
+    writeFile(root, 'src/Plat.android.tsx', 'export default {};');
+    const realRoot = fs.realpathSync(root);
+
+    const resolved = mockShims.resolveMockKey('./src/Plat', root);
+    cleanup(root);
+
+    // One shim, one canonical identity; the require specifier is platform-free so
+    // Metro re-resolves the correct .ios/.android file per platform at bundle time.
+    const expectedBase = path.join(realRoot, 'src', 'Plat');
+    expect(resolved.canonicalRealPath).toBe(expectedBase);
+    expect(resolved.requireSpecifier).toBe(expectedBase);
+    expect(resolved.requireSpecifier).not.toContain('.ios');
+    expect(resolved.requireSpecifier).not.toContain('.android');
+  });
+
+  it('throws for an unresolvable key (drives FG-01)', () => {
+    const root = mkProject('sherlo-resolvekey-fail-');
+    expect(() => mockShims.resolveMockKey('totally-not-installed', root)).toThrow();
+    cleanup(root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end resolver redirect via applySherloTransforms
+// ---------------------------------------------------------------------------
+
+describe('applySherloTransforms resolver redirect', () => {
+  it('MK-01: redirects an npm-package import to its shim', () => {
+    const root = mkProject('sherlo-redirect-npm-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+      'expo-localization': realPath,
+    });
+
+    const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+    const shimExists = fs.existsSync(resolved.filePath);
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+    expect(shimExists).toBe(true);
+  });
+
+  it('MK-02 + MK-03: redirects scoped-package and subpath keys', () => {
+    const root = mkProject('sherlo-redirect-scoped-');
+    writePackage(root, '@scope/pkg', 'index.js', { 'index.js': 'module.exports = {};' });
+    writePackage(root, 'libpkg', 'index.js', {
+      'index.js': 'module.exports = {};',
+      'submodule.js': 'module.exports = {};',
+    });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { '@scope/pkg': {}, 'libpkg/submodule': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const scopedReal = path.join(root, 'node_modules', '@scope', 'pkg', 'index.js');
+    const subReal = path.join(root, 'node_modules', 'libpkg', 'submodule.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+      '@scope/pkg': scopedReal,
+      'libpkg/submodule': subReal,
+    });
+
+    const scopedResolved = result.resolver.resolveRequest(ctx, '@scope/pkg', 'ios');
+    const subResolved = result.resolver.resolveRequest(ctx, 'libpkg/submodule', 'ios');
+    cleanup(root);
+
+    expect(scopedResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+    expect(subResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+    expect(scopedResolved.filePath).not.toBe(subResolved.filePath);
+  });
+
+  it('MK-04: redirects a project-relative app-module import', () => {
+    const root = mkProject('sherlo-redirect-app-');
+    writeFile(root, 'src/utils/localization.ts', 'export default {};');
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { './src/utils/localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const realPath = path.join(root, 'src', 'utils', 'localization.ts');
+    // Importer uses a relative specifier that Metro resolves to the same file.
+    const ctx = makeContext(path.join(root, 'src', 'screens', 'Home.tsx'), {
+      '../utils/localization': realPath,
+    });
+
+    const resolved = result.resolver.resolveRequest(ctx, '../utils/localization', 'ios');
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('MK-06: both platform variants redirect to the SAME single shim', () => {
+    const root = mkProject('sherlo-redirect-plat-');
+    writeFile(root, 'src/Plat.ios.tsx', 'export default {};');
+    writeFile(root, 'src/Plat.android.tsx', 'export default {};');
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { './src/Plat': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const iosCtx = makeContext(path.join(root, 'src', 'App.tsx'), {
+      './Plat': path.join(root, 'src', 'Plat.ios.tsx'),
+    });
+    const androidCtx = makeContext(path.join(root, 'src', 'App.tsx'), {
+      './Plat': path.join(root, 'src', 'Plat.android.tsx'),
+    });
+
+    const iosResolved = result.resolver.resolveRequest(iosCtx, './Plat', 'ios');
+    const androidResolved = result.resolver.resolveRequest(androidCtx, './Plat', 'android');
+    cleanup(root);
+
+    expect(iosResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+    expect(iosResolved.filePath).toBe(androidResolved.filePath);
+  });
+
+  it('MK-08: a transitive importer inside node_modules is redirected too', () => {
+    const root = mkProject('sherlo-redirect-transitive-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
+    // Origin is a file INSIDE node_modules (a transitive dependency).
+    const ctx = makeContext(path.join(root, 'node_modules', 'some-lib', 'index.js'), {
+      'expo-localization': realPath,
+    });
+
+    const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('the shim itself is exempt (require inside a shim resolves to the real module)', () => {
+    const root = mkProject('sherlo-shim-exempt-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
+    const shimPath = path.join(
+      root,
+      'node_modules',
+      '.cache',
+      'sherlo',
+      'mocks',
+      mockShims.shimFileName('expo-localization')
+    );
+    const ctx = makeContext(shimPath, { 'expo-localization': realPath });
+
+    const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+    cleanup(root);
+
+    // No redirect: the shim's own require(real) reaches the real module.
+    expect(resolved.filePath).toBe(realPath);
+  });
+
+  it('MK-10: mockModules option registers a key static scan cannot see', () => {
+    const root = mkProject('sherlo-mockmodules-');
+    writePackage(root, 'native-only-lib', 'index.js', { 'index.js': 'module.exports = {};' });
+    // No story declares it - only the escape hatch does.
+
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { enabled: true, mockModules: ['native-only-lib'] }
+    );
+    const realPath = path.join(root, 'node_modules', 'native-only-lib', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { 'native-only-lib': realPath });
+
+    const resolved = result.resolver.resolveRequest(ctx, 'native-only-lib', 'ios');
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('FG-04: a mocked module no component imports is a harmless no-op', () => {
+    const root = mkProject('sherlo-noop-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const shimPath = path.join(
+      root,
+      'node_modules',
+      '.cache',
+      'sherlo',
+      'mocks',
+      mockShims.shimFileName('expo-localization')
+    );
+    const shimExists = fs.existsSync(shimPath);
+
+    // Some other module is imported; it must pass through untouched.
+    const otherReal = path.join(root, 'node_modules', 'other', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { other: otherReal });
+    const resolved = result.resolver.resolveRequest(ctx, 'other', 'ios');
+    cleanup(root);
+
+    expect(shimExists).toBe(true); // shim generated
+    expect(resolved.filePath).toBe(otherReal); // unrelated import untouched
+  });
+
+  it('FG-01: an unresolvable mock key fails config naming the story file AND key', () => {
+    const root = mkProject('sherlo-fg01-');
+    writeFile(
+      root,
+      'src/Broken.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'not-installed-pkg': {} } } } };`
+    );
+
+    let error: Error | null = null;
+    try {
+      applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    } catch (e) {
+      error = e as Error;
+    }
+    cleanup(root);
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('not-installed-pkg');
+    expect(error!.message).toContain('Broken.stories.tsx');
+  });
+
+  it('FG-02: a deny-listed key fails with guidance to mock a wrapper module', () => {
+    const root = mkProject('sherlo-fg02-');
+    writeFile(
+      root,
+      'src/Bad.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'react-native': {} } } } };`
+    );
+
+    let error: Error | null = null;
+    try {
+      applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    } catch (e) {
+      error = e as Error;
+    }
+    cleanup(root);
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain('react-native');
+    expect(error!.message.toLowerCase()).toContain('wrapper');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EB-01 - enabled:false contributes nothing
+// ---------------------------------------------------------------------------
+
+describe('EB-01: enabled:false disables the mocking system entirely', () => {
+  it('emits no shims and installs no resolver redirect', () => {
+    const root = mkProject('sherlo-eb01-');
+    writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: false });
+
+    const mocksDir = path.join(root, 'node_modules', '.cache', 'sherlo', 'mocks');
+    const mocksDirExists = fs.existsSync(mocksDir);
+
+    const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+      'expo-localization': realPath,
+    });
+    const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+    cleanup(root);
+
+    expect(mocksDirExists).toBe(false); // no shims emitted
+    expect(resolved.filePath).toBe(realPath); // no redirect - reaches the real module
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
@@ -178,6 +178,16 @@ describe('mockShims deny list (FG-02)', () => {
     expect(mockShims.isDeniedKey('expo-localization')).toBe(false);
     expect(mockShims.isDeniedKey('react-native-svg')).toBe(false);
   });
+
+  it('denies subpaths of exact deny entries (FG-02), not lookalikes', () => {
+    // Exact entries deny their subpaths too, so Storybook-critical internals
+    // can't slip through under a deeper specifier.
+    expect(mockShims.isDeniedKey('react/jsx-runtime')).toBe(true);
+    expect(mockShims.isDeniedKey('react-native/Libraries/Core/InitializeCore')).toBe(true);
+    // A distinct package that merely shares a prefix is still mockable - the '/'
+    // boundary keeps 'react-native-svg' from matching the 'react-native' entry.
+    expect(mockShims.isDeniedKey('react-native-svg')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -307,6 +317,41 @@ describe('mockShims.resolveMockKey', () => {
     expect(resolved.requireSpecifier).toBe(expectedBase);
   });
 
+  it('MK-04 (dotless): resolves a DOTLESS project-root-relative app module to the extensionless abs path', () => {
+    const root = mkProject('sherlo-resolvekey-dotless-');
+    writeFile(root, 'src/utils/localization.ts', 'export default {};');
+    const realRoot = fs.realpathSync(root);
+
+    // No './' prefix - the canonical app-module key form from the epic. It is
+    // not an installed package, so require.resolve fails and we fall back to the
+    // project-root-relative app-module file.
+    const resolved = mockShims.resolveMockKey('src/utils/localization', root);
+    cleanup(root);
+
+    const expectedBase = path.join(realRoot, 'src', 'utils', 'localization');
+    expect(resolved.canonicalRealPath).toBe(expectedBase);
+    expect(resolved.requireSpecifier).toBe(expectedBase);
+  });
+
+  it('MK-03: a subpath package still resolves as a BARE package, not an app module', () => {
+    const root = mkProject('sherlo-resolvekey-subpath-');
+    writePackage(root, 'libpkg', 'index.js', {
+      'index.js': 'module.exports = {};',
+      'submodule.js': 'module.exports = {};',
+    });
+    const realRoot = fs.realpathSync(root);
+
+    // require.resolve wins first, so the shim keeps the bare specifier and the
+    // canonical identity points into node_modules (not a project-root file).
+    const resolved = mockShims.resolveMockKey('libpkg/submodule', root);
+    cleanup(root);
+
+    expect(resolved.requireSpecifier).toBe('libpkg/submodule');
+    expect(resolved.canonicalRealPath).toBe(
+      path.join(realRoot, 'node_modules', 'libpkg', 'submodule')
+    );
+  });
+
   it('MK-06: platform-split app module resolves to one canonical identity + extensionless specifier', () => {
     const root = mkProject('sherlo-resolvekey-plat-');
     writeFile(root, 'src/Plat.ios.tsx', 'export default {};');
@@ -410,6 +455,39 @@ describe('applySherloTransforms resolver redirect', () => {
     cleanup(root);
 
     expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('MK-04 (dotless): redirects a DOTLESS project-root-relative app-module import', () => {
+    const root = mkProject('sherlo-redirect-app-dotless-');
+    writeFile(root, 'src/utils/localization.ts', 'export default {};');
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'src/utils/localization': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const realPath = path.join(root, 'src', 'utils', 'localization.ts');
+    // Importer uses a relative specifier that Metro resolves to the same file.
+    const ctx = makeContext(path.join(root, 'src', 'screens', 'Home.tsx'), {
+      '../utils/localization': realPath,
+    });
+
+    const resolved = result.resolver.resolveRequest(ctx, '../utils/localization', 'ios');
+    // The dotless key also emitted a shim (scan-to-shim path).
+    const shimPath = path.join(
+      root,
+      'node_modules',
+      '.cache',
+      'sherlo',
+      'mocks',
+      mockShims.shimFileName('src/utils/localization')
+    );
+    const shimExists = fs.existsSync(shimPath);
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+    expect(shimExists).toBe(true);
   });
 
   it('MK-06: both platform variants redirect to the SAME single shim', () => {

--- a/packages/react-native-storybook/src/types/types.ts
+++ b/packages/react-native-storybook/src/types/types.ts
@@ -1,5 +1,17 @@
 import type { View } from '@storybook/react-native';
+import type { MockSet } from '../mocking/types';
+
 export interface SherloParameters {
+  /**
+   * Module Mocking (SHERLO-1734): a map of module specifier -> mock definition,
+   * applied for the duration of the story's snapshot. Declaring a key here also
+   * registers it for the config-time Metro scan, which emits the shim that makes
+   * the module mockable. The key must be a string literal so the static scan can
+   * see it. Deny-listed modules (react, react-native, @storybook/*, @sherlo/*)
+   * cannot be mocked - mock a wrapper module you own instead.
+   */
+  mocks?: MockSet;
+
   /**
    * Setting exclude to true skips the story during testing. This might be
    * useful if the story has animations that cannot be stabilized for testing


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1734

## [Phase 2] Metro layer: mock key scan, shim emission, resolver redirect

Phase 2 of the Module Mocking epic (SHERLO-1732). Builds on the Phase 1 `createMockable` runtime.

### What changed
- **`metro/mockScan.js`** (new) - single self-contained scan module. Shallow Babel parse (the parser Metro ships) of `*.stories.*` and `preview.*` files; extracts STRING-LITERAL keys under `parameters.sherlo.mocks` only, never values. Tolerant of TS `as`/`satisfies`/`!`/`<T>` wrappers. (MK-09)
- **`metro/mockShims.js`** (new) - resolves each key to an absolute path, emits one deterministic one-line shim per key (`mock-<sha1>.js`) under `node_modules/.cache/sherlo/mocks/`, and returns an in-memory `canonicalRealPath -> shim` map. Enforces the deny-list before resolution (FG-02) and throws a file+key-named error on unresolvable keys (FG-01). Shim body is exactly one `createMockable(key, require(real))` call, requiring createMockable via the package `./mocking` export.
- **`metro/applySherloTransforms.js`** - extends the single existing `resolveRequest` hook with a small delegate-first branch: resolve through the existing chain, then redirect to the shim when the resolved path is mocked and the importer is not itself a shim. Gated entirely behind `enabled !== false` (EB-01). Adds the `mockModules` escape-hatch option (MK-10).
- **`package.json`** - adds `./mocking` export -> `dist/mocking/index.js` (with `react-native` condition so Metro resolves the shim's require); ships the two new metro files.
- **`src/types/types.ts`** - types `SherloParameters.mocks?: MockSet` for authoring DX.

### Tests (all green: 293 passed / 2 skipped)
- **`src/__tests__/mocking/metroMockLayer.test.ts`** (new) - unit coverage mapped to every scenario: MK-01/02/03/04 (npm/scoped/subpath/app-module redirect), MK-06 (platform-split -> one shim), MK-08 (transitive node_modules importer), MK-09 (scan + TS tolerance), MK-10 (escape hatch), FG-01/FG-02/FG-04, EB-01, deny-list sync with the TS source, and shim determinism.
- **`src/__tests__/bundle/mockBundle.test.ts`** (new) - JS-only bundle lane: builds a fixture with REAL Metro programmatically and asserts shim presence with `enabled: true` and total absence with `enabled: false` (EB-01 at bundle level). Runs under `yarn test`, so it executes in CI (`pr_checks.yml`) alongside the unit lane.

Lint: 0 errors. Typecheck: clean.

Note: user-facing error copy (FG-01/FG-02 strings) is functional here; final wording is owned by content in Phase 7 (SHERLO-1739).

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
