### PR TITLE
feat: [Phase 3] Activation wiring: parameter merge, test mode, int…

### DIFF
--- a/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
@@ -1,0 +1,139 @@
+vi.mock('../../SherloModule', () => ({
+  default: {
+    getMode: vi.fn().mockReturnValue('default'),
+  },
+}));
+
+import createMockable from '../../mocking/createMockable';
+import { activateStoryMocks } from '../../mocking';
+import { clearMocks, __resetShimmedKeysForTests } from '../../mocking/registry';
+import { enumerateStories } from '../../storybook/adapter';
+import type { StorybookView } from '../../types';
+
+afterEach(() => {
+  clearMocks();
+  __resetShimmedKeysForTests();
+  vi.restoreAllMocks();
+  delete (globalThis as any).STORIES;
+});
+
+describe('activateStoryMocks - activation lifecycle (IS-02, IS-07)', () => {
+  it('IS-02: activating a second story replaces the first story’s mock for the same module - no bleed', () => {
+    const realModule = { greet: () => 'real' };
+    const mockable = createMockable('pkg/greet', realModule);
+
+    activateStoryMocks({ 'pkg/greet': { greet: () => 'story-1' } });
+    expect(mockable.greet()).toBe('story-1');
+
+    activateStoryMocks({ 'pkg/greet': { greet: () => 'story-2' } });
+    expect(mockable.greet()).toBe('story-2');
+  });
+
+  it('IS-02: a module mocked in story 1 but left untouched by story 2 falls back to real - not story 1’s mock', () => {
+    const realModule = { region: 'real-region' };
+    const mockable = createMockable('pkg/region', realModule);
+
+    activateStoryMocks({ 'pkg/region': { region: 'story-1-region' } });
+    expect(mockable.region).toBe('story-1-region');
+
+    // Story 2's mock set doesn't mention 'pkg/region' at all.
+    activateStoryMocks({ 'pkg/other': { value: 'story-2' } });
+    expect(mockable.region).toBe('real-region');
+  });
+
+  it('IS-07: after the run ends (clearMocks) every mocked module passes through to real', () => {
+    const realModule = { greet: () => 'real' };
+    const mockable = createMockable('pkg/greet-2', realModule);
+
+    activateStoryMocks({ 'pkg/greet-2': { greet: () => 'mocked' } });
+    expect(mockable.greet()).toBe('mocked');
+
+    clearMocks();
+
+    expect(mockable.greet()).toBe('real');
+  });
+});
+
+describe('activateStoryMocks - declared-but-unshimmed tripwire (FG-03)', () => {
+  it('warns exactly once, naming the key and both fixes, when a declared mock has no shim', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    activateStoryMocks({ 'pkg/never-shimmed': { value: 1 } });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('pkg/never-shimmed');
+    expect(message.toLowerCase()).toContain('restart');
+    expect(message).toContain('mockModules');
+  });
+
+  it('names every unshimmed key in a single warning, not one warning per key', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    activateStoryMocks({ 'pkg/missing-a': {}, 'pkg/missing-b': {} });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('pkg/missing-a');
+    expect(message).toContain('pkg/missing-b');
+  });
+
+  it('does not warn about a key that IS shimmed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createMockable('pkg/shimmed-ok', {});
+
+    activateStoryMocks({ 'pkg/shimmed-ok': { value: 1 } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('in a mixed activation, only names the unshimmed key - not the correctly-shimmed one', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createMockable('pkg/shimmed', {});
+
+    activateStoryMocks({ 'pkg/shimmed': {}, 'pkg/not-shimmed': {} });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('"pkg/not-shimmed"');
+    expect(message).not.toContain('"pkg/shimmed"');
+  });
+
+  it('does not warn when no mocks are declared at all', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    activateStoryMocks({});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('load ordering: a key whose shim was evaluated via enumerateStories’ require.context walk is not a false positive', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const fileExports = {
+      default: { title: 'Components/Widget' },
+      Default: { parameters: { sherlo: { mocks: { 'pkg/widget-dep': { value: 'mock' } } } } },
+    };
+    // Requiring a story file also evaluates its static imports, including any
+    // generated shim reachable from it - mirror that by having req() itself run
+    // createMockable, exactly like a shim module would when Metro's require.context
+    // eagerly requires every story file.
+    const req = Object.assign(
+      (_filename: string) => {
+        createMockable('pkg/widget-dep', {});
+        return fileExports;
+      },
+      { keys: () => ['./Widget.stories.tsx'] }
+    );
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = { _storyIndex: { entries: {} } } as unknown as StorybookView;
+    // enumerateStories eagerly requires every story file - by the time it returns,
+    // every reachable shim (including pkg/widget-dep's) has already registered.
+    const storyMetas = enumerateStories(view);
+
+    activateStoryMocks(storyMetas[0].mocks);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/createMockable.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/createMockable.test.ts
@@ -1,8 +1,24 @@
 import createMockable from '../../mocking/createMockable';
-import { activateMocks, clearMocks } from '../../mocking/registry';
+import {
+  activateMocks,
+  clearMocks,
+  isKeyShimmed,
+  __resetShimmedKeysForTests,
+} from '../../mocking/registry';
 
 afterEach(() => {
   clearMocks();
+  __resetShimmedKeysForTests();
+});
+
+describe('createMockable - registers its key as shimmed (FG-03)', () => {
+  it('registers the key the moment the shim module evaluates, before any activation', () => {
+    expect(isKeyShimmed('pkg/registers-on-eval')).toBe(false);
+
+    createMockable('pkg/registers-on-eval', {});
+
+    expect(isKeyShimmed('pkg/registers-on-eval')).toBe(true);
+  });
 });
 
 describe('createMockable - no active mock set (IS-07)', () => {

--- a/packages/react-native-storybook/src/__tests__/mocking/enumerateStoriesMocks.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/enumerateStoriesMocks.test.ts
@@ -1,0 +1,129 @@
+vi.mock('../../SherloModule', () => ({
+  default: {
+    getMode: vi.fn().mockReturnValue('default'),
+  },
+}));
+
+import { enumerateStories } from '../../storybook/adapter';
+import type { StorybookView } from '../../types';
+
+afterEach(() => {
+  delete (globalThis as any).STORIES;
+});
+
+// Global-level merging is covered exhaustively by mergeMocks.test.ts (CP-01, CP-04,
+// CP-07) against the pure mergeMockSet function. These tests instead exercise the
+// wiring in enumerateStories itself: proving that meta- and story-level mocks merge
+// per key even though the collapsed `parameters.sherlo` field (the shallow spread at
+// the top of enumerateStories) has already lost that precedence by the time it lands
+// on StoryMeta.parameters - see the CRITICAL PITFALL note on StoryMeta.mocks.
+describe('enumerateStories – StoryMeta.mocks merged from the raw parameter levels (SHERLO-1735)', () => {
+  it('merges meta and story mocks per key even though `parameters.sherlo` itself is collapsed wholesale', () => {
+    const fileExports = {
+      default: {
+        title: 'Components/Button',
+        parameters: {
+          sherlo: { mocks: { 'pkg/b': { value: 'meta-b' }, 'pkg/c': { value: 'meta-c' } } },
+        },
+      },
+      Primary: {
+        parameters: { sherlo: { mocks: { 'pkg/c': { value: 'story-c' } } } },
+      },
+    };
+    const req = Object.assign((_filename: string) => fileExports, {
+      keys: () => ['./Button.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = { _storyIndex: { entries: {} } } as unknown as StorybookView;
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    const meta = storyMetas[0];
+
+    // Per-key merge: story overrides meta ('pkg/c'); 'pkg/b' (meta-only) survives untouched.
+    expect(meta.mocks).toEqual({
+      'pkg/b': { value: 'meta-b' },
+      'pkg/c': { value: 'story-c' },
+    });
+
+    // The collapsed `parameters.sherlo` is a WHOLESALE spread - the story's `sherlo`
+    // object replaces meta's entirely, so it does NOT contain 'pkg/b' at all. This is
+    // exactly why `.mocks` must be computed from the raw levels separately.
+    expect(meta.parameters.sherlo.mocks).toEqual({ 'pkg/c': { value: 'story-c' } });
+  });
+
+  it('auto-titled fallback pass also merges meta and story mocks from the raw levels', () => {
+    const autoTitledFileExports = {
+      default: {
+        component: function AutoBtn() {
+          return null;
+        },
+        parameters: { sherlo: { mocks: { 'pkg/b': { value: 'meta-b' } } } },
+      },
+      Basic: {
+        parameters: { sherlo: { mocks: { 'pkg/c': { value: 'story-c' } } } },
+      },
+    };
+    const req = Object.assign((_filename: string) => autoTitledFileExports, {
+      keys: () => ['./AutoBtn.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = {
+      _storyIndex: {
+        entries: {
+          'autobtn--basic': {
+            id: 'autobtn--basic',
+            title: 'AutoBtn',
+            name: 'Basic',
+            importPath: './src/AutoBtn.stories.tsx',
+          },
+        },
+      },
+    } as unknown as StorybookView;
+
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    expect(storyMetas[0].mocks).toEqual({
+      'pkg/b': { value: 'meta-b' },
+      'pkg/c': { value: 'story-c' },
+    });
+  });
+
+  it('a story that declares no mocks of its own still inherits the meta-level mock untouched', () => {
+    const fileExports = {
+      default: {
+        title: 'Components/Plain',
+        parameters: { sherlo: { mocks: { 'pkg/a': { value: 'meta-a' } } } },
+      },
+      Default: {},
+    };
+    const req = Object.assign((_filename: string) => fileExports, {
+      keys: () => ['./Plain.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = { _storyIndex: { entries: {} } } as unknown as StorybookView;
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas[0].mocks).toEqual({ 'pkg/a': { value: 'meta-a' } });
+  });
+
+  it('a story with no sherlo parameters at any level gets an empty mock set, not undefined', () => {
+    const fileExports = {
+      default: { title: 'Components/NoMocks' },
+      Default: {},
+    };
+    const req = Object.assign((_filename: string) => fileExports, {
+      keys: () => ['./NoMocks.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = { _storyIndex: { entries: {} } } as unknown as StorybookView;
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas[0].mocks).toEqual({});
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/mergeMocks.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/mergeMocks.test.ts
@@ -1,0 +1,112 @@
+import { mergeMockSet } from '../../mocking/mergeMocks';
+
+describe('mergeMockSet - per-module-key precedence (CP-01..CP-05, CP-07)', () => {
+  it('CP-01: global mocks apply everywhere', () => {
+    const merged = mergeMockSet({ 'pkg/a': { value: 'global' } }, {}, {});
+
+    expect(merged).toEqual({ 'pkg/a': { value: 'global' } });
+  });
+
+  it('CP-02: meta mocks apply to the file', () => {
+    const merged = mergeMockSet({}, { 'pkg/a': { value: 'meta' } }, {});
+
+    expect(merged).toEqual({ 'pkg/a': { value: 'meta' } });
+  });
+
+  it('CP-03: story overrides meta for the same key', () => {
+    const merged = mergeMockSet(
+      {},
+      { 'pkg/a': { value: 'meta', extra: 'only-on-meta' } },
+      { 'pkg/a': { value: 'story' } }
+    );
+
+    // story's definition for 'pkg/a' replaces meta's ENTIRELY - it does not merge
+    // fields within the definition, so 'extra' from meta is gone too.
+    expect(merged).toEqual({ 'pkg/a': { value: 'story' } });
+  });
+
+  it('CP-04: story overrides global while untouched global keys still apply', () => {
+    const merged = mergeMockSet(
+      { 'pkg/a': { value: 'global' }, 'pkg/b': { value: 'global - untouched' } },
+      {},
+      { 'pkg/a': { value: 'story' } }
+    );
+
+    expect(merged).toEqual({
+      'pkg/a': { value: 'story' },
+      'pkg/b': { value: 'global - untouched' },
+    });
+  });
+
+  it('CP-05: story adds a module alongside inherited ones', () => {
+    const merged = mergeMockSet(
+      { 'pkg/a': { value: 'global' }, 'pkg/shared-global': { value: 'global-shared' } },
+      { 'pkg/b': { value: 'meta' } },
+      { 'pkg/c': { value: 'story-new' } }
+    );
+
+    // 'pkg/c' is a new story-only key that coexists with keys inherited from
+    // global and meta - it doesn't replace or remove them.
+    expect(merged).toEqual({
+      'pkg/a': { value: 'global' },
+      'pkg/shared-global': { value: 'global-shared' },
+      'pkg/b': { value: 'meta' },
+      'pkg/c': { value: 'story-new' },
+    });
+  });
+
+  it('CP-07: story with no own mocks inherits global', () => {
+    const merged = mergeMockSet(
+      { 'pkg/a': { value: 'global' } },
+      { 'pkg/b': { value: 'meta - unrelated key' } },
+      {}
+    );
+
+    // The story declares no mocks of its own, so 'pkg/a' passes through from
+    // global untouched.
+    expect(merged).toEqual({
+      'pkg/a': { value: 'global' },
+      'pkg/b': { value: 'meta - unrelated key' },
+    });
+  });
+
+  it('meta overrides global for the same key wholesale', () => {
+    const merged = mergeMockSet(
+      { 'pkg/a': { value: 'global', extra: 'only-on-global' } },
+      { 'pkg/a': { value: 'meta' } },
+      {}
+    );
+
+    // meta's definition for 'pkg/a' replaces global's ENTIRELY - it does not merge
+    // fields within the definition, so 'extra' from global is gone too.
+    expect(merged).toEqual({ 'pkg/a': { value: 'meta' } });
+  });
+
+  it('untouched keys from every level all survive in the merged set', () => {
+    const merged = mergeMockSet(
+      { 'pkg/global-only': { value: 'global' } },
+      { 'pkg/meta-only': { value: 'meta' } },
+      { 'pkg/story-only': { value: 'story' } }
+    );
+
+    expect(merged).toEqual({
+      'pkg/global-only': { value: 'global' },
+      'pkg/meta-only': { value: 'meta' },
+      'pkg/story-only': { value: 'story' },
+    });
+  });
+
+  it('story wins even when all three levels declare the same key', () => {
+    const merged = mergeMockSet(
+      { 'pkg/a': { value: 'global' } },
+      { 'pkg/a': { value: 'meta' } },
+      { 'pkg/a': { value: 'story' } }
+    );
+
+    expect(merged).toEqual({ 'pkg/a': { value: 'story' } });
+  });
+
+  it('defaults every level to an empty set, returning {} when nothing is declared', () => {
+    expect(mergeMockSet()).toEqual({});
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/registry.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/registry.test.ts
@@ -1,7 +1,15 @@
-import { activateMocks, clearMocks, resolveMockExports } from '../../mocking/registry';
+import {
+  activateMocks,
+  clearMocks,
+  resolveMockExports,
+  registerShimmedKey,
+  isKeyShimmed,
+  __resetShimmedKeysForTests,
+} from '../../mocking/registry';
 
 afterEach(() => {
   clearMocks();
+  __resetShimmedKeysForTests();
 });
 
 describe('registry', () => {
@@ -38,5 +46,22 @@ describe('registry', () => {
     clearMocks();
 
     expect(resolveMockExports('pkg/a', {})).toBeUndefined();
+  });
+});
+
+describe('registry - shimmed key tracking (FG-03)', () => {
+  it('a key is not shimmed until registerShimmedKey is called for it', () => {
+    expect(isKeyShimmed('pkg/unregistered')).toBe(false);
+
+    registerShimmedKey('pkg/unregistered');
+
+    expect(isKeyShimmed('pkg/unregistered')).toBe(true);
+  });
+
+  it('registering the same key twice is a harmless no-op', () => {
+    registerShimmedKey('pkg/a');
+    registerShimmedKey('pkg/a');
+
+    expect(isKeyShimmed('pkg/a')).toBe(true);
   });
 });

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/TestingMode.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/TestingMode.tsx
@@ -8,6 +8,8 @@ import useTestAllStories from './useTestAllStories';
 import SherloModule from '../../../SherloModule';
 import deepmerge from 'deepmerge';
 import { MetadataProvider, MetadataProviderRef } from './MetadataProvider';
+import { enumerateStories } from '../../../storybook/adapter';
+import { activateStoryMocks } from '../../../mocking';
 
 setupErrorSilencing();
 
@@ -23,12 +25,23 @@ function TestingMode({
   const defaultTheme = useColorScheme() === 'dark' ? darkTheme : theme;
   const metadataProviderRef = useRef<MetadataProviderRef>(null);
 
+  const nextSnapshot = lastState?.nextSnapshot;
+
+  // Install this story's mock set before Storybook (rendered below) mounts it - a plain
+  // render-body call, not an effect, so it runs before any child component's effects
+  // (React flushes child effects before the parent's). Guarded to run once per boot;
+  // each story capture is a fresh app boot, so there is at most one story to activate.
+  const mocksActivatedRef = useRef(false);
+  if (!mocksActivatedRef.current && nextSnapshot) {
+    mocksActivatedRef.current = true;
+    const storyMeta = enumerateStories(view).find((story) => story.id === nextSnapshot.storyId);
+    activateStoryMocks(storyMeta?.mocks ?? {});
+  }
+
   useTestAllStories({
     view,
     metadataProviderRef,
   });
-
-  const nextSnapshot = lastState?.nextSnapshot;
   const uiSettings = nextSnapshot
     ? {
         theme: deepmerge(defaultTheme, nextSnapshot.parameters?.theme ?? {}),

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/useTestAllStories/useTestStory.tsx
@@ -8,6 +8,7 @@ import { readStoryError, clearStoryError } from '../../../storyErrorRegistry';
 import { Config } from '../../../../helpers/RunnerBridge/types';
 import { StorybookView } from '../../../../types';
 import { getStorybookChannel, waitForStoryRendered } from './storyRenderedReadiness';
+import { clearMocks } from '../../../../mocking';
 
 // Readiness defaults, applied SDK-side so an OLD runner that omits
 // these fields still works. Documented in Config (RunnerBridge/types.ts).
@@ -372,6 +373,10 @@ function useTestStory({
       } catch (error) {
         // @ts-ignore
         RunnerBridge.log('story capturing failed', { errorMessage: error?.message });
+      } finally {
+        // IS-07: the run for this story is over - pass every mocked module through to
+        // its real implementation again, regardless of how the try block above exited.
+        clearMocks();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -15,6 +15,10 @@ import {
   getStorybookChannel,
   startStoryRenderedTracking,
 } from './components/TestingMode/useTestAllStories/storyRenderedReadiness';
+import {
+  startInteractiveMockActivation,
+  stopInteractiveMockActivation,
+} from './interactiveMockActivation';
 
 let isSdkCompatible = true;
 if (SherloModule.getMode() === 'testing') {
@@ -84,6 +88,13 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
         ...(initialStoryId && { initialSelection: initialStoryId as InitialSelection }),
       };
     } catch (_e) {}
+
+    // Attach the story-change listener here - the earliest JS access to the channel in
+    // this mode, before the component tree below ever renders - so the very first
+    // selection Storybook resolves on mount is not missed.
+    try {
+      startInteractiveMockActivation(view, getStorybookChannel(view));
+    } catch (_e) {}
   }
 
   const isTestingMode = mode === 'testing';
@@ -128,6 +139,15 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
         inspectLogReported.current = true;
         SherloModule.appendFile(LOG_FILE, `INSPECT_STORY_OPENED:${storyId}\n`);
       } catch (_e) {}
+    }, []);
+
+    // Leaving Storybook (unmount) tears down the mock activation started above:
+    // stop tracking selection changes and pass every module through to real again.
+    useEffect(() => {
+      if (!isStorybookMode) return;
+      return () => {
+        stopInteractiveMockActivation();
+      };
     }, []);
 
     if (isTestingMode) {

--- a/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
+++ b/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
@@ -1,0 +1,86 @@
+/**
+ * Interactive-mode counterpart to the testing-mode activation wired in TestingMode.tsx:
+ * whenever the user picks a different story in Storybook's UI, install that story's
+ * merged mock set before it renders, and clear it when Storybook is torn down.
+ *
+ * CHANNEL / EVENT-NAME CHOICE
+ * Storybook emits `storyChanged` once a new selection settles, BEFORE the story
+ * component itself renders - `storyRendered` (used by storyRenderedReadiness.ts for
+ * testing-mode readiness) fires much later, after render AND play have finished. We
+ * deliberately do NOT import the event name from a `storybook` core package: it is only
+ * a peer dependency of `@storybook/react-native` and isn't guaranteed resolvable from
+ * this SDK. The literal string is part of Storybook's stable wire protocol (8.x/9.x).
+ *
+ * SUBSCRIBE-EARLY
+ * We attach the listener as soon as `getStorybook()` knows it is in interactive mode -
+ * before the returned component tree ever renders - mirroring
+ * storyRenderedReadiness.startStoryRenderedTracking. React flushes a child component's
+ * effects before its parent's, so a listener attached from a hook inside the rendered
+ * tree could lose the race against Storybook's own initial-selection effects; attaching
+ * imperatively from getStorybook() has no such race.
+ */
+import { StorybookView } from '../types';
+import { enumerateStories } from '../storybook/adapter';
+import { activateStoryMocks, clearMocks } from '../mocking';
+
+const STORY_CHANGED = 'storyChanged';
+
+type StorybookChannel = {
+  on: (event: string, listener: (...args: unknown[]) => void) => void;
+  off: (event: string, listener: (...args: unknown[]) => void) => void;
+};
+
+let trackedChannel: StorybookChannel | null = null;
+let trackedView: StorybookView | undefined;
+
+function extractStoryId(args: unknown[]): string | undefined {
+  const first = args[0];
+  if (typeof first === 'string') return first;
+  if (first && typeof first === 'object') {
+    const obj = first as { storyId?: string; id?: string };
+    return obj.storyId ?? obj.id;
+  }
+  return undefined;
+}
+
+function handleStoryChanged(...args: unknown[]): void {
+  const storyId = extractStoryId(args);
+  if (!storyId || !trackedView) return;
+
+  const storyMeta = enumerateStories(trackedView).find((story) => story.id === storyId);
+  activateStoryMocks(storyMeta?.mocks ?? {});
+}
+
+/**
+ * Attach the story-change listener. Idempotent: only the first usable channel is
+ * bound, subsequent calls are no-ops - safe to call once from getStorybook().
+ */
+export function startInteractiveMockActivation(
+  view: StorybookView,
+  channel: StorybookChannel | null
+): void {
+  if (trackedChannel || !channel) return;
+  trackedChannel = channel;
+  trackedView = view;
+  channel.on(STORY_CHANGED, handleStoryChanged as (...args: unknown[]) => void);
+}
+
+/** Call when Storybook is torn down / left: stop tracking and clear the active mock set. */
+export function stopInteractiveMockActivation(): void {
+  if (trackedChannel) {
+    try {
+      trackedChannel.off(STORY_CHANGED, handleStoryChanged as (...args: unknown[]) => void);
+    } catch {
+      // best effort
+    }
+  }
+  trackedChannel = null;
+  trackedView = undefined;
+  clearMocks();
+}
+
+/** Test-only: reset the singleton tracker between unit tests. */
+export function __resetInteractiveMockActivationForTests(): void {
+  trackedChannel = null;
+  trackedView = undefined;
+}

--- a/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
+++ b/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
@@ -1,0 +1,35 @@
+import { activateMocks, isKeyShimmed } from './registry';
+import { MockSet } from './types';
+
+// FG-03: a key declared in `sherlo.mocks` with no generated shim can never take effect -
+// the module import was never redirected, so createMockable never ran for it (typically
+// a static-scan miss, or a key added after the last Metro start). Warn loudly, once per
+// activation, naming the key and both fixes - callers must call this only once shims have
+// had the chance to load (see enumerateStories, which forces every shim to evaluate).
+function warnUnshimmedKeys(mocks: MockSet): void {
+  const unshimmedKeys = Object.keys(mocks).filter((key) => !isKeyShimmed(key));
+  if (unshimmedKeys.length === 0) return;
+
+  const keyList = unshimmedKeys.map((key) => `"${key}"`).join(', ');
+  const plural = unshimmedKeys.length > 1;
+
+  console.warn(
+    `[Sherlo] Mock declared for ${
+      plural ? 'modules' : 'module'
+    } ${keyList} but no shim was generated - ` +
+      `${plural ? 'these mocks' : 'this mock'} will not apply. Fix by either: ` +
+      '(1) restarting Metro so the mock scan picks up the new key, or ' +
+      `(2) adding ${
+        plural ? 'them' : 'it'
+      } to the "mockModules" option in your Sherlo Metro config.`
+  );
+}
+
+// Installs `mocks` as the active set for one story (replacing whatever was active
+// before) and flags any declared key that has no generated shim.
+export function activateStoryMocks(mocks: MockSet): void {
+  activateMocks(mocks);
+  warnUnshimmedKeys(mocks);
+}
+
+export default activateStoryMocks;

--- a/packages/react-native-storybook/src/mocking/createMockable.ts
+++ b/packages/react-native-storybook/src/mocking/createMockable.ts
@@ -1,4 +1,4 @@
-import { resolveMockExports } from './registry';
+import { registerShimmedKey, resolveMockExports } from './registry';
 import { ModuleExports } from './types';
 
 const hasOwn = (obj: ModuleExports, prop: PropertyKey): boolean =>
@@ -10,6 +10,10 @@ const hasOwn = (obj: ModuleExports, prop: PropertyKey): boolean =>
 // itself, so trap results are never constrained by invariants coming from a frozen or sealed
 // real module.
 function createMockable<T extends ModuleExports>(key: string, realModule: T): T {
+  // Runs once, when the shim module is first evaluated - proof that `key` is really
+  // mockable at runtime. Read by the FG-03 declared-but-unshimmed tripwire.
+  registerShimmedKey(key);
+
   const delegate: ModuleExports = {};
 
   return new Proxy(delegate, {

--- a/packages/react-native-storybook/src/mocking/index.ts
+++ b/packages/react-native-storybook/src/mocking/index.ts
@@ -1,4 +1,6 @@
 export { default as createMockable } from './createMockable';
-export { activateMocks, clearMocks } from './registry';
+export { activateMocks, clearMocks, isKeyShimmed } from './registry';
+export { default as activateStoryMocks } from './activateStoryMocks';
+export { mergeMockSet } from './mergeMocks';
 export { MOCK_DENY_LIST } from './denyList';
 export * from './types';

--- a/packages/react-native-storybook/src/mocking/mergeMocks.ts
+++ b/packages/react-native-storybook/src/mocking/mergeMocks.ts
@@ -1,0 +1,17 @@
+import { MockSet } from './types';
+
+// Precedence: story > meta > global. For any module key, the most specific level that
+// declares it wins outright - its whole mock definition replaces what an outer level
+// declared for that key. Keys an inner level leaves untouched still come through from
+// whichever outer level declared them. Spreading global, then meta, then story - in that
+// order - onto one object is the precedence rule: each pass overwrites only the keys it
+// actually declares.
+export function mergeMockSet(
+  global: MockSet = {},
+  meta: MockSet = {},
+  story: MockSet = {}
+): MockSet {
+  return { ...global, ...meta, ...story };
+}
+
+export default mergeMockSet;

--- a/packages/react-native-storybook/src/mocking/registry.ts
+++ b/packages/react-native-storybook/src/mocking/registry.ts
@@ -8,6 +8,10 @@ type Activation = {
 
 let activeActivation: Activation | null = null;
 
+// Keys that a generated shim has actually registered via createMockable, i.e. modules
+// that are really mockable at runtime. Populated as shim modules are evaluated (FG-03).
+const shimmedKeys = new Set<string>();
+
 // Installs the mock set for one story, replacing any previously active set.
 function activateMocks(mocks: MockSet): void {
   activeActivation = { mocks, resolved: new Map() };
@@ -43,4 +47,28 @@ function resolveMockExports(key: string, realModule: ModuleExports): ModuleExpor
   return exports;
 }
 
-export { activateMocks, clearMocks, resolveMockExports };
+// Called once by createMockable when a shim module is evaluated, i.e. the module is
+// really mockable. Idempotent - the module cache guarantees a shim evaluates once anyway.
+function registerShimmedKey(key: string): void {
+  shimmedKeys.add(key);
+}
+
+// Whether `key` has a generated shim that has actually run createMockable. A declared
+// mock key that is NOT shimmed can never apply - see warnUnshimmedKeys (FG-03).
+function isKeyShimmed(key: string): boolean {
+  return shimmedKeys.has(key);
+}
+
+/** Test-only: reset shimmedKeys between unit tests so shim registration doesn't leak. */
+function __resetShimmedKeysForTests(): void {
+  shimmedKeys.clear();
+}
+
+export {
+  activateMocks,
+  clearMocks,
+  resolveMockExports,
+  registerShimmedKey,
+  isKeyShimmed,
+  __resetShimmedKeysForTests,
+};

--- a/packages/react-native-storybook/src/storybook/adapter.ts
+++ b/packages/react-native-storybook/src/storybook/adapter.ts
@@ -1,5 +1,7 @@
 import { StorybookView } from '../types';
 import SherloModule from '../SherloModule';
+import { mergeMockSet } from '../mocking/mergeMocks';
+import { MockSet } from '../mocking/types';
 
 export interface StoryMeta {
   id: string;
@@ -13,6 +15,15 @@ export interface StoryMeta {
    * directory + filename for the primary (titled) path.
    */
   importPath?: string;
+  /**
+   * Module Mocking (SHERLO-1735): the story's mock set, already merged per module key
+   * across global/meta/story parameters (precedence story > meta > global - see
+   * mergeMockSet). Computed from the three RAW `parameters.sherlo.mocks` levels, not
+   * from `parameters` above - that field is a shallow spread of all three levels, so a
+   * story's `parameters.sherlo` replaces meta's and global's wholesale and the
+   * per-key mock precedence would otherwise be lost.
+   */
+  mocks: MockSet;
 }
 
 const SANITIZE_REGEX = /[ '–-―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/gi;
@@ -54,6 +65,7 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
   const indexEntries = (view as unknown as ViewInternal)._storyIndex?.entries ?? {};
   const storyEntries = readStoryEntries();
   const globalParams = readGlobalParameters();
+  const globalMocks: MockSet = globalParams?.sherlo?.mocks ?? {};
   const result: StoryMeta[] = [];
   const seen = new Set<string>();
 
@@ -143,12 +155,15 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
           ...(meta.parameters ?? {}),
           ...(annotations.parameters ?? {}),
         };
+        const metaMocks: MockSet = meta.parameters?.sherlo?.mocks ?? {};
+        const storyMocks: MockSet = annotations.parameters?.sherlo?.mocks ?? {};
         result.push({
           id,
           title: titleStr,
           name: displayName,
           parameters,
           importPath: primaryImportPath,
+          mocks: mergeMockSet(globalMocks, metaMocks, storyMocks),
         });
       }
     }
@@ -188,6 +203,8 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
           break;
         }
       }
+      const metaMocks: MockSet = cached.meta.parameters?.sherlo?.mocks ?? {};
+      const storyMocks: MockSet = storyAnnotations.parameters?.sherlo?.mocks ?? {};
       result.push({
         id,
         title: indexEntry.title,
@@ -198,6 +215,7 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
           ...(storyAnnotations.parameters ?? {}),
         },
         importPath: indexEntry.importPath,
+        mocks: mergeMockSet(globalMocks, metaMocks, storyMocks),
       });
     } else {
       result.push({
@@ -206,6 +224,7 @@ export function enumerateStories(view: StorybookView): StoryMeta[] {
         name: indexEntry.name,
         parameters: { ...(globalParams ?? {}) },
         importPath: indexEntry.importPath,
+        mocks: globalMocks,
       });
     }
   }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1735

## Phase 3 - Activation wiring (Module Mocking epic, SHERLO-1735)

Wires the Phase 1 mocking runtime into Sherlo's story flow. Phases 1 (runtime) and 2 (Metro shim layer) are already merged.

### What changed
- **Per-module-key merge** (`src/mocking/mergeMocks.ts`): `mergeMockSet(global, meta, story)` merges the three `parameters.sherlo.mocks` levels per module key with precedence story > meta > global. A level's entry for a key replaces the outer entry for that key wholesale; untouched outer keys still apply. Reads as the precedence rule itself.
- **Adapter** (`src/storybook/adapter.ts`): `enumerateStories` attaches a merged `mocks` set to every `StoryMeta`, computed from the three RAW parameter levels - not from the already shallow-spread `parameters` (which would collapse `sherlo.mocks` wholesale and lose per-key precedence).
- **Test mode** (`TestingMode.tsx`, `useTestStory.tsx`): the active story's merged set is installed in the render body before Storybook mounts the story (IS-02, wholesale replace); `clearMocks()` runs in a `finally` after each story's capture so modules pass through to real afterward (IS-07).
- **Interactive mode** (`getStorybook.tsx`, `interactiveMockActivation.ts`): subscribes to the Storybook `storyChanged` channel event (fires before render), activates the selected story's merged set on each selection change, clears on Storybook teardown.
- **FG-03 tripwire** (`createMockable.ts`, `registry.ts`, `activateStoryMocks.ts`): `createMockable` registers each shimmed key with the registry when its shim evaluates. On activation, any declared key with no shim triggers one loud `console.warn` naming the key and both fixes (restart Metro, or add to `mockModules`). Enumeration forces all shims to load before the warning fires, so a correctly-declared key is never a false positive.

### Tests
- Merge precedence rows CP-01..CP-05, CP-07 (each mapped 1:1 to the ticket's scenario definitions).
- Activation lifecycle IS-02 (no bleed between consecutive stories), IS-07 (post-run pass-through), FG-03 (declared-but-unshimmed warning, incl. an explicit load-ordering false-positive guard).
- Full package suite green: 323 passed / 2 skipped; `tsc` and `eslint` clean.

### Out of scope
Device-level proof (the AC's manual smoke on a fixture app) is owned by Phases 4-5; the unit lifecycle tests stand in for it here.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
