### PR TITLE
feat: [Phase 4.5] Fix SDK defects caught by device suite I: global…

### DIFF
--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -115,12 +115,119 @@ function appModuleResult(file) {
   };
 }
 
+// A bare key is a package ROOT (not a subpath) when it has no path segment past
+// the package name: 'async-storage' or '@scope/name', but NOT 'pkg/submodule' or
+// '@scope/name/submodule'. Only roots need alternate-entry registration below -
+// subpath keys resolve to one concrete file that Node and Metro agree on.
+function isPackageRootKey(key) {
+  if (key.charAt(0) === '@') return key.split('/').length === 2;
+  return key.indexOf('/') === -1;
+}
+
+// Walk up from a resolved file to the directory of the package that owns it,
+// returning { dir, pkg } once a package.json whose "name" matches the key is
+// found. Matching on name (not just "first package.json up") skips nested
+// dependency package.jsons and lands on the real package root.
+function findPackageDir(fromFile, key) {
+  var dir = path.dirname(fromFile);
+  while (true) {
+    try {
+      var pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      if (pkg && pkg.name === key) return { dir: dir, pkg: pkg };
+    } catch (_) {
+      /* no package.json here (or unreadable) - keep walking up */
+    }
+    var parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// Collect every string leaf under a package.json "exports" value that applies to
+// the package root ("."). exports can be a bare string, a { ".": ... } map, or a
+// pure conditions object (no subpath keys). Different conditions (react-native,
+// import, require, default) can each point at a DIFFERENT file, and Metro follows
+// the 'react-native' condition while Node follows 'require'/'default' - so we
+// gather them all as alternate entries.
+function collectExportsRootLeaves(exportsField) {
+  if (!exportsField) return [];
+  var rootEntry;
+  if (typeof exportsField === 'string') {
+    rootEntry = exportsField;
+  } else if (Object.prototype.hasOwnProperty.call(exportsField, '.')) {
+    rootEntry = exportsField['.'];
+  } else if (Object.keys(exportsField).some((k) => k.charAt(0) === '.')) {
+    // Has subpath keys but no '.' entry -> no root entry to register.
+    return [];
+  } else {
+    // A pure conditions object applies to the root.
+    rootEntry = exportsField;
+  }
+  return collectStringLeaves(rootEntry);
+}
+
+function collectStringLeaves(node) {
+  if (typeof node === 'string') return [node];
+  if (node && typeof node === 'object') {
+    var out = [];
+    for (var k of Object.keys(node)) {
+      out = out.concat(collectStringLeaves(node[k]));
+    }
+    return out;
+  }
+  return [];
+}
+
+// For a package-root key, the canonical entry file Node's require.resolve picks
+// (e.g. lib/commonjs/index.js via "main"/exports.require) can differ from the one
+// Metro picks (e.g. src/index.ts via the "react-native" field/condition). When
+// they diverge the resolver's map lookup misses and the redirect silently no-ops
+// (MK-02). To keep config-time identity in agreement with Metro's bundle-time
+// resolution, register EVERY plausible root entry - "main", "react-native", and
+// all exports-root leaves - as an alternate canonical path pointing at the same
+// shim. Whichever file Metro resolves at bundle time then matches.
+function packageRootAlternateCanonicalPaths(key, resolved, primaryCanonicalPath) {
+  if (!isPackageRootKey(key)) return [];
+  var located = findPackageDir(resolved, key);
+  if (!located) return [];
+
+  var candidates = [located.pkg.main, located.pkg['react-native']].concat(
+    collectExportsRootLeaves(located.pkg.exports)
+  );
+
+  var seen = {};
+  var alternates = [];
+  for (var i = 0; i < candidates.length; i++) {
+    var candidate = candidates[i];
+    if (!candidate || typeof candidate !== 'string') continue;
+    // Resolve the candidate (a package-relative specifier) to a concrete file,
+    // probing extensions/index the same way an app module is resolved.
+    var abs = path.resolve(located.dir, candidate);
+    var file = null;
+    try {
+      if (fs.statSync(abs).isFile()) file = abs;
+    } catch (_) {
+      /* not a direct file - fall through to extension/index probing */
+    }
+    if (!file) file = resolveAppModuleFile(abs);
+    if (!file) continue;
+
+    var canonical = canonicalizeModulePath(file);
+    if (canonical === primaryCanonicalPath || seen[canonical]) continue;
+    seen[canonical] = true;
+    alternates.push(canonical);
+  }
+  return alternates;
+}
+
 // Resolve one mock key to:
 //   - canonicalRealPath: the identity the resolver matches delegate output on,
 //   - requireSpecifier:  what the shim's inner require() targets. Bare package
 //     keys keep their specifier so Metro re-resolves per platform (MK-06);
 //     app-module keys use the extensionless absolute path so Metro re-resolves
 //     the platform-split file per platform.
+//   - alternateCanonicalPaths: extra identities (for package roots) that Metro
+//     might resolve the same key to, all pointing at the same shim (MK-02).
 // Throws when the key cannot be resolved (FG-01).
 function resolveMockKey(key, projectRoot) {
   // Explicit './'-prefixed or absolute keys are always app modules.
@@ -138,9 +245,15 @@ function resolveMockKey(key, projectRoot) {
   // canonical app-module key form. FG-01 fires only when both routes fail.
   try {
     var resolved = require.resolve(key, { paths: [projectRoot] });
+    var canonicalRealPath = canonicalizeModulePath(resolved);
     return {
-      canonicalRealPath: canonicalizeModulePath(resolved),
+      canonicalRealPath: canonicalRealPath,
       requireSpecifier: key,
+      alternateCanonicalPaths: packageRootAlternateCanonicalPaths(
+        key,
+        resolved,
+        canonicalRealPath
+      ),
     };
   } catch (_) {
     var appFile = resolveAppModuleFile(path.resolve(projectRoot, key));
@@ -239,7 +352,14 @@ function setupMocks(opts) {
     var shimPath = path.join(mocksDir, shimFileName(key));
     fs.writeFileSync(shimPath, generateShimContent(key, resolved.requireSpecifier), 'utf8');
 
+    // Register the primary identity plus any alternate package-root entries
+    // (main/react-native/exports) so the redirect hits whichever file Metro
+    // resolves the key to at bundle time (MK-02).
     mockedPathToShim.set(resolved.canonicalRealPath, shimPath);
+    var alternates = resolved.alternateCanonicalPaths || [];
+    for (var a = 0; a < alternates.length; a++) {
+      mockedPathToShim.set(alternates[a], shimPath);
+    }
     shimPaths.push(shimPath);
   });
 

--- a/packages/react-native-storybook/src/__tests__/mocking/enumerateStoriesMocks.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/enumerateStoriesMocks.test.ts
@@ -11,12 +11,19 @@ afterEach(() => {
   delete (globalThis as any).STORIES;
 });
 
-// Global-level merging is covered exhaustively by mergeMocks.test.ts (CP-01, CP-04,
-// CP-07) against the pure mergeMockSet function. These tests instead exercise the
-// wiring in enumerateStories itself: proving that meta- and story-level mocks merge
-// per key even though the collapsed `parameters.sherlo` field (the shallow spread at
-// the top of enumerateStories) has already lost that precedence by the time it lands
-// on StoryMeta.parameters - see the CRITICAL PITFALL note on StoryMeta.mocks.
+// These tests exercise the wiring in enumerateStories itself: proving that meta-,
+// story- AND global-level mocks merge per key even though the collapsed
+// `parameters.sherlo` field (the shallow spread at the top of enumerateStories) has
+// already lost that precedence by the time it lands on StoryMeta.parameters - see the
+// CRITICAL PITFALL note on StoryMeta.mocks.
+//
+// The global level is sourced from Storybook's live preview object
+// (view._preview.storyStoreValue.projectAnnotations.parameters) - the merged
+// preview-level annotations declared in the app's .rnstorybook/preview.ts. The
+// dedicated describe block below pins that source: before SHERLO-1743, readGlobalParameters
+// require()'d @storybook/react-native/preview (an internal stub carrying no project
+// annotations), so global-level mocks were silently dropped on device and this
+// end-to-end path was never exercised.
 describe('enumerateStories – StoryMeta.mocks merged from the raw parameter levels (SHERLO-1735)', () => {
   it('merges meta and story mocks per key even though `parameters.sherlo` itself is collapsed wholesale', () => {
     const fileExports = {
@@ -125,5 +132,103 @@ describe('enumerateStories – StoryMeta.mocks merged from the raw parameter lev
     const storyMetas = enumerateStories(view);
 
     expect(storyMetas[0].mocks).toEqual({});
+  });
+});
+
+// Builds a fake StorybookView whose _preview carries preview-level parameters
+// exactly where Storybook stores the composed project annotations on device:
+// view._preview.storyStoreValue.projectAnnotations.parameters. This is the source
+// readGlobalParameters must read from (SHERLO-1743, Defect 1).
+function viewWithGlobalMocks(
+  globalMocks: Record<string, unknown>,
+  entries: Record<string, { id: string; title: string; name: string; importPath: string }> = {}
+): StorybookView {
+  return {
+    _storyIndex: { entries },
+    _preview: {
+      storyStoreValue: {
+        projectAnnotations: {
+          parameters: { sherlo: { mocks: globalMocks } },
+        },
+      },
+    },
+  } as unknown as StorybookView;
+}
+
+describe('enumerateStories – global (preview-level) mocks flow from view._preview (SHERLO-1743, Defect 1)', () => {
+  it('merges global, meta and story mocks per key with story > meta > global precedence', () => {
+    // Mirrors the Precedence.stories contract: alpha is global-only, beta is
+    // overridden at meta, gamma is overridden all the way to story.
+    const fileExports = {
+      default: {
+        title: 'Mocking/Precedence',
+        parameters: {
+          sherlo: { mocks: { beta: { origin: 'meta' }, gamma: { origin: 'meta' } } },
+        },
+      },
+      Overrides: {
+        parameters: { sherlo: { mocks: { gamma: { origin: 'story' } } } },
+      },
+    };
+    const req = Object.assign((_filename: string) => fileExports, {
+      keys: () => ['./Precedence.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = viewWithGlobalMocks({
+      alpha: { origin: 'global' },
+      beta: { origin: 'global' },
+      gamma: { origin: 'global' },
+    });
+
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    // alpha survives from global; beta wins at meta; gamma wins at story. Before the
+    // fix globalMocks was always {} (the @storybook/react-native/preview require
+    // stub), so `alpha` would be absent entirely and this assertion would fail.
+    expect(storyMetas[0].mocks).toEqual({
+      alpha: { origin: 'global' },
+      beta: { origin: 'meta' },
+      gamma: { origin: 'story' },
+    });
+  });
+
+  it('a story with no meta/story mocks still inherits the global mock (CP-07 inheritance)', () => {
+    const fileExports = {
+      default: { title: 'Mocking/Precedence' },
+      Inherited: {},
+    };
+    const req = Object.assign((_filename: string) => fileExports, {
+      keys: () => ['./Precedence.stories.tsx'],
+    });
+    (globalThis as any).STORIES = [{ directory: './src', req }];
+
+    const view = viewWithGlobalMocks({ alpha: { origin: 'global' } });
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas[0].mocks).toEqual({ alpha: { origin: 'global' } });
+  });
+
+  it('global mocks also reach the _storyIndex fallback pass (auto-titled / index-only stories)', () => {
+    // No STORIES require.context entry emits this id, so it is recovered only by the
+    // fallback loop - which must still layer in the global mocks.
+    (globalThis as any).STORIES = [];
+
+    const view = viewWithGlobalMocks(
+      { alpha: { origin: 'global' } },
+      {
+        'mocking-precedence--inherited': {
+          id: 'mocking-precedence--inherited',
+          title: 'Mocking/Precedence',
+          name: 'Inherited',
+          importPath: './src/Precedence.stories.tsx',
+        },
+      }
+    );
+    const storyMetas = enumerateStories(view);
+
+    expect(storyMetas).toHaveLength(1);
+    expect(storyMetas[0].mocks).toEqual({ alpha: { origin: 'global' } });
   });
 });

--- a/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
@@ -48,6 +48,31 @@ function writePackage(
   }
 }
 
+// Like writePackage but lets the caller supply arbitrary package.json fields
+// (e.g. a `react-native` field or an `exports` map whose entries diverge from
+// `main`). Used to reproduce the MK-02 scoped-root divergence: Node's
+// require.resolve picks `main` at config time while Metro follows the
+// `react-native` condition to a different file at bundle time.
+function writePackageWithJson(
+  root: string,
+  name: string,
+  pkgJson: Record<string, unknown>,
+  files: Record<string, string>
+): void {
+  const pkgDir = path.join(root, 'node_modules', name);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version: '1.0.0', ...pkgJson }),
+    'utf8'
+  );
+  for (const rel of Object.keys(files)) {
+    const f = path.join(pkgDir, rel);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, files[rel], 'utf8');
+  }
+}
+
 // Fake Metro resolver context whose delegate maps module names -> absolute paths.
 function makeContext(originModulePath: string, resolveMap: Record<string, string>) {
   return {
@@ -375,6 +400,93 @@ describe('mockShims.resolveMockKey', () => {
     expect(() => mockShims.resolveMockKey('totally-not-installed', root)).toThrow();
     cleanup(root);
   });
+
+  it('MK-02: a scoped package ROOT whose react-native field diverges from main registers BOTH entries', () => {
+    // require.resolve follows `main` (lib/commonjs/index.js); Metro follows the
+    // `react-native` field (src/index.ts). The two canonical identities diverge,
+    // so the config-time identity must ALSO include Metro's entry as an alternate.
+    const root = mkProject('sherlo-resolvekey-scoped-root-');
+    writePackageWithJson(
+      root,
+      '@react-native-async-storage/async-storage',
+      { main: 'lib/commonjs/index.js', 'react-native': 'src/index.ts' },
+      { 'lib/commonjs/index.js': 'module.exports = {};', 'src/index.ts': 'export default {};' }
+    );
+    const realRoot = fs.realpathSync(root);
+
+    const resolved = mockShims.resolveMockKey('@react-native-async-storage/async-storage', root);
+    cleanup(root);
+
+    const mainCanonical = path.join(
+      realRoot,
+      'node_modules',
+      '@react-native-async-storage',
+      'async-storage',
+      'lib',
+      'commonjs',
+      'index'
+    );
+    const rnCanonical = path.join(
+      realRoot,
+      'node_modules',
+      '@react-native-async-storage',
+      'async-storage',
+      'src',
+      'index'
+    );
+
+    // Primary is whatever Node picked (main); the react-native entry is registered
+    // as an alternate so Metro's bundle-time resolution still matches.
+    expect(resolved.canonicalRealPath).toBe(mainCanonical);
+    expect(resolved.alternateCanonicalPaths).toContain(rnCanonical);
+    expect(resolved.requireSpecifier).toBe('@react-native-async-storage/async-storage');
+  });
+
+  it('MK-02: an exports map whose react-native condition diverges from require is registered too', () => {
+    const root = mkProject('sherlo-resolvekey-exports-');
+    writePackageWithJson(
+      root,
+      '@react-native-community/slider',
+      {
+        main: 'lib/commonjs/index.js',
+        exports: {
+          '.': {
+            'react-native': './src/index.ts',
+            require: './lib/commonjs/index.js',
+            default: './lib/module/index.js',
+          },
+        },
+      },
+      {
+        'lib/commonjs/index.js': 'module.exports = {};',
+        'lib/module/index.js': 'export default {};',
+        'src/index.ts': 'export default {};',
+      }
+    );
+    const realRoot = fs.realpathSync(root);
+    const pkgRoot = path.join(realRoot, 'node_modules', '@react-native-community', 'slider');
+
+    const resolved = mockShims.resolveMockKey('@react-native-community/slider', root);
+    cleanup(root);
+
+    // The react-native condition (src/index) is the one Metro follows - it must be
+    // among the registered identities regardless of which entry Node picked.
+    const allIdentities = [resolved.canonicalRealPath, ...resolved.alternateCanonicalPaths];
+    expect(allIdentities).toContain(path.join(pkgRoot, 'src', 'index'));
+  });
+
+  it('subpath keys get no alternate root entries (require.resolve already matches Metro)', () => {
+    const root = mkProject('sherlo-resolvekey-subpath-noalt-');
+    writePackage(root, 'libpkg', 'index.js', {
+      'index.js': 'module.exports = {};',
+      'submodule.js': 'module.exports = {};',
+    });
+
+    const resolved = mockShims.resolveMockKey('libpkg/submodule', root);
+    cleanup(root);
+
+    expect(resolved.alternateCanonicalPaths).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -433,6 +545,48 @@ describe('applySherloTransforms resolver redirect', () => {
     expect(scopedResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
     expect(subResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
     expect(scopedResolved.filePath).not.toBe(subResolved.filePath);
+  });
+
+  it('MK-02: redirects a scoped package ROOT even when Metro resolves it to the react-native entry (not main)', () => {
+    // The regression: config-time require.resolve lands on `main`
+    // (lib/commonjs/index.js) while Metro's delegate resolver follows the
+    // `react-native` field to src/index.ts. Before the alternate-identity fix the
+    // resolver map lookup missed and the redirect silently no-op'd.
+    const root = mkProject('sherlo-redirect-scoped-root-');
+    writePackageWithJson(
+      root,
+      '@react-native-async-storage/async-storage',
+      { main: 'lib/commonjs/index.js', 'react-native': 'src/index.ts' },
+      { 'lib/commonjs/index.js': 'module.exports = {};', 'src/index.ts': 'export default {};' }
+    );
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { '@react-native-async-storage/async-storage': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    // Metro resolves the import to the react-native entry, NOT the main entry.
+    const metroEntry = path.join(
+      root,
+      'node_modules',
+      '@react-native-async-storage',
+      'async-storage',
+      'src',
+      'index.ts'
+    );
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+      '@react-native-async-storage/async-storage': metroEntry,
+    });
+
+    const resolved = result.resolver.resolveRequest(
+      ctx,
+      '@react-native-async-storage/async-storage',
+      'android'
+    );
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
   });
 
   it('MK-04: redirects a project-relative app-module import', () => {

--- a/packages/react-native-storybook/src/storybook/adapter.ts
+++ b/packages/react-native-storybook/src/storybook/adapter.ts
@@ -59,12 +59,25 @@ interface ViewInternal {
   _storyIndex?: {
     entries?: Record<string, { id: string; title: string; name: string; importPath: string }>;
   };
+  // Storybook's live Preview instance (PreviewWithSelection). Not on the public
+  // StorybookView type, so - like the other internal fields here and in
+  // getStorybook.tsx - it is reached through a cast. `storyStoreValue` is the
+  // StoryStore that Storybook builds once the preview is ready; its
+  // `projectAnnotations.parameters` holds the composed PROJECT (preview-level)
+  // parameters, including `parameters.sherlo.mocks` declared in the app's
+  // .rnstorybook/preview.ts. This is the only runtime source of global-level
+  // mocks on device (see readGlobalParameters).
+  _preview?: {
+    storyStoreValue?: {
+      projectAnnotations?: { parameters?: Record<string, any> };
+    };
+  };
 }
 
 export function enumerateStories(view: StorybookView): StoryMeta[] {
   const indexEntries = (view as unknown as ViewInternal)._storyIndex?.entries ?? {};
   const storyEntries = readStoryEntries();
-  const globalParams = readGlobalParameters();
+  const globalParams = readGlobalParameters(view);
   const globalMocks: MockSet = globalParams?.sherlo?.mocks ?? {};
   const result: StoryMeta[] = [];
   const seen = new Set<string>();
@@ -248,11 +261,18 @@ function readStoryEntries(): Array<{
   return stories;
 }
 
-function readGlobalParameters(): Record<string, any> {
-  try {
-    const sbRnPreview = (require as any)('@storybook/react-native/preview');
-    return (sbRnPreview && sbRnPreview.default && sbRnPreview.default.parameters) || {};
-  } catch (_) {
-    return {};
-  }
+// Preview-level (global) parameters, sourced from Storybook's live preview object.
+//
+// On device the app's `.rnstorybook/preview.ts` annotations are composed into
+// view._preview.storyStoreValue.projectAnnotations once the preview is ready
+// (which it always is by the time enumerateStories runs - during testing capture
+// or interactive selection). This is the SAME merged project object that
+// getStorybook.tsx reads via view._preview, and it carries `parameters.sherlo.mocks`.
+//
+// The old source - require('@storybook/react-native/preview') - resolves to an
+// internal package stub that never carries the user's project annotations, so
+// global-level mocks were silently dropped on device (SHERLO-1743, Defect 1).
+function readGlobalParameters(view: StorybookView): Record<string, any> {
+  const preview = (view as unknown as ViewInternal)._preview;
+  return preview?.storyStoreValue?.projectAnnotations?.parameters ?? {};
 }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1743

## Summary

Phase 4.5 fixes two genuine SDK defects in the module-mocking feature that the Phase 4 device suite caught, adds unit regression coverage, and un-quarantines the three affected scenario groups (now 9/9 green on Android emulator).

### Defect 1 - global (preview-level) mocks never activated on device
`readGlobalParameters` read the global `sherlo.mocks` from `require('@storybook/react-native/preview')`, an internal package stub that carries no project annotations at runtime, so preview.tsx global mocks were silently dropped (meta/story mocks worked because they come from the raw require.context exports). It now sources preview-level parameters from Storybook's live preview object `view._preview.storyStoreValue.projectAnnotations.parameters` - the same composed project annotations Storybook builds on device. Verified end to end: precedence CP-01/CP-04/CP-07 pass on the emulator.

### Defect 2 - scoped package-ROOT redirect missed
The resolver redirect matches a mock key by its canonical path. The map key was derived from Node `require.resolve` at config time, while the lookup side uses Metro's bundle-time resolution. For a scoped package keyed by its root whose package.json has an `exports` map or `react-native` main field (e.g. `@react-native-async-storage/async-storage`), Node picks a different file than Metro, so the identities never matched and the redirect no-op'd. Fix registers alternate canonical entry paths (`main`, `react-native`, and `exports` root leaves) for package-root keys, all pointing at the same shim, so whichever file Metro resolves at bundle time matches. Subpath keys get no alternates (Node and Metro already agree).

## Changes
- `metro/mockShims.js` - alternate canonical path registration for package roots
- `src/storybook/adapter.ts` - global params sourced from `view._preview`
- Unit regressions for both defects (each fails against pre-fix code)

## Verification
- SDK unit lane green (330 pass); both regressions fail pre-fix
- Full mocking integration variant 9/9 scenario groups green on Android emulator through the real capture flow (0 offline/retry, 137s), un-quarantined in the companion PR sherlo-io/sherlo-developer#18

No changes to the public API surface or mocking DX.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
