### PR TITLE
feat: Published CLI cannot compute base fingerprints: ncc bundle o…

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,13 +28,15 @@
     "cli.js"
   ],
   "scripts": {
-    "build": "rm -rf dist && ncc build src/index.ts --source-map --minify && tsc --emitDeclarationOnly && chmod u+x ./dist/index.js",
+    "build": "rm -rf dist && ncc build src/index.ts --source-map --minify --external @expo/fingerprint && tsc --emitDeclarationOnly && chmod u+x ./dist/index.js",
     "lint": "NODE_ENV=production yarn run -T eslint --ext .ts,.tsx src",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@expo/fingerprint": "^0.11.0"
+  },
   "devDependencies": {
     "@babel/parser": "^7.29.3",
-    "@expo/fingerprint": "^0.11.0",
     "@inquirer/core": "^10.3.2",
     "@inquirer/prompts": "^7.8.4",
     "@sentry/node": "10.47.0",

--- a/packages/cli/src/helpers/fingerprint/__tests__/packagedFingerprint.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/packagedFingerprint.test.ts
@@ -1,0 +1,230 @@
+/**
+ * PACKAGING REGRESSION TEST (SHERLO-1742)
+ *
+ * Proves the base-fingerprint path works from the REAL PUBLISH ARTIFACT - not
+ * the repo build tree. This is the one test that would have caught the shipped
+ * bug: `ncc` inlined @expo/fingerprint into dist/index.js, but that library
+ * SPAWNS a helper file it ships - ExpoConfigLoader.js - resolved relative to
+ * its own __dirname. Once inlined, __dirname was the CLI's dist/, the helper was
+ * never emitted there, and the spawned subprocess died MODULE_NOT_FOUND. Every
+ * existing test ran from the repo tree (where node_modules/@expo/fingerprint
+ * exists), so none of them saw it.
+ *
+ * So this test does exactly what a user's machine does:
+ *   1. `yarn build` the CLI (produces dist/).
+ *   2. `npm pack` it (the real tarball `npm publish` would upload).
+ *   3. `npm install` that tarball into a fresh throwaway project.
+ *   4. Run the base-fingerprint path FROM THE INSTALLED node_modules/sherlo.
+ *
+ * and asserts two things the shipped artifact must guarantee:
+ *   - AC1: on a staged-capable (managed Expo) fixture the fingerprint computes a
+ *     non-null hash with NO ExpoConfigLoader spawn failure.
+ *   - AC3: when @expo/fingerprint is unavailable, the CLI still LOADS and the
+ *     base-fingerprint path degrades to hash:null - it never crashes a push.
+ *
+ * It is heavy (build + pack + install) by necessity: only the installed artifact
+ * can prove the spawned asset is reachable. It runs inside `yarn test` (vitest)
+ * because that is the publish-gating unit workflow (pr_checks.yml).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// packages/cli root: this file is at src/helpers/fingerprint/__tests__/.
+const CLI_ROOT = path.resolve(__dirname, '../../../..');
+
+// Generous timeouts: the build + two installs are the slow part. Well under
+// CI limits, but far above vitest's 5s default.
+const SETUP_TIMEOUT_MS = 300_000;
+const PROBE_TIMEOUT_MS = 60_000;
+
+let tmpRoot: string;
+let stagedProject: string;
+let failSoftProject: string;
+
+beforeAll(() => {
+  // Sanity-check we resolved the right package before we build/pack it.
+  const pkg = JSON.parse(fs.readFileSync(path.join(CLI_ROOT, 'package.json'), 'utf8'));
+  expect(pkg.name).toBe('sherlo');
+
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-pack-test-'));
+
+  // 1. Build the CLI exactly as publish would (ncc bundle -> dist/).
+  run('npm', ['run', 'build'], CLI_ROOT);
+
+  // 2. Pack the real publish artifact.
+  const tarball = path.join(
+    tmpRoot,
+    execFileSync('npm', ['pack', '--silent', '--pack-destination', tmpRoot], {
+      cwd: CLI_ROOT,
+      encoding: 'utf8',
+    }).trim()
+  );
+
+  // 3. Install into two fresh projects.
+  stagedProject = installManagedExpoFixture(tarball, 'staged');
+
+  failSoftProject = installManagedExpoFixture(tarball, 'fail-soft');
+  // Deliberately remove @expo/fingerprint (the package that ships the spawned
+  // ExpoConfigLoader.js helper) to prove the CLI degrades, never crashes.
+  fs.rmSync(path.join(failSoftProject, 'node_modules', '@expo', 'fingerprint'), {
+    recursive: true,
+    force: true,
+  });
+}, SETUP_TIMEOUT_MS);
+
+afterAll(() => {
+  if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('packaged CLI base fingerprint (installed artifact)', () => {
+  it(
+    'computes a non-null hash with no ExpoConfigLoader spawn failure (AC1)',
+    () => {
+      const { output, result } = runInstalledFingerprint(stagedProject);
+
+      // The CLI loaded and the fingerprint path ran to completion.
+      expect(output).toContain('SHERLO_FINGERPRINT_RESULT');
+      expect(output).not.toContain('SHERLO_CLI_LOAD_CRASH');
+      expect(output).not.toContain('SHERLO_FINGERPRINT_THREW');
+
+      // The exact regression signature: @expo/fingerprint prints this warning
+      // when it fails to spawn its ExpoConfigLoader.js helper. It must be absent,
+      // and the helper must never be looked for inside the sherlo package.
+      expect(output).not.toContain('Cannot get Expo config from an Expo project');
+      expect(output).not.toMatch(/sherlo[/\\]dist[/\\]ExpoConfigLoader\.js/);
+
+      // A staged-capable fixture yields a real base fingerprint.
+      expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+    },
+    PROBE_TIMEOUT_MS
+  );
+
+  it(
+    'degrades to hash:null and never crashes when @expo/fingerprint is unavailable (AC3)',
+    () => {
+      const { output, result } = runInstalledFingerprint(failSoftProject);
+
+      // The CLI still loads (fingerprint is loaded lazily, not at startup) and
+      // the base-fingerprint path returns rather than throwing.
+      expect(output).not.toContain('SHERLO_CLI_LOAD_CRASH');
+      expect(output).not.toContain('SHERLO_FINGERPRINT_THREW');
+      expect(output).toContain('SHERLO_FINGERPRINT_RESULT');
+
+      // Fail-soft: unavailable fingerprint -> null hash (staged flow unavailable).
+      expect(result.hash).toBeNull();
+    },
+    PROBE_TIMEOUT_MS
+  );
+});
+
+/* ========================================================================== */
+/* Helpers                                                                     */
+/* ========================================================================== */
+
+/** Run a command, throwing with captured output if it fails. */
+function run(command: string, args: string[], cwd: string): void {
+  const res = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(
+      `\`${command} ${args.join(' ')}\` failed (exit ${res.status}):\n${res.stdout ?? ''}\n${
+        res.stderr ?? ''
+      }`
+    );
+  }
+}
+
+/**
+ * Create a fresh throwaway project, install the packed CLI tarball into it, and
+ * shape it like a minimal managed Expo app - just enough for @expo/fingerprint
+ * to resolve `expo/config`, spawn its ExpoConfigLoader.js helper, and let that
+ * helper run to completion (load env, read the Expo config). No real Expo
+ * install is needed - only the entry points the helper touches.
+ */
+function installManagedExpoFixture(tarball: string, name: string): string {
+  const projectDir = path.join(tmpRoot, name);
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDir, 'package.json'),
+    JSON.stringify({ name: `fixture-${name}`, version: '1.0.0', private: true })
+  );
+
+  run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', tarball], projectDir);
+
+  writeFixtureFile(projectDir, 'app.json', JSON.stringify({ expo: { name, slug: name } }));
+
+  // Minimal `expo` package: resolvable `expo/config` with a getConfig() the
+  // spawned helper calls.
+  writeFixtureFile(
+    projectDir,
+    'node_modules/expo/package.json',
+    JSON.stringify({ name: 'expo', version: '52.0.0', main: 'index.js' })
+  );
+  writeFixtureFile(
+    projectDir,
+    'node_modules/expo/config.js',
+    `exports.getConfig = () => ({ exp: { name: ${JSON.stringify(name)}, slug: ${JSON.stringify(
+      name
+    )} } });\n`
+  );
+
+  // Minimal `@expo/env`: the helper loads it before reading the config.
+  writeFixtureFile(
+    projectDir,
+    'node_modules/@expo/env/package.json',
+    JSON.stringify({ name: '@expo/env', version: '0.0.0', main: 'index.js' })
+  );
+  writeFixtureFile(projectDir, 'node_modules/@expo/env/index.js', 'exports.load = () => {};\n');
+
+  // Stub the autolinking CLI the managed path shells out to (`npx
+  // expo-modules-autolinking resolve --json`), so the test never reaches the
+  // network for it. Returning an empty module list is enough.
+  const autolinkBinRelPath = 'node_modules/.bin/expo-modules-autolinking';
+  writeFixtureFile(projectDir, autolinkBinRelPath, "#!/usr/bin/env node\nconsole.log('[]');\n");
+  fs.chmodSync(path.join(projectDir, autolinkBinRelPath), 0o755);
+
+  return projectDir;
+}
+
+function writeFixtureFile(projectDir: string, relativePath: string, content: string): void {
+  const fullPath = path.join(projectDir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+/**
+ * Run the base-fingerprint path FROM THE INSTALLED CLI (node_modules/sherlo),
+ * with the project directory as cwd, capturing combined stdout+stderr so we can
+ * see any @expo/fingerprint spawn-failure warnings.
+ */
+function runInstalledFingerprint(projectDir: string): {
+  output: string;
+  result: { hash: string | null; debugMessage?: string };
+} {
+  const probePath = path.join(projectDir, 'probe.js');
+  fs.writeFileSync(
+    probePath,
+    [
+      'let computeBaseFingerprint;',
+      'try {',
+      "  ({ computeBaseFingerprint } = require('sherlo'));",
+      '} catch (error) {',
+      "  console.log('SHERLO_CLI_LOAD_CRASH ' + (error && error.message ? error.message : String(error)));",
+      '  process.exit(0);',
+      '}',
+      'computeBaseFingerprint(process.cwd())',
+      "  .then((result) => console.log('SHERLO_FINGERPRINT_RESULT ' + JSON.stringify(result)))",
+      "  .catch((error) => console.log('SHERLO_FINGERPRINT_THREW ' + (error && error.stack ? error.stack : String(error))));",
+    ].join('\n')
+  );
+
+  const res = spawnSync(process.execPath, [probePath], { cwd: projectDir, encoding: 'utf8' });
+  const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+
+  const match = output.match(/SHERLO_FINGERPRINT_RESULT (\{.*\})/);
+  const result = match ? JSON.parse(match[1]) : { hash: null };
+
+  return { output, result };
+}

--- a/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
+++ b/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
@@ -26,14 +26,38 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import {
-  createFingerprintAsync,
-  SourceSkips,
-  type FileHookTransformFunction,
-  type FileHookTransformSource,
-  type Options as FingerprintOptions,
+import type {
+  FileHookTransformFunction,
+  FileHookTransformSource,
+  Options as FingerprintOptions,
 } from '@expo/fingerprint';
 import runShellCommand from '../runShellCommand';
+
+/**
+ * `@expo/fingerprint` is an EXTERNAL runtime dependency: it is declared in
+ * `dependencies` and EXCLUDED from the ncc bundle (see the
+ * `--external @expo/fingerprint` build flag in package.json). It must stay
+ * external because at runtime it SPAWNS a helper file it ships -
+ * `ExpoConfigLoader.js` - resolved relative to its own `__dirname`. If it were
+ * inlined into the CLI's `dist/`, that `__dirname` would point at `dist/`,
+ * where the helper was never emitted, and the spawned subprocess would die with
+ * MODULE_NOT_FOUND (SHERLO-1742). Kept external, the library runs from its own
+ * installed package directory with its helper assets intact.
+ *
+ * Because it is external (and only the types above are compiled in), it is
+ * loaded LAZILY here via a dynamic `import()` rather than a top-level `import`
+ * value binding. A top-level binding compiles to an eager
+ * `require('@expo/fingerprint')` that would run when the CLI module graph loads,
+ * so a missing or broken install would crash the ENTIRE CLI at startup. Loading
+ * it inside `computeBaseFingerprint`'s fail-soft try/catch instead means an
+ * unavailable fingerprint library degrades only this one function to
+ * `hash: null` (staged flow unavailable) and NEVER crashes a push.
+ */
+type ExpoFingerprintModule = typeof import('@expo/fingerprint');
+
+function loadExpoFingerprint(): Promise<ExpoFingerprintModule> {
+  return import('@expo/fingerprint');
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -66,6 +90,10 @@ export async function computeBaseFingerprint(projectRoot: string): Promise<BaseF
   let layer1Hash: string | null = null;
 
   try {
+    // Lazy, fail-soft load: a missing/broken @expo/fingerprint install rejects
+    // here and is caught below, degrading to hash:null instead of crashing.
+    const { createFingerprintAsync, SourceSkips } = await loadExpoFingerprint();
+
     const options: FingerprintOptions =
       workflow === 'managed'
         ? {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,4 +3,11 @@ import start from './start';
 export * as commands from './commands';
 export * as constants from './constants';
 
+// Exposed on the package's public entry so the packaging regression test
+// (src/helpers/fingerprint/__tests__/packagedFingerprint.test.ts) can invoke
+// the EXACT bundled base-fingerprint path from the installed CLI artifact,
+// proving @expo/fingerprint's spawned ExpoConfigLoader.js helper is reachable
+// at runtime. See SHERLO-1742.
+export { computeBaseFingerprint } from './helpers/fingerprint';
+
 export default start;


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1742

## SHERLO-1742: Published CLI can now compute base fingerprints from the installed artifact

### The bug

`packages/cli` builds via `ncc build src/index.ts --minify`, which INLINED `@expo/fingerprint` into `dist/index.js`. At runtime that library SPAWNS a helper file it ships, `ExpoConfigLoader.js`, resolved relative to its own `__dirname`. Once inlined, `__dirname` was the CLI's `dist/`, where the helper was never emitted (bundlers cannot see spawn targets), so the subprocess died `MODULE_NOT_FOUND`. The CLI's fail-soft correctly degraded every base-fingerprint computation to `hash:null` -> not-stageable, so nothing crashed and no test caught it: unit/integration tests all ran from the repo build tree (where `node_modules/@expo/fingerprint` exists), never from the packed artifact. Result: the staged fast path was silently unavailable on ALL dist channels (test/dev AND npm latest, same build script).

### The fix (approach chosen: externalize `@expo/fingerprint`)

Two approaches were on the table:

- **(a) Copy the spawned asset into `dist/` at build time** and pin its source path against the installed `@expo/fingerprint`, failing the build loudly if it moves on upgrade.
- **(b) Externalize `@expo/fingerprint`** (real runtime `dependencies` entry, excluded from the ncc bundle) so it runs from its own installed package directory with its helper assets intact.

**Chosen: (b) externalize.** It is correct by construction: kept external, `@expo/fingerprint`'s `__dirname` points at its own installed package directory, so `ExpoConfigLoader.js` (and any sibling files it `require`s) resolve exactly as the library authors intended. There is no asset path for us to track.

**Why (a) was rejected:** copying the asset re-implements the bundler's job for a spawn target the bundler cannot see. It would require pinning the exact source path of `ExpoConfigLoader.js` plus every file it transitively `require`s, and a build-time guard that fails when any of them move. A future `@expo/fingerprint` refactor that renames, relocates, or adds a spawned helper would silently reintroduce this exact bug class. Externalizing instead delegates asset integrity to npm/yarn's own package resolution, which is the source of truth.

Concretely:

- `@expo/fingerprint` moved from `devDependencies` to `dependencies`.
- ncc build gains `--external @expo/fingerprint`, so it is no longer inlined.
- The import is now a LAZY dynamic `import()` inside `computeBaseFingerprint`'s fail-soft try/catch (only the erased `import type` remains at the top). A top-level value import would compile to an eager `require('@expo/fingerprint')` at CLI startup, so a missing/broken install would crash the ENTIRE CLI. Lazy-loading keeps the degradation scoped to this one function: unavailable fingerprint -> `hash:null`, never a crashed push.

**Correct under both installers:** as a normal `dependencies` entry, `@expo/fingerprint` and its transitive deps install into `node_modules` under both `yarn` and `npm`, and the external dynamic import resolves them from there in both cases. **Future upgrades need no re-pinning:** a version bump simply installs the new package with whatever assets it ships.

### Fail-soft preserved exactly

`@expo/fingerprint` unavailability still degrades to `hash:null` and never throws. A test asserts this by deleting `@expo/fingerprint` from the installed project and confirming the CLI still loads and returns `hash:null` (no crash).

### The publish gate (this class can never ship again)

New test `packages/cli/src/helpers/fingerprint/__tests__/packagedFingerprint.test.ts` does exactly what a user's machine does:

1. `yarn build` the CLI (ncc bundle -> `dist/`).
2. `npm pack` it (the real tarball `npm publish` would upload).
3. `npm install` that tarball into a fresh throwaway project.
4. Run the base-fingerprint path FROM the installed `node_modules/sherlo`.

It asserts (AC1) a non-null hash with no `ExpoConfigLoader` spawn failure on a staged-capable managed-Expo fixture, and (AC3) `hash:null` with no crash when `@expo/fingerprint` is removed. It runs inside `yarn test` (vitest), which is the publish-gating unit workflow (`pr_checks.yml`) - the same publish-gate principle as SHERLO-1729.

`src/index.ts` now re-exports `computeBaseFingerprint` on the package entry so the test can invoke the exact bundled path from the installed artifact (the ncc bundle is a single file with no importable sub-paths).

### Verification

- `tsc --noEmit -p packages/cli`: clean.
- `yarn lint` (packages/cli): 0 errors.
- `yarn test` (packages/cli): 425/425 passing, including the new packaging + fail-soft tests.
- The fingerprint algorithm/augmentation logic (SHERLO-1682) is untouched; this is packaging only.

### Scope / follow-up

- **Out of scope, by design:** npm-latest republish. The operator decides prod timing. After merge, only the **test** and **dev** dist-tags should be republished from the fixed build (the Director then re-fires SHERLO-1725's held suites on the test republish).

Closes SHERLO-1742.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
