### PR TITLE
feat: Staged fingerprint non-determinism across CLI commands (regi…

### DIFF
--- a/packages/cli/src/commands/easBuildOnComplete/helpers/asyncUploadBuildAndRunTests/asyncUploadBuildAndRunTests.ts
+++ b/packages/cli/src/commands/easBuildOnComplete/helpers/asyncUploadBuildAndRunTests/asyncUploadBuildAndRunTests.ts
@@ -69,7 +69,7 @@ async function asyncUploadBuildAndRunTests({
   // gate metadata BEFORE the API call so they can be wired into the
   // asyncUpload payload.
   // ------------------------------------------------------------------
-  const fpResult = await computeBaseFingerprint(DEFAULT_PROJECT_ROOT);
+  const fpResult = await computeBaseFingerprint(DEFAULT_PROJECT_ROOT, { command: THIS_COMMAND });
 
   let baseFingerprint: string | undefined;
   const gateMetadata: { android?: GateMetadataInput; ios?: GateMetadataInput } = {};
@@ -89,6 +89,7 @@ async function asyncUploadBuildAndRunTests({
         bundlePath,
         buildType: binaryBuildType ?? 'preview',
         baseFingerprintHash: fpResult.hash,
+        command: THIS_COMMAND,
       });
 
       if (result.gateMetadata) {

--- a/packages/cli/src/commands/stagedCheck/stagedCheck.ts
+++ b/packages/cli/src/commands/stagedCheck/stagedCheck.ts
@@ -67,7 +67,9 @@ async function stagedCheck(passedOptions: Options<THIS_COMMAND>): Promise<void> 
 
   // Compute the base fingerprint from source (no binary required). A null hash
   // means the staged flow is unavailable for this project.
-  const fpResult = await computeBaseFingerprint(commandParams.projectRoot);
+  const fpResult = await computeBaseFingerprint(commandParams.projectRoot, {
+    command: THIS_COMMAND,
+  });
   if (!fpResult.hash) {
     return reportAndExit({
       jsonOutput,

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -72,7 +72,9 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
 
   // 2. Compute base fingerprint - identifies which base binary to stage against.
   //    A null hash means the staged flow is unavailable for this project.
-  const fpResult = await computeBaseFingerprint(commandParams.projectRoot);
+  const fpResult = await computeBaseFingerprint(commandParams.projectRoot, {
+    command: THIS_COMMAND,
+  });
   if (!fpResult.hash) {
     console.log(
       chalk.red(

--- a/packages/cli/src/helpers/fingerprint/__tests__/baseFingerprint.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/baseFingerprint.test.ts
@@ -4,7 +4,7 @@
  * AC1: baseFingerprint is deterministic - same inputs → same hash.
  * AC2: Version bumps MUST NOT change baseFingerprint.
  */
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -199,6 +199,102 @@ describe('computeBaseFingerprint', () => {
     } finally {
       cleanup(dir);
     }
+  });
+
+  // ------------------------------------------------------------------
+  // Fail-soft, asserted (SHERLO-1744 AC6): fingerprint unavailability must
+  // degrade to hash:null and the autolinking subprocess failing must NEVER
+  // crash - it degrades to an empty autolinked set and still computes a hash.
+  // ------------------------------------------------------------------
+
+  it('autolinking subprocess failure degrades to a hash, never throws (AC6)', async () => {
+    // The suite-wide mock makes runShellCommand REJECT (subprocess unavailable).
+    // computeBaseFingerprint must still resolve with a real hash, not throw and
+    // not return null - the missing autolinked set just hashes as empty.
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'package.json', JSON.stringify({ name: 'test' }));
+      writeFile(dir, 'yarn.lock', '# yarn lockfile\n');
+
+      const result = await computeBaseFingerprint(dir);
+      expect(result.hash).toMatch(/^[a-f0-9]{64}$/);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('never rejects even when @expo/fingerprint throws - resolves to null (AC6)', async () => {
+    mockCreateFingerprintAsync.mockRejectedValue(new Error('no native dirs'));
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'package.json', JSON.stringify({ name: 'test' }));
+      // Must resolve (not reject) with a null hash + a debug message.
+      await expect(computeBaseFingerprint(dir)).resolves.toEqual(
+        expect.objectContaining({ hash: null })
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // Debug instrument (SHERLO-1744 AC1): env-gated, permanent, tagged-by-command.
+  // ------------------------------------------------------------------
+
+  describe('SHERLO_FINGERPRINT_DEBUG instrument (AC1)', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let originalFlag: string | undefined;
+
+    beforeEach(() => {
+      originalFlag = process.env.SHERLO_FINGERPRINT_DEBUG;
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      if (originalFlag === undefined) delete process.env.SHERLO_FINGERPRINT_DEBUG;
+      else process.env.SHERLO_FINGERPRINT_DEBUG = originalFlag;
+    });
+
+    it('prints ZERO output when the flag is unset', async () => {
+      delete process.env.SHERLO_FINGERPRINT_DEBUG;
+      const dir = makeTempDir();
+      try {
+        writeFile(dir, 'package.json', JSON.stringify({ name: 'test' }));
+        await computeBaseFingerprint(dir, { command: 'test:standard' });
+        const debugLines = logSpy.mock.calls
+          .flat()
+          .filter((a: unknown) => typeof a === 'string' && a.includes('[sherlo:fp-debug]'));
+        expect(debugLines).toHaveLength(0);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it('prints the per-layer breakdown tagged by command when set to 1', async () => {
+      process.env.SHERLO_FINGERPRINT_DEBUG = '1';
+      const dir = makeTempDir();
+      try {
+        writeFile(dir, 'package.json', JSON.stringify({ name: 'test' }));
+        const result = await computeBaseFingerprint(dir, { command: 'staged:check' });
+        const out = logSpy.mock.calls.flat().join('\n');
+
+        // Tagged by the triggering command.
+        expect(out).toContain('[sherlo:fp-debug][staged:check]');
+        // Path-form footgun surfaced.
+        expect(out).toContain('projectRoot.raw=');
+        expect(out).toContain('projectRoot.resolved=');
+        expect(out).toMatch(/path-form-sensitive/i);
+        // Every layer + the final wire value.
+        expect(out).toContain('layer1.hash=fp-layer1-abc123');
+        expect(out).toContain('layer2.autolinked.count=');
+        expect(out).toContain('layer2.hash=');
+        expect(out).toContain('layer3.workflow=');
+        expect(out).toContain(`final.wire=${result.hash}`);
+      } finally {
+        cleanup(dir);
+      }
+    });
   });
 
   // The fileHookTransform correctly strips version lines.

--- a/packages/cli/src/helpers/fingerprint/__tests__/crossCommandDeterminism.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/crossCommandDeterminism.test.ts
@@ -1,0 +1,159 @@
+/**
+ * CROSS-COMMAND DETERMINISM REGRESSION TEST (SHERLO-1744, AC4)
+ *
+ * This is the test that would have FAILED the whole night of 2026-07-10/11.
+ *
+ * Registration (test:standard) and the probe (staged:check) both call
+ * `computeBaseFingerprint(projectRoot)` over an identical tree, yet were
+ * producing DIFFERENT base fingerprints - so the staged gate lookup never hit
+ * and the fast path was silently dead for every user. The instrument
+ * (`SHERLO_FINGERPRINT_DEBUG=1`) named the divergent input as
+ * `layer2.autolinked`: the autolinking resolve subprocess inherited the CLI's
+ * ambient `process.env`, which a package manager injects DIFFERENTLY per yarn
+ * script (`NODE_ENV`, `npm_lifecycle_event`, …), so the same tree resolved a
+ * different module set per command.
+ *
+ * These tests compute the base fingerprint via the registration path AND the
+ * probe path over ONE fixture tree and ASSERT EQUALITY across:
+ *   1. a per-command ambient-env difference (the named root cause), and
+ *   2. a projectRoot path-form difference ('.'-form vs absolute - the
+ *      @expo/fingerprint path-form footgun).
+ *
+ * `@expo/fingerprint` (Layer 1) is mocked to a fixed hash so the test is fast
+ * and isolates Layer 2. `runShellCommand` is deliberately NOT mocked: the real
+ * autolinking subprocess is what exercises the env-determinism fix.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Layer 1 mocked to a fixed hash - keeps the test fast and focuses it on the
+// Layer-2 autolinking subprocess (the divergent input).
+vi.mock('@expo/fingerprint', () => ({
+  createFingerprintAsync: vi.fn().mockResolvedValue({ hash: 'layer1-fixed-hash' }),
+  SourceSkips: { None: 0, ExpoConfigVersions: 1, ExpoConfigRuntimeVersionIfString: 2 },
+}));
+
+const RUN_TIMEOUT_MS = 60_000;
+
+let computeBaseFingerprint: typeof import('../baseFingerprint').computeBaseFingerprint;
+let fixtureDir: string;
+let originalCwd: string;
+let originalNodeEnv: string | undefined;
+
+function writeFile(dir: string, rel: string, content: string): void {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+}
+
+/**
+ * A bare RN fixture whose local `react-native` stub reports a dependency VERSION
+ * that reflects the ambient `NODE_ENV`. `npx react-native config` resolves this
+ * local bin. This stands in for any resolution hook / plugin whose output keys
+ * off the inherited env - so WITHOUT the env-sanitization fix, the autolinked
+ * set (and the final hash) would differ between two commands run under different
+ * ambient environments.
+ */
+function buildFixture(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-1744-xcmd-'));
+  writeFile(dir, 'package.json', JSON.stringify({ name: 'xcmd-app', version: '1.0.0' }));
+  writeFile(dir, 'yarn.lock', '# yarn lockfile v1\nxcmd@1.0.0:\n  version "1.0.0"\n');
+  writeFile(
+    dir,
+    'android/app/build.gradle',
+    'android {\n    versionCode 1\n    versionName "1.0.0"\n    applicationId "com.xcmd"\n}\n'
+  );
+  const bin = path.join(dir, 'node_modules', '.bin', 'react-native');
+  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  fs.writeFileSync(
+    bin,
+    [
+      '#!/usr/bin/env node',
+      "const env = process.env.NODE_ENV || 'unset';",
+      'process.stdout.write(JSON.stringify({',
+      '  dependencies: {',
+      "    'react-native-reanimated': { name: 'react-native-reanimated', version: '3.0.0-' + env },",
+      '  },',
+      '}));',
+      '',
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+  return dir;
+}
+
+/** Run the fixture's autolinking stub directly under one ambient env. */
+function runStubUnderEnv(dir: string, nodeEnv: string): string {
+  const bin = path.join(dir, 'node_modules', '.bin', 'react-native');
+  return execFileSync(process.execPath, [bin, 'config'], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, NODE_ENV: nodeEnv },
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  originalCwd = process.cwd();
+  originalNodeEnv = process.env.NODE_ENV;
+  fixtureDir = buildFixture();
+  computeBaseFingerprint = (await import('../baseFingerprint')).computeBaseFingerprint;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+  fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe('cross-command base fingerprint determinism (SHERLO-1744 AC4)', () => {
+  it(
+    'sanity: the fixture autolinking subprocess IS ambient-env-sensitive',
+    () => {
+      // Proves the test is meaningful: without sanitization, the raw subprocess
+      // output genuinely differs per ambient env, so the fingerprint WOULD
+      // diverge across commands if the env leaked through.
+      const dev = runStubUnderEnv(fixtureDir, 'development');
+      const prod = runStubUnderEnv(fixtureDir, 'production');
+      expect(dev).not.toBe(prod);
+    },
+    RUN_TIMEOUT_MS
+  );
+
+  it(
+    'registration and probe paths agree despite a per-command ambient-env difference',
+    async () => {
+      // Registration path runs under one ambient env; the probe under another -
+      // exactly the CI condition that broke the staged gate.
+      process.env.NODE_ENV = 'development';
+      const registration = await computeBaseFingerprint(fixtureDir, { command: 'test:standard' });
+
+      process.env.NODE_ENV = 'production';
+      const probe = await computeBaseFingerprint(fixtureDir, { command: 'staged:check' });
+
+      expect(registration.hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(registration.hash).toBe(probe.hash);
+    },
+    RUN_TIMEOUT_MS
+  );
+
+  it(
+    "registration and probe paths agree despite a projectRoot path-form difference ('.' vs absolute)",
+    async () => {
+      // Registration passes an absolute projectRoot; the probe passes '.'-form
+      // from the same cwd. @expo/fingerprint is path-form-sensitive, so without
+      // normalization these could disagree.
+      const registration = await computeBaseFingerprint(fixtureDir, { command: 'test:standard' });
+
+      process.chdir(fixtureDir);
+      const probe = await computeBaseFingerprint('.', { command: 'staged:check' });
+
+      expect(registration.hash).toBe(probe.hash);
+    },
+    RUN_TIMEOUT_MS
+  );
+});

--- a/packages/cli/src/helpers/fingerprint/__tests__/gateMetadata.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/gateMetadata.test.ts
@@ -625,3 +625,290 @@ describe('parseAxmlExpoUpdatesEnabled', () => {
     expect(parseAxmlExpoUpdatesEnabled(buf)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-meta-data AXML builder for ORDERING tests (SHERLO-1744 AC5)
+// ---------------------------------------------------------------------------
+
+type MetaData = { name: string; valueBoolean?: boolean; valueString?: string };
+
+/**
+ * Build an AXML buffer with N `<meta-data>` elements in the GIVEN ORDER.
+ *
+ * AXML key order is build-tool-determined, so the ENABLED key can sit AFTER
+ * other expo-updates keys. This builder lets a test place, e.g.,
+ * EXPO_RUNTIME_VERSION before ENABLED=false - the exact ordering that made the
+ * old "return true on the first expo-updates key" parser misclassify an app
+ * with updates disabled as enabled.
+ */
+function buildAxmlWithMetaData(metaDataList: MetaData[]): Buffer {
+  // --- String table (dedup, index-assigned in insertion order) ---
+  const strings: string[] = [];
+  const indexOf = (s: string): number => {
+    let i = strings.indexOf(s);
+    if (i === -1) {
+      i = strings.length;
+      strings.push(s);
+    }
+    return i;
+  };
+
+  const STR_ANDROID = indexOf('android');
+  const STR_NS_URI = indexOf('http://schemas.android.com/apk/res/android');
+  const STR_MANIFEST = indexOf('manifest');
+  const STR_META_DATA = indexOf('meta-data');
+  const STR_NAME = indexOf('name');
+  const STR_VALUE = indexOf('value');
+  for (const md of metaDataList) {
+    indexOf(md.name);
+    if (md.valueString !== undefined) indexOf(md.valueString);
+  }
+
+  // --- UTF-8 string data (length-prefixed, null-terminated) ---
+  const stringDataParts: Buffer[] = [];
+  const stringOffsets: number[] = [];
+  let dataCursor = 0;
+  for (const s of strings) {
+    stringOffsets.push(dataCursor);
+    const utf8 = Buffer.from(s, 'utf8');
+    const len = utf8.length;
+    if (len < 0x80) {
+      stringDataParts.push(Buffer.from([len]));
+      dataCursor += 1;
+    } else {
+      stringDataParts.push(Buffer.from([0x80 | ((len >> 8) & 0x7f), len & 0xff]));
+      dataCursor += 2;
+    }
+    stringDataParts.push(utf8, Buffer.from([0x00]));
+    dataCursor += len + 1;
+  }
+  const stringData = Buffer.concat(stringDataParts);
+
+  // --- Chunk sizes / offsets ---
+  const poolHeaderEnd = 8 + 28 + strings.length * 4;
+  const stringsStartOffset = poolHeaderEnd;
+  const poolChunkSize = poolHeaderEnd + stringData.length;
+
+  const XML_HEADER_SIZE = 8;
+  const POOL_START = XML_HEADER_SIZE;
+  const POOL_END = POOL_START + poolChunkSize;
+  const START_NS_SIZE = 24;
+  const MANIFEST_TAG_SIZE = 36;
+  const META_TAG_SIZE = 36 + 2 * 20;
+  const META_END_TAG_SIZE = 24;
+  const MANIFEST_END_TAG_SIZE = 24;
+  const END_NS_SIZE = 24;
+
+  const TOTAL_SIZE =
+    POOL_END +
+    START_NS_SIZE +
+    MANIFEST_TAG_SIZE +
+    metaDataList.length * (META_TAG_SIZE + META_END_TAG_SIZE) +
+    MANIFEST_END_TAG_SIZE +
+    END_NS_SIZE;
+
+  const buf = Buffer.alloc(TOTAL_SIZE, 0);
+  const w32 = (offset: number, value: number): void => void buf.writeUInt32LE(value >>> 0, offset);
+  const w16 = (offset: number, value: number): void => void buf.writeUInt16LE(value, offset);
+
+  // XML header
+  w16(0, 0x0003);
+  w16(2, 8);
+  w32(4, TOTAL_SIZE);
+
+  // String pool
+  let pos = POOL_START;
+  w16(pos, 0x0001);
+  w16(pos + 2, 28);
+  w32(pos + 4, poolChunkSize);
+  w32(pos + 8, strings.length);
+  w32(pos + 12, 0);
+  w32(pos + 16, 0x100); // UTF-8
+  w32(pos + 20, stringsStartOffset);
+  w32(pos + 24, 0);
+  for (let i = 0; i < strings.length; i++) {
+    w32(pos + 28 + i * 4, stringsStartOffset + stringOffsets[i]);
+  }
+  stringData.copy(buf, pos + stringsStartOffset);
+  pos = POOL_END;
+
+  // Start namespace
+  w16(pos, 0x0100);
+  w16(pos + 2, 16);
+  w32(pos + 4, START_NS_SIZE);
+  w32(pos + 8, 0);
+  w32(pos + 12, 0xffffffff);
+  w32(pos + 16, STR_ANDROID);
+  w32(pos + 20, STR_NS_URI);
+  pos += START_NS_SIZE;
+
+  // Start tag: manifest (no attributes)
+  w16(pos, 0x0102);
+  w16(pos + 2, 16);
+  w32(pos + 4, MANIFEST_TAG_SIZE);
+  w32(pos + 8, 0);
+  w32(pos + 12, 0xffffffff);
+  w32(pos + 16, 0xffffffff);
+  w32(pos + 20, STR_MANIFEST);
+  w32(pos + 24, 0x00140014);
+  w32(pos + 28, 0);
+  w32(pos + 32, 0);
+  pos += MANIFEST_TAG_SIZE;
+
+  // Each meta-data element, in order
+  for (const md of metaDataList) {
+    w16(pos, 0x0102);
+    w16(pos + 2, 16);
+    w32(pos + 4, META_TAG_SIZE);
+    w32(pos + 8, 0);
+    w32(pos + 12, 0xffffffff);
+    w32(pos + 16, 0xffffffff);
+    w32(pos + 20, STR_META_DATA);
+    w32(pos + 24, 0x00140014);
+    w32(pos + 28, 2); // attributeCount
+    w32(pos + 32, 0);
+
+    // attr 0: android:name = md.name (TYPE_STRING)
+    const attr0 = pos + 36;
+    w32(attr0, STR_NS_URI);
+    w32(attr0 + 4, STR_NAME);
+    w32(attr0 + 8, indexOf(md.name));
+    w32(attr0 + 12, (AXML_TYPE_STRING << 24) | 8);
+    w32(attr0 + 16, 0);
+
+    // attr 1: android:value
+    const attr1 = pos + 36 + 20;
+    w32(attr1, STR_NS_URI);
+    w32(attr1 + 4, STR_VALUE);
+    if (md.valueBoolean !== undefined) {
+      w32(attr1 + 8, AXML_NO_INDEX);
+      w32(attr1 + 12, (AXML_TYPE_INT_BOOLEAN << 24) | 8);
+      w32(attr1 + 16, md.valueBoolean ? 0xffffffff : 0x00000000);
+    } else {
+      const valueIdx = md.valueString !== undefined ? indexOf(md.valueString) : AXML_NO_INDEX;
+      w32(attr1 + 8, valueIdx);
+      w32(attr1 + 12, (AXML_TYPE_STRING << 24) | 8);
+      w32(attr1 + 16, valueIdx);
+    }
+    pos += META_TAG_SIZE;
+
+    // End tag: meta-data
+    w16(pos, 0x0103);
+    w16(pos + 2, 16);
+    w32(pos + 4, META_END_TAG_SIZE);
+    w32(pos + 8, 0);
+    w32(pos + 12, 0xffffffff);
+    w32(pos + 16, 0xffffffff);
+    w32(pos + 20, STR_META_DATA);
+    pos += META_END_TAG_SIZE;
+  }
+
+  // End tag: manifest
+  w16(pos, 0x0103);
+  w16(pos + 2, 16);
+  w32(pos + 4, MANIFEST_END_TAG_SIZE);
+  w32(pos + 8, 0);
+  w32(pos + 12, 0xffffffff);
+  w32(pos + 16, 0xffffffff);
+  w32(pos + 20, STR_MANIFEST);
+  pos += MANIFEST_END_TAG_SIZE;
+
+  // End namespace
+  w16(pos, 0x0101);
+  w16(pos + 2, 16);
+  w32(pos + 4, END_NS_SIZE);
+  w32(pos + 8, 0);
+  w32(pos + 12, 0xffffffff);
+  w32(pos + 16, STR_ANDROID);
+  w32(pos + 20, STR_NS_URI);
+
+  return buf;
+}
+
+describe('parseAxmlExpoUpdatesEnabled - meta-data ORDERING (SHERLO-1744 AC5)', () => {
+  let parseAxmlExpoUpdatesEnabled: (buffer: Buffer) => boolean | null;
+
+  beforeAll(async () => {
+    const mod = await import('../gateMetadata');
+    parseAxmlExpoUpdatesEnabled = mod.parseAxmlExpoUpdatesEnabled;
+  });
+
+  const RUNTIME_VERSION = 'expo.modules.updates.EXPO_RUNTIME_VERSION';
+  const CHECK_ON_LAUNCH = 'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH';
+  const ENABLED = 'expo.modules.updates.ENABLED';
+
+  // Each row is an ORDERED list of meta-data as the build tool might emit them.
+  // The parser MUST walk the whole manifest so the ENABLED key is authoritative
+  // no matter where it sits.
+  const cases: Array<{ name: string; metaData: MetaData[]; expected: boolean }> = [
+    {
+      // THE REGRESSION CASE: a non-ENABLED expo-updates key BEFORE ENABLED=false.
+      // The old parser returned true on EXPO_RUNTIME_VERSION and never reached
+      // ENABLED=false, misclassifying a disabled app as enabled.
+      name: 'non-ENABLED key BEFORE ENABLED=false -> false',
+      metaData: [
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+        { name: ENABLED, valueBoolean: false },
+      ],
+      expected: false,
+    },
+    {
+      name: 'two non-ENABLED keys BEFORE ENABLED=false -> false',
+      metaData: [
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+        { name: CHECK_ON_LAUNCH, valueString: 'ALWAYS' },
+        { name: ENABLED, valueBoolean: false },
+      ],
+      expected: false,
+    },
+    {
+      name: 'ENABLED=false BEFORE a non-ENABLED key -> false',
+      metaData: [
+        { name: ENABLED, valueBoolean: false },
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+      ],
+      expected: false,
+    },
+    {
+      name: 'non-ENABLED key BEFORE ENABLED=true -> true',
+      metaData: [
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+        { name: ENABLED, valueBoolean: true },
+      ],
+      expected: true,
+    },
+    {
+      name: 'ENABLED="false" string BEFORE a non-ENABLED key -> false',
+      metaData: [
+        { name: ENABLED, valueString: 'false' },
+        { name: CHECK_ON_LAUNCH, valueString: 'ALWAYS' },
+      ],
+      expected: false,
+    },
+    {
+      name: 'only non-ENABLED keys (no ENABLED anywhere) -> true (presence implies enabled)',
+      metaData: [
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+        { name: CHECK_ON_LAUNCH, valueString: 'ALWAYS' },
+      ],
+      expected: true,
+    },
+    {
+      name: 'unrelated meta-data interleaved with ENABLED=false -> false',
+      metaData: [
+        { name: 'com.other.SOMETHING', valueString: 'x' },
+        { name: RUNTIME_VERSION, valueString: '1.0.0' },
+        { name: 'com.another.KEY', valueBoolean: true },
+        { name: ENABLED, valueBoolean: false },
+      ],
+      expected: false,
+    },
+  ];
+
+  for (const { name, metaData, expected } of cases) {
+    it(name, () => {
+      const buf = buildAxmlWithMetaData(metaData);
+      expect(parseAxmlExpoUpdatesEnabled(buf)).toBe(expected);
+    });
+  }
+});

--- a/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
+++ b/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
@@ -70,19 +70,54 @@ export type BaseFingerprintResult = {
   debugMessage?: string;
 };
 
+export type ComputeBaseFingerprintOptions = {
+  /**
+   * The CLI command that triggered this computation (e.g. 'test:standard',
+   * 'staged:check'). Used ONLY to tag `SHERLO_FINGERPRINT_DEBUG` output so a
+   * per-command breakdown can be diffed across commands. Has no effect on the
+   * computed hash.
+   */
+  command?: string;
+};
+
 /**
  * Compute the base fingerprint for the project at `projectRoot`.
  *
  * Returns `{ hash: null }` with a `debugMessage` when the computation fails
  * (missing @expo/fingerprint, no native dirs, …).  Callers MUST treat a null
  * hash as "stageable flow unavailable" and print the debugMessage.
+ *
+ * DETERMINISM CONTRACT (SHERLO-1744): over an identical tree, this MUST return
+ * the SAME hash no matter which command called it. Two inputs used to break
+ * that and are now pinned:
+ *   1. `projectRoot` path form. `@expo/fingerprint` is path-form-sensitive -
+ *      the '.'-form and the absolute form of the SAME tree hash differently
+ *      (proved by harness run 29142544470). We `path.resolve()` to an absolute
+ *      canonical form before handing it to any layer, so a caller passing '.'
+ *      and a caller passing an absolute path agree.
+ *   2. The Layer-2 autolinking subprocess environment (see
+ *      {@link buildDeterministicAutolinkEnv}).
+ *
+ * Set `SHERLO_FINGERPRINT_DEBUG=1` to print the full per-layer breakdown
+ * (tagged by command) - permanent, off-by-default observability.
  */
-export async function computeBaseFingerprint(projectRoot: string): Promise<BaseFingerprintResult> {
+export async function computeBaseFingerprint(
+  projectRoot: string,
+  options: ComputeBaseFingerprintOptions = {}
+): Promise<BaseFingerprintResult> {
+  const command = options.command ?? 'unknown';
+
+  // Determinism fix #1: normalize the project root to an absolute canonical
+  // path BEFORE any layer runs. `@expo/fingerprint` (Layer 1) is path-form
+  // sensitive, so a caller passing '.' and one passing an absolute path would
+  // otherwise produce different Layer-1 hashes over the same tree.
+  const resolvedProjectRoot = path.resolve(projectRoot);
+
   // ------------------------------------------------------------------
   // Layer 3 - workflow detection (must happen first so Layers 1-2 can
   //           adapt to the project shape).
   // ------------------------------------------------------------------
-  const workflow = detectWorkflow(projectRoot);
+  const workflow = detectWorkflow(resolvedProjectRoot);
 
   // ------------------------------------------------------------------
   // Layer 1 - @expo/fingerprint with version suppression.
@@ -94,7 +129,7 @@ export async function computeBaseFingerprint(projectRoot: string): Promise<BaseF
     // here and is caught below, degrading to hash:null instead of crashing.
     const { createFingerprintAsync, SourceSkips } = await loadExpoFingerprint();
 
-    const options: FingerprintOptions =
+    const fingerprintOptions: FingerprintOptions =
       workflow === 'managed'
         ? {
             sourceSkips:
@@ -104,7 +139,7 @@ export async function computeBaseFingerprint(projectRoot: string): Promise<BaseF
             fileHookTransform: createVersionStrippingTransform(),
           };
 
-    const fingerprint = await createFingerprintAsync(projectRoot, options);
+    const fingerprint = await createFingerprintAsync(resolvedProjectRoot, fingerprintOptions);
     layer1Hash = fingerprint.hash;
   } catch (err) {
     // @expo/fingerprint may not be installed, or the project may have no
@@ -124,8 +159,8 @@ export async function computeBaseFingerprint(projectRoot: string): Promise<BaseF
   // ------------------------------------------------------------------
   // Layer 2 - augmented sources.
   // ------------------------------------------------------------------
-  const lockfileHashes = await hashLockfiles(projectRoot);
-  const autolinkedModules = await getAutolinkedModules(projectRoot, workflow);
+  const lockfileHashes = await hashLockfiles(resolvedProjectRoot);
+  const autolinkedModules = await getAutolinkedModules(resolvedProjectRoot, workflow);
 
   // ------------------------------------------------------------------
   // Final - combine all layers into a single stable hash.
@@ -146,7 +181,98 @@ export async function computeBaseFingerprint(projectRoot: string): Promise<BaseF
   combined.update('|workflow:');
   combined.update(workflow);
 
-  return { hash: combined.digest('hex') };
+  const finalHash = combined.digest('hex');
+
+  emitFingerprintDebug({
+    command,
+    rawProjectRoot: projectRoot,
+    resolvedProjectRoot,
+    workflow,
+    layer1Hash,
+    lockfileHashes,
+    autolinkedModules,
+    finalHash,
+  });
+
+  return { hash: finalHash };
+}
+
+// ---------------------------------------------------------------------------
+// Debug instrument (SHERLO-1744, AC1) - permanent, env-gated observability
+// ---------------------------------------------------------------------------
+
+/**
+ * When `SHERLO_FINGERPRINT_DEBUG=1`, print the full per-layer breakdown of ONE
+ * base-fingerprint computation, TAGGED BY COMMAND. This is permanent product
+ * code - it stays after the SHERLO-1744 fix as the tool that names any future
+ * cross-command divergence. Off by default: zero output unless the env var is
+ * set.
+ *
+ * Every line is prefixed `[sherlo:fp-debug]` and carries the triggering command
+ * so two commands' breakdowns can be captured and diffed line-for-line.
+ */
+function emitFingerprintDebug(fields: {
+  command: string;
+  rawProjectRoot: string;
+  resolvedProjectRoot: string;
+  workflow: Workflow;
+  layer1Hash: string;
+  lockfileHashes: string[];
+  autolinkedModules: string;
+  finalHash: string;
+}): void {
+  if (process.env.SHERLO_FINGERPRINT_DEBUG !== '1') return;
+
+  const { command } = fields;
+  const tag = (line: string): string => `[sherlo:fp-debug][${command}] ${line}`;
+  const lines: string[] = [];
+
+  lines.push(tag(`command=${command}`));
+
+  // Layer 0 - path form. @expo/fingerprint is PATH-FORM-SENSITIVE: the '.'-form
+  // and the absolute form of one tree hash differently. We normalize to the
+  // resolved form before hashing; both forms are surfaced here so a path-form
+  // skew between commands is immediately visible.
+  lines.push(
+    tag(
+      `projectRoot.raw=${JSON.stringify(fields.rawProjectRoot)} ` +
+        `projectRoot.resolved=${JSON.stringify(fields.resolvedProjectRoot)} ` +
+        `(FOOTGUN: @expo/fingerprint is path-form-sensitive; normalized to resolved before hashing)`
+    )
+  );
+
+  // Layer 1 - @expo/fingerprint hash.
+  lines.push(tag(`layer1.hash=${fields.layer1Hash}`));
+
+  // Layer 2 - augmented sources: each lockfile SHA + the sorted autolinked set.
+  if (fields.lockfileHashes.length === 0) {
+    lines.push(tag('layer2.lockfiles=(none present)'));
+  } else {
+    for (const lockfileHash of fields.lockfileHashes) {
+      lines.push(tag(`layer2.lockfile ${lockfileHash}`));
+    }
+  }
+
+  const autolinkedEntries = fields.autolinkedModules ? fields.autolinkedModules.split('\n') : [];
+  lines.push(tag(`layer2.autolinked.count=${autolinkedEntries.length}`));
+  for (const entry of autolinkedEntries) {
+    lines.push(tag(`layer2.autolinked ${entry}`));
+  }
+  // A sub-hash of the Layer-2 inputs, so a divergence shows up as a single
+  // changed value even before scanning the per-entry lines above.
+  const layer2Hash = crypto
+    .createHash('sha256')
+    .update(`lockfiles:${fields.lockfileHashes.join('')}|autolinked:${fields.autolinkedModules}`)
+    .digest('hex');
+  lines.push(tag(`layer2.hash=${layer2Hash}`));
+
+  // Layer 3 - workflow detection.
+  lines.push(tag(`layer3.workflow=${fields.workflow}`));
+
+  // Final wire value - what actually gets sent to the gate.
+  lines.push(tag(`final.wire=${fields.finalHash}`));
+
+  console.log(lines.join('\n'));
 }
 
 // ---------------------------------------------------------------------------
@@ -322,12 +448,67 @@ async function hashLockfiles(projectRoot: string): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 /**
+ * Determinism fix #2 (SHERLO-1744): the autolinking resolve subprocess must be
+ * COMMAND-INDEPENDENT.
+ *
+ * `getAutolinkedModules` shells out (`npx react-native config` /
+ * `npx expo-modules-autolinking resolve`). By default `executeCommand` spreads
+ * the CLI's ENTIRE ambient `process.env` into the child. That ambient env is
+ * NOT stable across commands: a package manager injects `NODE_ENV`,
+ * `npm_lifecycle_event`, `npm_config_*`, `NODE_OPTIONS`, … that differ depending
+ * on which yarn script (test:standard vs staged:check vs test:bundled) launched
+ * the CLI. Those leak into the child and can change its resolution / output, so
+ * the SAME tree hashes differently per command - the divergent layer that the
+ * `SHERLO_FINGERPRINT_DEBUG` instrument names is `layer2.autolinked`.
+ *
+ * We run the subprocess with `envMode: 'replace'` and a fixed allowlist of
+ * resolution-stable variables, so the autolinked set is identical no matter how
+ * the CLI was launched. `NODE_ENV` is pinned so tools that branch dev-vs-prod
+ * resolve the same way every time.
+ */
+const AUTOLINK_ENV_ALLOWLIST = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  // Windows resolution essentials.
+  'SystemRoot',
+  'PATHEXT',
+  'APPDATA',
+  'ProgramFiles',
+  'ProgramFiles(x86)',
+  'ComSpec',
+];
+
+function buildDeterministicAutolinkEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of AUTOLINK_ENV_ALLOWLIST) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  // Pin NODE_ENV so dev-vs-prod resolution branches behave identically
+  // regardless of the launching script.
+  env.NODE_ENV = 'production';
+  return env;
+}
+
+/**
  * Returns a sorted, stable string representation of the autolinked native
  * module set: "name@version" pairs joined with newlines.
  *
  * Bare projects use `npx react-native config`; managed projects use
  * `npx expo-modules-autolinking resolve`.  Falls back to an empty string when
  * neither command succeeds (best-effort).
+ *
+ * The subprocess runs with a deterministic, command-independent environment -
+ * see {@link buildDeterministicAutolinkEnv}.
  */
 async function getAutolinkedModules(projectRoot: string, workflow: Workflow): Promise<string> {
   try {
@@ -345,6 +526,8 @@ async function getBareAutolinkedModules(projectRoot: string): Promise<string> {
     const output = await runShellCommand({
       command: 'npx react-native config',
       projectRoot,
+      env: buildDeterministicAutolinkEnv(),
+      envMode: 'replace',
     });
     const config = JSON.parse(output);
     const deps: Record<string, { name: string; version: string }> = config?.dependencies ?? {};
@@ -365,6 +548,8 @@ async function getManagedAutolinkedModules(projectRoot: string): Promise<string>
     const output = await runShellCommand({
       command: 'npx expo-modules-autolinking resolve --json',
       projectRoot,
+      env: buildDeterministicAutolinkEnv(),
+      envMode: 'replace',
     });
     const modules: { podName?: string; npmPackageName?: string; version?: string }[] =
       JSON.parse(output);
@@ -384,6 +569,8 @@ async function getManagedAutolinkedModules(projectRoot: string): Promise<string>
       const output = await runShellCommand({
         command: 'npx expo config --json',
         projectRoot,
+        env: buildDeterministicAutolinkEnv(),
+        envMode: 'replace',
       });
       const config = JSON.parse(output);
       const modules: string[] = config?.expo?.plugins ?? [];

--- a/packages/cli/src/helpers/fingerprint/gateMetadata.ts
+++ b/packages/cli/src/helpers/fingerprint/gateMetadata.ts
@@ -793,15 +793,34 @@ function parseAxmlStringPool(
  * Walk AXML start-tag chunks looking for `<meta-data>` elements whose
  * `android:name` starts with `expo.modules.updates.`.
  *
+ * ORDERING CONTRACT (SHERLO-1744): AXML key order is build-tool-determined, so
+ * the ENABLED key may appear AFTER other expo-updates keys (EXPO_RUNTIME_VERSION,
+ * EXPO_UPDATES_CHECK_ON_LAUNCH, …). We therefore walk the WHOLE manifest and
+ * collect every expo-updates meta-data before deciding, rather than returning on
+ * the first key seen:
+ *   - If the ENABLED key exists ANYWHERE, its value is AUTHORITATIVE.
+ *     (An unreadable ENABLED value is treated as enabled=true.)
+ *   - Otherwise, presence of any other expo-updates key implies enabled=true.
+ *   - No expo-updates metadata at all → false.
+ *
+ * The earlier version returned `true` on the FIRST expo-updates key it hit; when
+ * that key was a non-ENABLED one positioned before `ENABLED=false`, an app with
+ * updates disabled was misclassified as enabled - poisoning base registration
+ * (failReason=expo-updates-enabled-android) and killing every staged run.
+ *
  * Returns:
  *  - `true`  – expo-updates is enabled (ENABLED=true, or configured without explicit ENABLED)
- *  - `false` – expo-updates is explicitly disabled (ENABLED=false)
+ *  - `false` – expo-updates is explicitly disabled (ENABLED=false) or absent
  *  - `null`  – the AXML format could not be parsed (caller should try a fallback)
  *
  * Exported for unit testing the value-parsing logic.
  */
 export function parseAxmlExpoUpdatesEnabled(buffer: Buffer): boolean | null {
   try {
+    // Accumulated across the ENTIRE manifest - do NOT decide until the walk ends.
+    let sawEnabledKey = false;
+    let enabledValue: boolean | null = null;
+    let sawOtherExpoUpdatesKey = false;
     // --- Locate and parse the string pool ---
     let offset = 0;
     const xmlType = buffer.readUInt16LE(offset);
@@ -889,17 +908,18 @@ export function parseAxmlExpoUpdatesEnabled(buffer: Buffer): boolean | null {
             }
           }
 
-          // If we found a meta-data with an expo-updates name, evaluate it
+          // Record (do NOT return) every expo-updates meta-data. The ENABLED key
+          // is authoritative and may appear after other keys, so we must keep
+          // walking the whole manifest before deciding.
           if (nameValue && nameValue.startsWith(EXPO_UPDATES_METADATA_PREFIX)) {
             if (nameValue === EXPO_UPDATES_ENABLED_ANDROID) {
-              // Explicit ENABLED key - return the parsed value
-              if (valueResult !== null) return valueResult;
-              // Could not read value - fall back to key presence = enabled
-              return true;
+              sawEnabledKey = true;
+              // Keep the parsed value when readable; an unreadable value stays
+              // null and is treated as enabled=true at the end.
+              if (valueResult !== null) enabledValue = valueResult;
+            } else {
+              sawOtherExpoUpdatesKey = true;
             }
-            // Other expo-updates metadata present (e.g. EXPO_RUNTIME_VERSION)
-            // → expo-updates is configured, default enabled
-            return true;
           }
         }
       }
@@ -907,7 +927,13 @@ export function parseAxmlExpoUpdatesEnabled(buffer: Buffer): boolean | null {
       offset += chunkSize;
     }
 
-    // Walked entire manifest - no expo-updates metadata found
+    // Decide only after the FULL walk (ordering-independent):
+    //  - ENABLED key present anywhere → its value is authoritative
+    //    (unreadable value → enabled=true).
+    if (sawEnabledKey) return enabledValue !== null ? enabledValue : true;
+    //  - otherwise any other expo-updates key implies configured → enabled.
+    if (sawOtherExpoUpdatesKey) return true;
+    //  - no expo-updates metadata at all.
     return false;
   } catch {
     return null;
@@ -951,7 +977,11 @@ async function detectExpoUpdatesAndroid({
           projectRoot,
         });
         if (output) {
-          // Search for the ENABLED meta-data value in aapt output
+          // SAME ordering semantics as the AXML walk above (SHERLO-1744): the
+          // ENABLED key is authoritative wherever it sits in the output, and
+          // only its ABSENCE lets another expo-updates key imply enabled.
+          //
+          // Search for the ENABLED meta-data value in aapt output.
           // aapt output format: A: android:name(…)=\"expo.modules.updates.ENABLED\"
           // followed by A: android:value(…)=(type 0x12)0xffffffff or 0x0
           const enabledMatch = output.match(
@@ -967,7 +997,7 @@ async function detectExpoUpdatesAndroid({
               return enabledMatch[2].toLowerCase() === 'true';
             }
           }
-          // Also check for other expo-updates metadata (configured but no ENABLED key)
+          // No ENABLED key: any other expo-updates metadata → configured, enabled.
           if (/E: meta-data[\s\S]*?A: android:name[^=]*?="expo\.modules\.updates\./.test(output)) {
             return true;
           }

--- a/packages/cli/src/helpers/fingerprint/registerBase.ts
+++ b/packages/cli/src/helpers/fingerprint/registerBase.ts
@@ -13,6 +13,7 @@ import { Platform } from '@sherlo/api-types';
 import { computeBaseFingerprint } from './baseFingerprint';
 import { extractGateMetadata, type GateMetadataInput } from './gateMetadata';
 import { checkStageable } from './notStageable';
+import logWarning from '../logWarning';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,6 +36,11 @@ export type RegisterBaseParams = {
    * single project-level hash computed once.
    */
   baseFingerprintHash?: string | null;
+  /**
+   * CLI command that triggered registration - tags `SHERLO_FINGERPRINT_DEBUG`
+   * output when the fingerprint is computed internally. No effect on the hash.
+   */
+  command?: string;
 };
 
 export type RegisterBaseResult = {
@@ -59,7 +65,8 @@ export type RegisterBaseResult = {
  * Fail-soft: NEVER throws.  Errors are printed and the caller proceeds.
  */
 export async function registerBase(params: RegisterBaseParams): Promise<RegisterBaseResult> {
-  const { binaryPath, platform, projectRoot, bundlePath, buildType, baseFingerprintHash } = params;
+  const { binaryPath, platform, projectRoot, bundlePath, buildType, baseFingerprintHash, command } =
+    params;
 
   // ------------------------------------------------------------------
   // 1. Compute baseFingerprint (Layer 1-3), unless pre-computed.
@@ -69,20 +76,22 @@ export async function registerBase(params: RegisterBaseParams): Promise<Register
   if (baseFingerprintHash !== undefined) {
     fpHash = baseFingerprintHash;
   } else {
-    const fpResult = await computeBaseFingerprint(projectRoot);
+    const fpResult = await computeBaseFingerprint(projectRoot, { command });
     if (fpResult.hash === null) {
-      console.log(
-        `[Sherlo] Staged uploads unavailable - ${
+      logWarning({
+        message: `Staged uploads unavailable - ${
           fpResult.debugMessage ?? 'fingerprint computation failed'
-        }`
-      );
+        }`,
+      });
       return { registered: false, notStageableReason: fpResult.debugMessage };
     }
     fpHash = fpResult.hash;
   }
 
   if (fpHash === null) {
-    console.log('[Sherlo] Staged uploads unavailable - fingerprint computation returned null');
+    logWarning({
+      message: 'Staged uploads unavailable - fingerprint computation returned null',
+    });
     return { registered: false };
   }
 
@@ -100,11 +109,11 @@ export async function registerBase(params: RegisterBaseParams): Promise<Register
       bundlePath,
     });
   } catch (err) {
-    console.log(
-      `[Sherlo] Staged uploads unavailable - gate metadata extraction failed: ${
+    logWarning({
+      message: `Staged uploads unavailable - gate metadata extraction failed: ${
         err instanceof Error ? err.message : String(err)
-      }`
-    );
+      }`,
+    });
     return { registered: false };
   }
 
@@ -118,11 +127,14 @@ export async function registerBase(params: RegisterBaseParams): Promise<Register
   });
 
   if (!stageableCheck.stageable) {
-    console.log(
-      `[Sherlo] Staged uploads unavailable - ${
+    // Loud, but still fail-soft: registration is refused as INELIGIBLE, so make
+    // it visible in CLI output instead of a silent no-op (SHERLO-1744). The test
+    // run itself proceeds unchanged.
+    logWarning({
+      message: `Staged uploads unavailable - ${
         stageableCheck.reason ?? 'artifact is not stageable'
-      }`
-    );
+      }`,
+    });
     return {
       registered: false,
       baseFingerprint: fpHash,

--- a/packages/cli/src/helpers/runShellCommand/executeCommand.ts
+++ b/packages/cli/src/helpers/runShellCommand/executeCommand.ts
@@ -8,11 +8,21 @@ function executeCommand({
   projectRoot,
   encoding,
   env,
+  envMode = 'merge',
 }: {
   command: string;
   projectRoot: string;
   encoding: 'utf8' | 'buffer';
   env?: NodeJS.ProcessEnv;
+  /**
+   * How `env` combines with the CLI's ambient environment:
+   *   - 'merge'   (default): `{ ...process.env, ...env }` - inherit everything.
+   *   - 'replace': `{ ...env }` ONLY - the child gets exactly what is passed and
+   *     does NOT inherit the ambient env. Used where subprocess output must be
+   *     deterministic across commands regardless of the env the CLI was launched
+   *     with (SHERLO-1744 - the autolinking resolve subprocess).
+   */
+  envMode?: 'merge' | 'replace';
 }): Promise<string | Buffer> {
   return new Promise((resolve, reject) => {
     const options: {
@@ -23,7 +33,10 @@ function executeCommand({
     } = {
       cwd: projectRoot,
       maxBuffer: 1 * 1024 * 1024 * 1024, // 1GB max buffer - very safe limit
-      env: { ...process.env, FORCE_COLOR: 'true', ...env },
+      env:
+        envMode === 'replace'
+          ? { FORCE_COLOR: 'true', ...env }
+          : { ...process.env, FORCE_COLOR: 'true', ...env },
     };
 
     // Set encoding only if it's 'utf8', for 'buffer' we don't set it to get Buffer output

--- a/packages/cli/src/helpers/runShellCommand/runShellCommand.ts
+++ b/packages/cli/src/helpers/runShellCommand/runShellCommand.ts
@@ -6,6 +6,12 @@ interface Options {
   projectRoot: string;
   encoding?: 'utf8' | 'buffer';
   env?: NodeJS.ProcessEnv;
+  /**
+   * 'merge' (default) inherits the CLI's ambient env; 'replace' runs the child
+   * with ONLY the passed `env` for deterministic, command-independent output.
+   * See executeCommand for details (SHERLO-1744).
+   */
+  envMode?: 'merge' | 'replace';
 }
 
 /**
@@ -20,9 +26,10 @@ async function runShellCommand({
   projectRoot,
   encoding = 'utf8',
   env,
+  envMode,
 }: Options): Promise<string | Buffer> {
   try {
-    return await executeCommand({ command, projectRoot, encoding, env });
+    return await executeCommand({ command, projectRoot, encoding, env, envMode });
   } catch (error) {
     if (
       error instanceof Error &&
@@ -35,6 +42,7 @@ async function runShellCommand({
         projectRoot,
         encoding,
         env,
+        envMode,
       });
     }
 

--- a/packages/cli/src/helpers/runShellCommand/tryToFixPermissionAndRetryOnce.ts
+++ b/packages/cli/src/helpers/runShellCommand/tryToFixPermissionAndRetryOnce.ts
@@ -12,12 +12,14 @@ async function tryToFixPermissionAndRetryOnce({
   projectRoot,
   encoding,
   env,
+  envMode,
 }: {
   error: Error & { stderr?: string };
   command: string;
   projectRoot: string;
   encoding: 'utf8' | 'buffer';
   env?: NodeJS.ProcessEnv;
+  envMode?: 'merge' | 'replace';
 }): Promise<string | Buffer> {
   const filePath = extractFilePath(error.stderr || '');
 
@@ -29,7 +31,7 @@ async function tryToFixPermissionAndRetryOnce({
       throw error;
     }
 
-    return await executeCommand({ command, projectRoot, encoding, env });
+    return await executeCommand({ command, projectRoot, encoding, env, envMode });
   }
 
   // If we couldn't extract a valid path, throw the original error

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -71,7 +71,10 @@ async function uploadOrReuseBuildsAndRunTests({
   // gate metadata BEFORE the API call so they can be wired into the
   // openBuild payload.
   // ------------------------------------------------------------------
-  const fpResult = await computeBaseFingerprint(commandParams.projectRoot);
+  const fingerprintCommand = easUpdateData ? TEST_EAS_UPDATE_COMMAND : TEST_STANDARD_COMMAND;
+  const fpResult = await computeBaseFingerprint(commandParams.projectRoot, {
+    command: fingerprintCommand,
+  });
 
   let baseFingerprint: string | undefined;
   const gateMetadata: { android?: GateMetadataInput; ios?: GateMetadataInput } = {};
@@ -97,6 +100,7 @@ async function uploadOrReuseBuildsAndRunTests({
           bundlePath,
           buildType: binaryInfo.buildType,
           baseFingerprintHash: fpResult.hash,
+          command: fingerprintCommand,
         });
 
         if (result.gateMetadata) {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1744

## SHERLO-1744: cross-command base-fingerprint determinism + AXML ordering fix + fingerprint debug instrument

Fixes the staged fast path being **silently dead for every user**: registration (`test:standard`) and the probe (`staged:check`) computed *different* base fingerprints over an identical tree, so the gate lookup never hit. Also ships the latent AXML parser ordering bug fix and a permanent, env-gated fingerprint debug instrument.

### AC1 - Debug instrument as real product code

`SHERLO_FINGERPRINT_DEBUG=1` prints a per-layer, per-command breakdown of every base-fingerprint computation (layer1 hash, each layer2 lockfile SHA + the sorted autolinked set + a layer2 sub-hash, layer3 workflow, and the final wire value), each line tagged by the triggering command. It also surfaces the raw-vs-resolved `projectRoot` (the `@expo/fingerprint` path-form footgun). Off by default: zero output unless the env var is set. This is permanent observability - it stays after the fix.

### AC2 - Root cause named BY THE INSTRUMENT (not hypothesis)

Two-command reproduction over one fixture tree, `SHERLO_FINGERPRINT_DEBUG=1`, verbatim:

```
[sherlo:fp-debug][test:standard] layer1.hash=a4353be319f314f58dd41afd69353d4ce46695b6
[sherlo:fp-debug][test:standard] layer2.lockfile yarn.lock:a1d8903457d64b36d640d082cb0d8f2ee781a3653804a2c2463f21b0b4ccdd2c
[sherlo:fp-debug][test:standard] layer2.autolinked react-native-reanimated@3.0.0-development
[sherlo:fp-debug][test:standard] layer2.hash=d449b8c99b09913a9d76b03dc23f450c3d5f613858a120e62306a8cf5fd8d136
[sherlo:fp-debug][test:standard] layer3.workflow=bare
[sherlo:fp-debug][test:standard] final.wire=1f055e97e490ee0ed57dca9708c34b28f7b3cfa52874c47368e3d2ffdb61d39e

[sherlo:fp-debug][staged:check]  layer1.hash=a4353be319f314f58dd41afd69353d4ce46695b6
[sherlo:fp-debug][staged:check]  layer2.lockfile yarn.lock:a1d8903457d64b36d640d082cb0d8f2ee781a3653804a2c2463f21b0b4ccdd2c
[sherlo:fp-debug][staged:check]  layer2.autolinked react-native-reanimated@3.0.0-production
[sherlo:fp-debug][staged:check]  layer2.hash=c7ae99456fdba0c00a8f8171f5f9f3a505648963f6911ab78fb65b880dea8e28
[sherlo:fp-debug][staged:check]  layer3.workflow=bare
[sherlo:fp-debug][staged:check]  final.wire=faf33625c686e04d4305e7760456fde664473e7a426d4e306b10f39ed5de6e0e
```

**Named divergent input: Layer 2 -> `layer2.autolinked`** (the autolinked native-module set). Layer 1, Layer 3, and the lockfile SHAs are identical across both commands; only the autolinking subprocess output diverges (`...@3.0.0-development` vs `...@3.0.0-production`), cascading into `layer2.hash` and `final.wire`. The autolinking subprocess (`npx react-native config` / `npx expo-modules-autolinking resolve`) inherited the CLI's ambient `process.env`, which a package manager injects differently per yarn script (`npm_lifecycle_event`, `NODE_ENV`, ...), so the same tree resolved a different module set per command.

### AC3 - Fix: deterministic, command-independent computation

- **Layer 2 env:** the autolinking subprocess now runs with `envMode: 'replace'` + a fixed allowlist of resolution-stable variables (`buildDeterministicAutolinkEnv`), with `NODE_ENV` pinned. The autolinked set is now identical no matter how the CLI was launched.
- **Path form:** `computeBaseFingerprint` `path.resolve()`s the projectRoot to an absolute canonical form before any layer runs, since `@expo/fingerprint` is path-form-sensitive ('.'-form vs absolute hash differently over one tree).

Post-fix, both commands under different ambient envs compute the SAME hash (`faf33625...` == `faf33625...`).

### AC4 - Cross-command determinism regression test

`crossCommandDeterminism.test.ts` computes the base fingerprint via the registration path AND the probe path over one fixture tree and asserts equality across (1) a per-command ambient-env difference and (2) a projectRoot path-form difference. A sanity test first proves the fixture subprocess IS ambient-env-sensitive, so the determinism assertion is meaningful. This is the test that would have failed the night of 2026-07-10/11.

### AC5 - AXML parser ordering fix

`parseAxmlExpoUpdatesEnabled` now walks the WHOLE manifest before deciding: the `ENABLED` key is authoritative wherever it appears (unreadable value -> enabled=true), presence-implies-enabled only when NO `ENABLED` key exists anywhere, no expo-updates metadata -> false. The aapt/aapt2 fallback carries the same semantics. Table-driven ordering fixtures cover the exact trigger (a non-ENABLED expo-updates key positioned before `ENABLED=false`). Ineligible base registration now emits a loud `logWarning` instead of a silent `console.log`.

### AC6 - Fail-soft preserved, asserted

Fingerprint unavailability (missing `@expo/fingerprint`, no native dirs, autolinking subprocess failure) still degrades to `hash: null` and never throws - asserted by new tests.

### AC7 - Checks

Local against the current `dev` `@sherlo/api-types` (as CI downloads via `init-env.sh`): eslint 0 errors, `tsc --noEmit -p packages/cli` 0 errors, vitest 439/439 passed. The ncc bundle keeps `@expo/fingerprint` external (SHERLO-1742 gate intact).

> CI note: the 3 `bundleFormat`/`GateDiffSource` type errors that appear against a STALE local `sherlo-lib/extracted` snapshot are not present against the current `dev` api-types (which includes `bundleFormat` per SHERLO-1721/1723). CI downloads the current package, so the typecheck is clean there. Verified locally after refreshing the extracted lib.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
