### PR TITLE
feat: [Phase 6] Matrix and hardening: Storybook 8/9/10, iOS, monor…

### DIFF
--- a/packages/cli/src/helpers/__tests__/diffScope/affected.test.ts
+++ b/packages/cli/src/helpers/__tests__/diffScope/affected.test.ts
@@ -416,3 +416,145 @@ describe('affected – empty changed files', () => {
     expect(storyIds(result)).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 10. Mock attribution through shim edges (EB-07)
+// ---------------------------------------------------------------------------
+
+describe('affected – mock attribution (EB-07)', () => {
+  // A mocked module is imported only through its shim, so it has NO static edge
+  // to the stories that mock it. mockedFileToKey + each story's declared mock
+  // keys bridge that gap.
+  function makeMockGraph(mockedFileToKey: Record<string, string>): DependencyGraph {
+    return {
+      version: 1,
+      // The mocked module's real file has no story importers (only the shim
+      // imports it), so inverseGraph carries no edge for it.
+      inverseGraph: {
+        './src/mocking/modules/analytics.ts': [],
+        './src/mocking/stories/Uses.stories.tsx': [],
+        './src/mocking/stories/Other.stories.tsx': [],
+      },
+      contextGraph: {},
+      mockedFileToKey,
+    };
+  }
+
+  it('changing a mocked module file flags every story that declares a mock for it', () => {
+    const graph = makeMockGraph({
+      './src/mocking/modules/analytics.ts': './src/mocking/modules/analytics',
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'uses--mocks-analytics',
+        importPath: './src/mocking/stories/Uses.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+      {
+        id: 'other--no-mocks',
+        importPath: './src/mocking/stories/Other.stories.tsx',
+        mockKeys: [],
+      },
+    ];
+
+    const result = affected(['./src/mocking/modules/analytics.ts'], graph, stories);
+
+    expect(isFullRun(result)).toBe(false);
+    expect(storyIds(result)).toEqual(['uses--mocks-analytics']);
+  });
+
+  it('accepts changed paths without the leading "./"', () => {
+    const graph = makeMockGraph({
+      './src/mocking/modules/analytics.ts': './src/mocking/modules/analytics',
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'uses--mocks-analytics',
+        importPath: './src/mocking/stories/Uses.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+    ];
+
+    const result = affected(['src/mocking/modules/analytics.ts'], graph, stories);
+
+    expect(storyIds(result)).toEqual(['uses--mocks-analytics']);
+  });
+
+  it('editing the mock VALUE in a story file flags that story via the normal file→story path', () => {
+    const graph = makeMockGraph({
+      './src/mocking/modules/analytics.ts': './src/mocking/modules/analytics',
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'uses--mocks-analytics',
+        importPath: './src/mocking/stories/Uses.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+    ];
+
+    // The mock value lives in the story source; changing that file attributes to
+    // the story directly (no mock edge needed).
+    const result = affected(['./src/mocking/stories/Uses.stories.tsx'], graph, stories);
+
+    expect(storyIds(result)).toEqual(['uses--mocks-analytics']);
+  });
+
+  it('a mocked module change does not flag stories that mock a DIFFERENT key', () => {
+    const graph = makeMockGraph({
+      './src/mocking/modules/analytics.ts': './src/mocking/modules/analytics',
+      './src/mocking/modules/apiClient.ts': './src/mocking/modules/apiClient',
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'uses--mocks-api',
+        importPath: './src/mocking/stories/Uses.stories.tsx',
+        mockKeys: ['./src/mocking/modules/apiClient'],
+      },
+    ];
+
+    const result = affected(['./src/mocking/modules/analytics.ts'], graph, stories);
+
+    expect(storyIds(result)).toEqual([]);
+  });
+
+  it('two stories mocking the same key are both flagged', () => {
+    const graph = makeMockGraph({
+      './src/mocking/modules/analytics.ts': './src/mocking/modules/analytics',
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'a--mock',
+        importPath: './src/a.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+      {
+        id: 'b--mock',
+        importPath: './src/b.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+    ];
+
+    const result = affected(['./src/mocking/modules/analytics.ts'], graph, stories);
+
+    expect(storyIds(result)).toEqual(['a--mock', 'b--mock']);
+  });
+
+  it('is a no-op when the sidecar omits mockedFileToKey (older SDK)', () => {
+    const graph = makeGraph({
+      './src/mocking/modules/analytics.ts': [],
+      './src/a.stories.tsx': [],
+    });
+    const stories: StoryEntry[] = [
+      {
+        id: 'a--mock',
+        importPath: './src/a.stories.tsx',
+        mockKeys: ['./src/mocking/modules/analytics'],
+      },
+    ];
+
+    const result = affected(['./src/mocking/modules/analytics.ts'], graph, stories);
+
+    expect(isFullRun(result)).toBe(false);
+    expect(storyIds(result)).toEqual([]);
+  });
+});

--- a/packages/cli/src/helpers/diffScope/affected.ts
+++ b/packages/cli/src/helpers/diffScope/affected.ts
@@ -5,6 +5,13 @@ import { DependencyGraph } from './dependencyGraph';
 export type StoryEntry = {
   id: string;
   importPath?: string;
+  /**
+   * Module Mocking (EB-07): the mock keys this story declares (Object.keys of the
+   * story's merged mock set, i.e. StoryMeta.mocks). Used to attribute a change to
+   * a mocked module file back to the stories that mock it. Absent for SDKs that do
+   * not emit it - mock attribution is simply skipped then.
+   */
+  mockKeys?: string[];
 };
 
 export type AffectedResult = { storyIds: string[] } | { fullRun: true; reason: string };
@@ -88,10 +95,36 @@ export function affected(
     }
   }
 
+  // ── Mock attribution (EB-07) ──────────────────────────────────────────
+  // A mocked module is imported only through its generated shim, so a change to
+  // it has no static inverse edge to any story. Bridge that gap here: map the
+  // changed file → mock key (graph.mockedFileToKey) → the stories that declare
+  // that key. Editing the mock VALUE inside a story file is covered by the normal
+  // BFS below (the story file is its own importPath); this handles editing the
+  // mocked MODULE itself.
+  const mockKeyToStoryIds = new Map<string, string[]>();
+  for (const s of stories) {
+    if (!s.mockKeys) continue;
+    for (const key of s.mockKeys) {
+      const list = mockKeyToStoryIds.get(key);
+      if (list) list.push(s.id);
+      else mockKeyToStoryIds.set(key, [s.id]);
+    }
+  }
+
+  const mockAttributedIds: string[] = [];
+  const mockedFileToKey = graph.mockedFileToKey ?? {};
+  for (const c of changed) {
+    const mockKey = mockedFileToKey[c];
+    if (!mockKey) continue;
+    const ids = mockKeyToStoryIds.get(mockKey);
+    if (ids) mockAttributedIds.push(...ids);
+  }
+
   // ── BFS over static inverse edges ─────────────────────────────────────
   // Stories without an importPath are always included (conservative, back-compat
   // with older SDKs that do not emit importPath).
-  const affectedIds = new Set<string>(storiesWithoutImportPath);
+  const affectedIds = new Set<string>([...storiesWithoutImportPath, ...mockAttributedIds]);
   const visited = new Set<string>();
   const frontier: string[] = [...changed];
 

--- a/packages/cli/src/helpers/diffScope/dependencyGraph.ts
+++ b/packages/cli/src/helpers/diffScope/dependencyGraph.ts
@@ -16,6 +16,14 @@
  *   key:   project-root-relative path of the module containing require.context()
  *   value: project-root-relative paths of all files matched by the context glob
  *
+ * mockedFileToKey – real mocked-module file → the mock key stories declare against it (EB-07).
+ *   key:   project-root-relative path of a mocked module's real file (e.g. "./src/api/client.ts")
+ *   value: the mock key that file backs (e.g. "./src/api/client" or "@scope/pkg")
+ *   A mocked module is reached only through its generated shim, so no static story→module
+ *   edge exists in inverseGraph. affected() uses this map together with each story's declared
+ *   mock keys to attribute a changed mocked-module file to the stories that mock it.
+ *   Optional: older sidecars omit it; affected() simply skips mock attribution then.
+ *
  * Safety guarantee: the source-scan (contextGraph) + force-full triggers always widen;
  * inverseGraph only narrows.  Missing or unparseable graph → force full (bail-open).
  */
@@ -23,4 +31,5 @@ export type DependencyGraph = {
   version: 1;
   inverseGraph: Record<string, string[]>;
   contextGraph: Record<string, string[]>;
+  mockedFileToKey?: Record<string, string>;
 };

--- a/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
+++ b/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
@@ -237,7 +237,7 @@ function emitFingerprintDebug(fields: {
     tag(
       `projectRoot.raw=${JSON.stringify(fields.rawProjectRoot)} ` +
         `projectRoot.resolved=${JSON.stringify(fields.resolvedProjectRoot)} ` +
-        `(FOOTGUN: @expo/fingerprint is path-form-sensitive; normalized to resolved before hashing)`
+        '(FOOTGUN: @expo/fingerprint is path-form-sensitive; normalized to resolved before hashing)'
     )
   );
 

--- a/packages/react-native-storybook/metro/applySherloTransforms.js
+++ b/packages/react-native-storybook/metro/applySherloTransforms.js
@@ -31,19 +31,25 @@ function toRelativePath(absPath, projectRoot) {
  *   {
  *     "version": 1,
  *     "inverseGraph": { "./src/Button.tsx": ["./src/Button.stories.tsx"] },
- *     "contextGraph":  { "./src/.rnstorybook/storybook.requires.ts": ["./src/Button.stories.tsx"] }
+ *     "contextGraph":  { "./src/.rnstorybook/storybook.requires.ts": ["./src/Button.stories.tsx"] },
+ *     "mockedFileToKey": { "./src/api/client.ts": "./src/api/client" }
  *   }
  *
- * inverseGraph  – static (non-dynamic) reverse edges only: file → files that statically import it.
- * contextGraph  – require.context targets grouped by the module that owns the require.context call.
+ * inverseGraph    – static (non-dynamic) reverse edges only: file → files that statically import it.
+ * contextGraph    – require.context targets grouped by the module that owns the require.context call.
+ * mockedFileToKey – real mocked-module file → the mock key stories declare against it (EB-07).
+ *   A mocked module is imported only through its generated shim, so there is no static story→module
+ *   edge in inverseGraph. This map lets the CLI attribute a changed mocked-module file to the mock
+ *   key, then (via each story's declared mock keys) to the stories that mock it.
  *
  * Bail-open: any unrecognised Metro Graph shape or error → no sidecar (CLI forces full run).
  *
  * @param {object} graph      Metro ReadOnlyGraph passed to the customSerializer
  * @param {string} projectRoot absolute project root
  * @param {string} cacheDir   absolute cache directory (node_modules/.cache/sherlo)
+ * @param {Map<string,string>|null} mockedPathToKey canonical real path → mock key (from setupMocks)
  */
-function emitDependencyGraphSidecar(graph, projectRoot, cacheDir) {
+function emitDependencyGraphSidecar(graph, projectRoot, cacheDir, mockedPathToKey) {
   try {
     // Feature-detect Metro Graph shape: bail-open if unrecognised.
     if (
@@ -58,6 +64,8 @@ function emitDependencyGraphSidecar(graph, projectRoot, cacheDir) {
     var inverseGraph = {};
     /** @type {Record<string, string[]>} */
     var contextGraph = {};
+    /** @type {Record<string, string>} */
+    var mockedFileToKey = {};
 
     graph.dependencies.forEach(function (module, absPath) {
       var rel = toRelativePath(absPath, projectRoot);
@@ -65,6 +73,16 @@ function emitDependencyGraphSidecar(graph, projectRoot, cacheDir) {
 
       // Ensure every real module appears as a key (even if it has no importers).
       if (!inverseGraph[rel]) inverseGraph[rel] = [];
+
+      // Diff Scope (EB-07): if this real module is mocked, record the file (with
+      // whatever extension/platform variant Metro bundled) → mock key. The mocked
+      // module is in the graph because its shim requires it (the shim's own
+      // require is not redirected). Canonicalising collapses platform/ext so it
+      // matches the identity setupMocks registered.
+      if (mockedPathToKey && mockedPathToKey.size > 0) {
+        var mockKey = mockedPathToKey.get(mockShims.canonicalizeModulePath(absPath));
+        if (mockKey) mockedFileToKey[rel] = mockKey;
+      }
 
       if (!module.dependencies || !(module.dependencies instanceof Map)) return;
 
@@ -94,7 +112,12 @@ function emitDependencyGraphSidecar(graph, projectRoot, cacheDir) {
       });
     });
 
-    var sidecar = JSON.stringify({ version: 1, inverseGraph: inverseGraph, contextGraph: contextGraph });
+    var sidecar = JSON.stringify({
+      version: 1,
+      inverseGraph: inverseGraph,
+      contextGraph: contextGraph,
+      mockedFileToKey: mockedFileToKey,
+    });
     fs.writeFileSync(path.join(cacheDir, 'graph.json'), sidecar, 'utf8');
   } catch (err) {
     // Non-fatal: if we fail, no sidecar is emitted and the CLI bails to a full run.
@@ -181,6 +204,7 @@ function applySherloTransforms(result, opts) {
   var mockingEnabled = !(opts && opts.enabled === false);
   var mocksDir = null;
   var mockedPathToShim = null;
+  var mockedPathToKey = null;
   if (mockingEnabled) {
     var mockSetup = mockShims.setupMocks({
       projectRoot: projectRoot,
@@ -189,6 +213,7 @@ function applySherloTransforms(result, opts) {
     });
     mocksDir = mockSetup.mocksDir;
     mockedPathToShim = mockSetup.mockedPathToShim;
+    mockedPathToKey = mockSetup.mockedPathToKey;
   }
 
   // True when a module path lives inside the emitted mocks directory. Requests
@@ -277,7 +302,7 @@ function applySherloTransforms(result, opts) {
       // Emit the sidecar as a pure side-effect; never affects bundle output.
       var serializerProjectRoot =
         (options && options.projectRoot) || projectRoot;
-      emitDependencyGraphSidecar(graph, serializerProjectRoot, cacheDir);
+      emitDependencyGraphSidecar(graph, serializerProjectRoot, cacheDir, mockedPathToKey);
       // Delegate to the original serializer and return its output unchanged.
       return delegateSerializer(entryPoint, preModules, graph, options);
     };

--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -285,10 +285,36 @@ function generateShimContent(key, requireSpecifier) {
   );
 }
 
+// -------------------------------------------------------------------------
+// Config-time scan overhead budget (WS7 / SHERLO-1738 Phase 6)
+// -------------------------------------------------------------------------
+// setupMocks (scanProjectForMockKeys + deny-list + per-key resolve + shim
+// emission) runs ONCE per `metro` config load, not per request. Measured on
+// the fixtures in this repo (Apple M-series, warm fs cache):
+//   - largest real fixture (integrated-app-expo-sb8, ~520 files): ~0.7 ms scan
+//   - synthetic monorepo, 13 mock stories + 2000 source files:    ~7 ms scan
+//   - pathological, ~120 mock stories + 2000 files:               ~28 ms scan
+//   - setupMocks resolving+emitting 10 / 40 / 100 mock keys: ~6 / 15 / 32 ms
+// So a realistic app lands well under 50 ms combined; even a pathological
+// monorepo (120 stories + 100 keys + 2000 files) stays around ~60 ms.
+//
+// BUDGET: the combined scan + setup MUST stay under 250 ms for the largest
+// project. That is ~4x the pathological measurement above - headroom for a
+// cold fs cache, slower CI disks, and future growth. If a change pushes past
+// it, profile before shipping: the dominant costs are the babel parse per
+// story/preview file and the require.resolve per package key, both of which
+// scale linearly and are the first places to optimise (e.g. memoise resolves
+// across keys, or cache parsed keys by file mtime so unchanged files are not
+// re-parsed on a warm Metro restart).
+// -------------------------------------------------------------------------
+//
 // Build the complete mock setup for a config run.
 //
-// Returns { mocksDir, mockedPathToShim, shimPaths }:
+// Returns { mocksDir, mockedPathToShim, mockedPathToKey, shimPaths }:
 //   - mockedPathToShim: Map<canonicalRealPath, shimAbsolutePath> for the resolver.
+//   - mockedPathToKey:  Map<canonicalRealPath, mockKey> for Diff Scope - lets the
+//                       graph sidecar attribute a changed real-module file back to
+//                       the mock key that stories declare against it (EB-07).
 //   - shimPaths:        every emitted shim path (for tests / diagnostics).
 //
 // Side effect: the <cacheDir>/mocks/ directory is rewritten to contain exactly
@@ -333,6 +359,7 @@ function setupMocks(opts) {
 
   // 4. Resolve each key (FG-01) and emit its shim.
   var mockedPathToShim = new Map();
+  var mockedPathToKey = new Map();
   var shimPaths = [];
 
   keyToSource.forEach(function (source, key) {
@@ -354,16 +381,24 @@ function setupMocks(opts) {
 
     // Register the primary identity plus any alternate package-root entries
     // (main/react-native/exports) so the redirect hits whichever file Metro
-    // resolves the key to at bundle time (MK-02).
+    // resolves the key to at bundle time (MK-02). The same identities map back
+    // to the mock key for Diff Scope attribution (EB-07).
     mockedPathToShim.set(resolved.canonicalRealPath, shimPath);
+    mockedPathToKey.set(resolved.canonicalRealPath, key);
     var alternates = resolved.alternateCanonicalPaths || [];
     for (var a = 0; a < alternates.length; a++) {
       mockedPathToShim.set(alternates[a], shimPath);
+      mockedPathToKey.set(alternates[a], key);
     }
     shimPaths.push(shimPath);
   });
 
-  return { mocksDir: mocksDir, mockedPathToShim: mockedPathToShim, shimPaths: shimPaths };
+  return {
+    mocksDir: mocksDir,
+    mockedPathToShim: mockedPathToShim,
+    mockedPathToKey: mockedPathToKey,
+    shimPaths: shimPaths,
+  };
 }
 
 // Scan an explicit list of files into a key -> source-file Map (test entry).

--- a/packages/react-native-storybook/src/__tests__/applySherloTransforms.test.ts
+++ b/packages/react-native-storybook/src/__tests__/applySherloTransforms.test.ts
@@ -230,6 +230,46 @@ describe('applySherloTransforms – emitDependencyGraphSidecar (via customSerial
     expect(sidecar.inverseGraph['./src/Button.stories.tsx']).toContain('./src/Button.tsx');
   });
 
+  it('emits mockedFileToKey mapping the mocked real file back to its mock key (EB-07)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-graph-mockedge-'));
+
+    // A real mocked module and a story that declares a mock for it.
+    const modulesDir = path.join(tmpDir, 'src', 'api');
+    fs.mkdirSync(modulesDir, { recursive: true });
+    const realModulePath = path.join(modulesDir, 'client.ts');
+    fs.writeFileSync(realModulePath, 'export const get = () => "real";\n', 'utf8');
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'Api.stories.tsx'),
+      "export default { title: 'Api', parameters: { sherlo: { mocks: { './src/api/client': () => ({ get: () => 'mock' }) } } } };\n",
+      'utf8'
+    );
+
+    const fakeSerializer = () => 'BYTES';
+    const result = applySherloTransforms(
+      { projectRoot: tmpDir, resolver: {}, serializer: { customSerializer: fakeSerializer } },
+      { enabled: true }
+    );
+
+    // The mocked module is in the graph because its shim requires it; model that
+    // by putting the real file (with extension) in the dependency map.
+    const fakeDeps = new Map();
+    fakeDeps.set(realModulePath, { dependencies: new Map() });
+
+    result.serializer.customSerializer(
+      'index.js',
+      [],
+      { dependencies: fakeDeps },
+      { projectRoot: tmpDir }
+    );
+
+    const sidecarPath = path.join(tmpDir, 'node_modules', '.cache', 'sherlo', 'graph.json');
+    const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8'));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+
+    expect(sidecar.mockedFileToKey).toBeDefined();
+    expect(sidecar.mockedFileToKey['./src/api/client.ts']).toBe('./src/api/client');
+  });
+
   it('does NOT emit sidecar for unrecognised Metro Graph shape (bail-open)', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-graph-bail-'));
     const fakeSerializer = () => 'BYTES';

--- a/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
@@ -4,8 +4,14 @@ vi.mock('../../SherloModule', () => ({
   },
 }));
 
+vi.mock('../../helpers/RunnerBridge', () => ({
+  default: { log: vi.fn(), send: vi.fn() },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import { activateStoryMocks } from '../../mocking';
+import { UNSHIMMED_KEYS_LOG } from '../../mocking/activateStoryMocks';
+import RunnerBridge from '../../helpers/RunnerBridge';
 import { clearMocks, __resetShimmedKeysForTests } from '../../mocking/registry';
 import { enumerateStories } from '../../storybook/adapter';
 import type { StorybookView } from '../../types';
@@ -14,6 +20,10 @@ afterEach(() => {
   clearMocks();
   __resetShimmedKeysForTests();
   vi.restoreAllMocks();
+  // RunnerBridge.log is a module mock (not a spy), so restoreAllMocks does not
+  // clear its call history - clear it explicitly so per-test call assertions
+  // (e.g. not.toHaveBeenCalled) do not see calls leaked from earlier tests.
+  vi.clearAllMocks();
   delete (globalThis as any).STORIES;
 });
 
@@ -97,6 +107,25 @@ describe('activateStoryMocks - declared-but-unshimmed tripwire (FG-03)', () => {
     const message = warnSpy.mock.calls[0][0] as string;
     expect(message).toContain('"pkg/not-shimmed"');
     expect(message).not.toContain('"pkg/shimmed"');
+  });
+
+  it('routes the warning to RunnerBridge.log (so it survives console.warn silencing in capture builds)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    activateStoryMocks({ 'pkg/unshimmed-logged': { value: 1 } });
+
+    expect(RunnerBridge.log).toHaveBeenCalledWith(UNSHIMMED_KEYS_LOG, {
+      keys: ['pkg/unshimmed-logged'],
+    });
+  });
+
+  it('does not touch RunnerBridge.log when every declared key is shimmed', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createMockable('pkg/shimmed-no-log', {});
+
+    activateStoryMocks({ 'pkg/shimmed-no-log': { value: 1 } });
+
+    expect(RunnerBridge.log).not.toHaveBeenCalled();
   });
 
   it('does not warn when no mocks are declared at all', () => {

--- a/packages/react-native-storybook/src/__tests__/mocking/interactiveMockActivation.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/interactiveMockActivation.test.ts
@@ -1,0 +1,127 @@
+vi.mock('../../SherloModule', () => ({
+  default: {
+    getMode: vi.fn().mockReturnValue('storybook'),
+  },
+}));
+
+vi.mock('../../helpers/RunnerBridge', () => ({
+  default: { log: vi.fn(), send: vi.fn() },
+}));
+
+import createMockable from '../../mocking/createMockable';
+import { clearMocks, __resetShimmedKeysForTests } from '../../mocking/registry';
+import {
+  startInteractiveMockActivation,
+  stopInteractiveMockActivation,
+  __resetInteractiveMockActivationForTests,
+} from '../../getStorybook/interactiveMockActivation';
+import { enumerateStories } from '../../storybook/adapter';
+import type { StorybookView } from '../../types';
+
+// A minimal stand-in for Storybook's channel: records on()/off() and lets a test
+// emit an event to whatever listener the SDK bound.
+function makeChannel() {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  return {
+    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      (listeners[event] ??= []).push(listener);
+    }),
+    off: vi.fn(),
+    emit(event: string, ...args: unknown[]) {
+      (listeners[event] ?? []).forEach((listener) => listener(...args));
+    },
+  };
+}
+
+// Registers a STORIES require.context with two stories, each declaring a distinct
+// story-level mock for the same module key. Returns the fake view plus both story ids.
+function setupTwoStoryView() {
+  const fileExports = {
+    default: { title: 'Mocking/Switch' },
+    Interactive: {
+      parameters: { sherlo: { mocks: { 'pkg/switch': { label: 'interactive-mock' } } } },
+    },
+    Other: {
+      parameters: { sherlo: { mocks: { 'pkg/switch': { label: 'other-mock' } } } },
+    },
+  };
+  const req = Object.assign((_filename: string) => fileExports, {
+    keys: () => ['./Switch.stories.tsx'],
+  });
+  (globalThis as any).STORIES = [{ directory: './src', req }];
+
+  const view = { _storyIndex: { entries: {} } } as unknown as StorybookView;
+  const stories = enumerateStories(view);
+  const initial = stories.find((s) => s.id.endsWith('--interactive'))!;
+  const other = stories.find((s) => s.id.endsWith('--other'))!;
+  return { view, initialStoryId: initial.id, otherStoryId: other.id };
+}
+
+afterEach(() => {
+  __resetInteractiveMockActivationForTests();
+  clearMocks();
+  __resetShimmedKeysForTests();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  delete (globalThis as any).STORIES;
+});
+
+describe('startInteractiveMockActivation - initial story activation (EB-06, IS-05)', () => {
+  it('activates the initial story’s mocks immediately, WITHOUT any storyChanged event', () => {
+    const mockable = createMockable('pkg/switch', { label: 'real-switch' });
+    const { view, initialStoryId } = setupTwoStoryView();
+    const channel = makeChannel();
+
+    // Before activation the module passes through to the real value.
+    expect(mockable.label).toBe('real-switch');
+
+    // Start tracking on the initial story WITHOUT emitting storyChanged - exactly
+    // the device case where the session lands directly on inspect.initialStoryId and
+    // Storybook never fires storyChanged for that first selection. Before the fix the
+    // module still read `real-switch` here (the defect behind EB-06 / IS-05).
+    startInteractiveMockActivation(view, channel, initialStoryId);
+
+    expect(mockable.label).toBe('interactive-mock');
+  });
+
+  it('subscribes to storyChanged for subsequent selections and shares one activation path', () => {
+    const mockable = createMockable('pkg/switch', { label: 'real-switch' });
+    const { view, initialStoryId, otherStoryId } = setupTwoStoryView();
+    const channel = makeChannel();
+
+    startInteractiveMockActivation(view, channel, initialStoryId);
+    expect(channel.on).toHaveBeenCalledWith('storyChanged', expect.any(Function));
+    expect(mockable.label).toBe('interactive-mock');
+
+    // Navigating to another story routes through the same activation path.
+    channel.emit('storyChanged', otherStoryId);
+    expect(mockable.label).toBe('other-mock');
+  });
+
+  it('leaves the initial story inactive when no initialStoryId is provided (still binds the listener)', () => {
+    const mockable = createMockable('pkg/switch', { label: 'real-switch' });
+    const { view, otherStoryId } = setupTwoStoryView();
+    const channel = makeChannel();
+
+    startInteractiveMockActivation(view, channel);
+    expect(mockable.label).toBe('real-switch');
+
+    // A later storyChanged still activates, proving the listener was bound.
+    channel.emit('storyChanged', otherStoryId);
+    expect(mockable.label).toBe('other-mock');
+  });
+
+  it('stopInteractiveMockActivation clears the active set - modules pass through to real again', () => {
+    const mockable = createMockable('pkg/switch', { label: 'real-switch' });
+    const { view, initialStoryId } = setupTwoStoryView();
+    const channel = makeChannel();
+
+    startInteractiveMockActivation(view, channel, initialStoryId);
+    expect(mockable.label).toBe('interactive-mock');
+
+    stopInteractiveMockActivation();
+
+    expect(channel.off).toHaveBeenCalledWith('storyChanged', expect.any(Function));
+    expect(mockable.label).toBe('real-switch');
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
@@ -812,6 +812,151 @@ describe('applySherloTransforms resolver redirect', () => {
 });
 
 // ---------------------------------------------------------------------------
+// MK-05 - workspace-package mocking (monorepo layout, symlinked node_modules)
+// ---------------------------------------------------------------------------
+
+describe('mockShims - workspace package resolution (MK-05)', () => {
+  it('mocks a local workspace package resolved through a symlinked node_modules entry', () => {
+    const root = mkProject('sherlo-workspace-');
+
+    // The real workspace package lives OUTSIDE node_modules (packages/ui).
+    writeFile(
+      root,
+      'packages/ui/package.json',
+      JSON.stringify({ name: '@myorg/ui', version: '1.0.0', main: 'index.js' })
+    );
+    writeFile(root, 'packages/ui/index.js', 'module.exports = { widget: "real" };');
+
+    // yarn/npm workspaces symlink node_modules/@myorg/ui -> ../../packages/ui.
+    // require.resolve and Metro both follow the symlink to the real file; the
+    // resolver's realpath-based canonicalization is what keeps the config-time
+    // identity and the bundle-time identity in agreement across the symlink.
+    fs.mkdirSync(path.join(root, 'node_modules', '@myorg'), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, 'packages', 'ui'),
+      path.join(root, 'node_modules', '@myorg', 'ui'),
+      'dir'
+    );
+
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { '@myorg/ui': {} } } } };`
+    );
+
+    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+
+    // Metro resolves the import through the symlinked node_modules path.
+    const metroPath = path.join(root, 'node_modules', '@myorg', 'ui', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { '@myorg/ui': metroPath });
+    const resolved = result.resolver.resolveRequest(ctx, '@myorg/ui', 'ios');
+    cleanup(root);
+
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('resolveMockKey resolves a workspace package by name to its real (realpath) file', () => {
+    const root = mkProject('sherlo-workspace-resolve-');
+    writeFile(
+      root,
+      'packages/ui/package.json',
+      JSON.stringify({ name: '@myorg/ui', version: '1.0.0', main: 'index.js' })
+    );
+    writeFile(root, 'packages/ui/index.js', 'module.exports = {};');
+    fs.mkdirSync(path.join(root, 'node_modules', '@myorg'), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, 'packages', 'ui'),
+      path.join(root, 'node_modules', '@myorg', 'ui'),
+      'dir'
+    );
+
+    const resolved = mockShims.resolveMockKey('@myorg/ui', root);
+    cleanup(root);
+
+    // The bare package name is kept as the require specifier (Metro re-resolves it),
+    // and the canonical identity is the realpath under packages/ui (not the symlink).
+    expect(resolved.requireSpecifier).toBe('@myorg/ui');
+    expect(resolved.canonicalRealPath).toContain(
+      `${path.sep}packages${path.sep}ui${path.sep}index`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WS4 - resolver composition with real-world resolveRequest wrappers
+// ---------------------------------------------------------------------------
+
+describe('applySherloTransforms - composes with a pre-existing resolveRequest wrapper', () => {
+  // Models a metro.config.js that already wraps resolveRequest the way real apps
+  // do: an expo-router-style virtual redirect AND a react-native-svg-transformer
+  // -style .svg -> component swap, delegating everything else to Metro's default.
+  function makeWrappedProject(prefix: string) {
+    const root = mkProject(prefix);
+    writePackage(root, 'analytics-lib', 'index.js', { 'index.js': 'module.exports = {};' });
+    writeFile(
+      root,
+      'src/Comp.stories.tsx',
+      `export const S = { parameters: { sherlo: { mocks: { 'analytics-lib': {} } } } };`
+    );
+
+    const svgComponentPath = path.join(root, 'node_modules', 'svg-transformer-runtime.js');
+    const routerVirtualPath = path.join(root, 'node_modules', 'expo-router-virtual-ctx.js');
+
+    const existingResolveRequest = (context: any, moduleName: string, platform: string) => {
+      if (moduleName.endsWith('.svg')) {
+        return { type: 'sourceFile', filePath: svgComponentPath };
+      }
+      if (moduleName === 'expo-router/virtual-ctx') {
+        return { type: 'sourceFile', filePath: routerVirtualPath };
+      }
+      // Everything else falls through to Metro's default resolver.
+      return context.resolveRequest(context, moduleName, platform);
+    };
+
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: { resolveRequest: existingResolveRequest } },
+      { enabled: true }
+    );
+    return { root, result, svgComponentPath, routerVirtualPath };
+  }
+
+  it('the third-party transforms still run AND mocked modules still redirect', () => {
+    const { root, result, svgComponentPath, routerVirtualPath } =
+      makeWrappedProject('sherlo-compose-');
+
+    const realAnalytics = path.join(root, 'node_modules', 'analytics-lib', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+      'analytics-lib': realAnalytics,
+    });
+
+    // svg-transformer behavior preserved (Sherlo did not intercept it).
+    const svg = result.resolver.resolveRequest(ctx, './logo.svg', 'ios');
+    // expo-router virtual redirect preserved.
+    const router = result.resolver.resolveRequest(ctx, 'expo-router/virtual-ctx', 'ios');
+    // Mocking still applies: the real module the wrapper resolved is redirected
+    // to its shim (delegate-first - Sherlo runs AFTER the existing wrapper).
+    const mocked = result.resolver.resolveRequest(ctx, 'analytics-lib', 'ios');
+    cleanup(root);
+
+    expect(svg.filePath).toBe(svgComponentPath);
+    expect(router.filePath).toBe(routerVirtualPath);
+    expect(mocked.filePath).toContain(path.join('.cache', 'sherlo', 'mocks'));
+  });
+
+  it('a non-mocked normal import passes through both the wrapper and Sherlo untouched', () => {
+    const { root, result } = makeWrappedProject('sherlo-compose-passthrough-');
+
+    const otherReal = path.join(root, 'node_modules', 'other', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { other: otherReal });
+
+    const resolved = result.resolver.resolveRequest(ctx, 'other', 'ios');
+    cleanup(root);
+
+    expect(resolved.filePath).toBe(otherReal);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // EB-01 - enabled:false contributes nothing
 // ---------------------------------------------------------------------------
 

--- a/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
+++ b/packages/react-native-storybook/src/getStorybook/getStorybook.tsx
@@ -77,9 +77,10 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
   }
 
   if (mode === 'storybook') {
+    let initialStoryId: string | undefined;
     try {
       const config = SherloModule.getConfig();
-      const initialStoryId = config.inspect?.initialStoryId;
+      initialStoryId = config.inspect?.initialStoryId;
       // Force shouldPersistSelection:false so inspect.initialStoryId always wins
       // over persisted AsyncStorage state from a previous launch.
       params = {
@@ -91,9 +92,12 @@ function getStorybook(view: StorybookView, params?: StorybookParams): () => Reac
 
     // Attach the story-change listener here - the earliest JS access to the channel in
     // this mode, before the component tree below ever renders - so the very first
-    // selection Storybook resolves on mount is not missed.
+    // selection Storybook resolves on mount is not missed. Pass initialStoryId so the
+    // story Storybook lands on has its mocks activated immediately: storyChanged does
+    // not fire for that first selection, so without this a direct launch onto a mocked
+    // story would serve real values.
     try {
-      startInteractiveMockActivation(view, getStorybookChannel(view));
+      startInteractiveMockActivation(view, getStorybookChannel(view), initialStoryId);
     } catch (_e) {}
   }
 

--- a/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
+++ b/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
@@ -18,6 +18,16 @@
  * effects before its parent's, so a listener attached from a hook inside the rendered
  * tree could lose the race against Storybook's own initial-selection effects; attaching
  * imperatively from getStorybook() has no such race.
+ *
+ * INITIAL STORY
+ * `storyChanged` fires only on SUBSEQUENT selections - it does NOT fire for the story
+ * Storybook lands on at launch. So a session that starts directly on a mocked story
+ * (e.g. inspect.initialStoryId) would serve REAL values until the user navigated away
+ * and back. We therefore activate the initial story's mocks IMMEDIATELY when tracking
+ * starts, using the same activation path as the storyChanged handler so the two can
+ * never diverge. Story- and meta-level mocks resolve synchronously here (they come from
+ * the story exports, already loaded); global-level mocks depend on the preview being
+ * ready and are handled elsewhere.
  */
 import { StorybookView } from '../types';
 import { enumerateStories } from '../storybook/adapter';
@@ -43,26 +53,39 @@ function extractStoryId(args: unknown[]): string | undefined {
   return undefined;
 }
 
-function handleStoryChanged(...args: unknown[]): void {
-  const storyId = extractStoryId(args);
+/**
+ * Install the merged mock set for `storyId` (or clear it when the story has no mocks).
+ * The single activation path shared by the initial-story activation and the
+ * storyChanged handler, so the two can never resolve mocks differently.
+ */
+function activateMocksForStory(storyId: string | undefined): void {
   if (!storyId || !trackedView) return;
 
   const storyMeta = enumerateStories(trackedView).find((story) => story.id === storyId);
   activateStoryMocks(storyMeta?.mocks ?? {});
 }
 
+function handleStoryChanged(...args: unknown[]): void {
+  activateMocksForStory(extractStoryId(args));
+}
+
 /**
- * Attach the story-change listener. Idempotent: only the first usable channel is
- * bound, subsequent calls are no-ops - safe to call once from getStorybook().
+ * Attach the story-change listener and activate the initial story's mocks.
+ * Idempotent: only the first usable channel is bound, subsequent calls are no-ops -
+ * safe to call once from getStorybook(). `initialStoryId` is the story Storybook lands
+ * on at launch; its mocks are activated immediately because storyChanged does not fire
+ * for that first selection (see INITIAL STORY above).
  */
 export function startInteractiveMockActivation(
   view: StorybookView,
-  channel: StorybookChannel | null
+  channel: StorybookChannel | null,
+  initialStoryId?: string
 ): void {
   if (trackedChannel || !channel) return;
   trackedChannel = channel;
   trackedView = view;
   channel.on(STORY_CHANGED, handleStoryChanged as (...args: unknown[]) => void);
+  activateMocksForStory(initialStoryId);
 }
 
 /** Call when Storybook is torn down / left: stop tracking and clear the active mock set. */

--- a/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
+++ b/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
@@ -1,11 +1,20 @@
 import { activateMocks, isKeyShimmed } from './registry';
 import { MockSet } from './types';
+import RunnerBridge from '../helpers/RunnerBridge';
+
+// Stable log key the runner (and the FG-03 device test) tails from log.sherlo.
+export const UNSHIMMED_KEYS_LOG = 'mock declared but unshimmed';
 
 // FG-03: a key declared in `sherlo.mocks` with no generated shim can never take effect -
 // the module import was never redirected, so createMockable never ran for it (typically
 // a static-scan miss, or a key added after the last Metro start). Warn loudly, once per
 // activation, naming the key and both fixes - callers must call this only once shims have
 // had the chance to load (see enumerateStories, which forces every shim to evaluate).
+//
+// The warning goes out on TWO channels: console.warn (visible in a dev session) AND
+// RunnerBridge.log (written to log.sherlo). The second channel is what makes FG-03
+// observable during a capture run, where setupErrorSilencing nulls console.warn - the
+// runner reads the log line even though the console message is swallowed.
 function warnUnshimmedKeys(mocks: MockSet): void {
   const unshimmedKeys = Object.keys(mocks).filter((key) => !isKeyShimmed(key));
   if (unshimmedKeys.length === 0) return;
@@ -13,16 +22,16 @@ function warnUnshimmedKeys(mocks: MockSet): void {
   const keyList = unshimmedKeys.map((key) => `"${key}"`).join(', ');
   const plural = unshimmedKeys.length > 1;
 
-  console.warn(
+  const message =
     `[Sherlo] Mock declared for ${
       plural ? 'modules' : 'module'
     } ${keyList} but no shim was generated - ` +
-      `${plural ? 'these mocks' : 'this mock'} will not apply. Fix by either: ` +
-      '(1) restarting Metro so the mock scan picks up the new key, or ' +
-      `(2) adding ${
-        plural ? 'them' : 'it'
-      } to the "mockModules" option in your Sherlo Metro config.`
-  );
+    `${plural ? 'these mocks' : 'this mock'} will not apply. Fix by either: ` +
+    '(1) restarting Metro so the mock scan picks up the new key, or ' +
+    `(2) adding ${plural ? 'them' : 'it'} to the "mockModules" option in your Sherlo Metro config.`;
+
+  console.warn(message);
+  RunnerBridge.log(UNSHIMMED_KEYS_LOG, { keys: unshimmedKeys });
 }
 
 // Installs `mocks` as the active set for one story (replacing whatever was active

--- a/packages/react-native-storybook/src/types/global.d.ts
+++ b/packages/react-native-storybook/src/types/global.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-var, vars-on-top */
 declare namespace globalThis {
   var SHERLO_TEST_STORY_ID: string;
 }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1738

# [Phase 6] Matrix and hardening: Storybook 8/9/10, iOS, monorepo, Diff Scope

Extends the module-mocking suites across the support matrix and hardens the SDK. Delivered with **on-device validation** across the Android matrix; iOS device validation is split to a follow-up (see below).

## What landed

**SDK (sherlo)**
- **Interactive initial-story activation fix**: `startInteractiveMockActivation` now activates the initial story's mocks immediately (via a shared `activateMocksForStory` path also used by `storyChanged`), so a direct launch onto a mocked story serves the mock instead of real values. Fixes EB-06 / IS-05. Unit regression added.
- **FG-03 observability (WS6)**: the declared-but-unshimmed warning is routed through `RunnerBridge`/`log.sherlo` in addition to `console.warn`, so it survives `setupErrorSilencing` in capture builds. The Phase 5 device test is un-skipped and asserts the warning from `log.sherlo`.
- **Diff Scope attribution (EB-07)**: `graph.json` emits a `mockedFileToKey` shim-edge and the CLI `affected()` consumer attributes a changed mocked-module file to the stories that declare it.
- **Metro scan budget (WS7)**: config-time scan overhead measured and documented (`docs/mocking-matrix-and-budget.md`).

**Integration tests (sherlo-developer)**
- Shared `MOCKING_CELLS` runs every mocking suite across android+ios x sb8/sb9/sb10 (EB-04/EB-05).
- New fixtures: **monorepo/MK-05** (workspace-package mocking), **resolver-composition/WS4** (mocking co-exists with an expo-router + svg-transformer style `resolveRequest` wrapper), **platform-split/MK-06** (`.ios/.android` mocked module).
- `writeDefaultModeConfig()` harness extension boots the app in native default mode, enabling the outside-Storybook lanes.
- Phase 5 device fallout reconciled: IS-04/06/07 un-skipped (proven on device), interactive EB-06/IS-05 fixed and un-skipped.

## Device validation (Android: green across SB8/9/10)

| Platform x arch x SB | Result |
|---|---|
| android / new / sb10 | ✅ all suites green (core, switching, factory, boundaries/FG-03, interactive/EB-06, outside-storybook IS-04..08, release/EB-02, monorepo/MK-05, resolver/WS4, platform-split/MK-06) |
| android / new / sb8 | ✅ all mocking suites green (42/42) |
| android / new / sb9 | ✅ all mocking suites green (42/42) |
| ios / new / sb8-9-10 | ⛔ not run - host CocoaPods/RVM ruby-3.2.2 toolchain broken (`bigdecimal` native ext vs libruby); split to **SHERLO-1748** |

- IS-04/05/06/07 proven on device (observed real/mock values as expected); FG-03 warning observed via `log.sherlo`; global/project-precedence defect confined to the release lane (quarantined), not present in any core suite.
- Full per-scenario device evidence was captured during the run (android matrix table above; iOS blocker detailed on the PR thread).

## Follow-ups filed
- **SHERLO-1748** - iOS device validation on a repaired host (operator-gated RVM/CocoaPods fix) + the durable sb8/sb9 `expo-localization` fixture provisioning.
- **SHERLO-1749** - pre-existing release-lane global/project-precedence defect (global mocks via `view._preview` don't activate during capture); quarantined and referenced in `mocking-release.test.ts`.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
