### PR TITLE
feat: Fingerprint layer1 still command-dependent: @expo/fingerprin…

### DIFF
--- a/packages/cli/src/helpers/fingerprint/__tests__/crossCommandDeterminism.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/crossCommandDeterminism.test.ts
@@ -1,29 +1,37 @@
 /**
- * CROSS-COMMAND DETERMINISM REGRESSION TEST (SHERLO-1744, AC4)
+ * CROSS-COMMAND DETERMINISM REGRESSION TEST (SHERLO-1744, SHERLO-1746)
  *
  * This is the test that would have FAILED the whole night of 2026-07-10/11.
  *
- * Registration (test:standard) and the probe (staged:check) both call
- * `computeBaseFingerprint(projectRoot)` over an identical tree, yet were
+ * Registration (test:standard) and the probe (staged:check / test:bundled) both
+ * call `computeBaseFingerprint(projectRoot)` over an identical tree, yet were
  * producing DIFFERENT base fingerprints - so the staged gate lookup never hit
- * and the fast path was silently dead for every user. The instrument
- * (`SHERLO_FINGERPRINT_DEBUG=1`) named the divergent input as
- * `layer2.autolinked`: the autolinking resolve subprocess inherited the CLI's
- * ambient `process.env`, which a package manager injects DIFFERENTLY per yarn
- * script (`NODE_ENV`, `npm_lifecycle_event`, …), so the same tree resolved a
- * different module set per command.
+ * and the fast path was silently dead for every user. The root cause is
+ * per-command ambient `process.env`: a package manager injects `NODE_ENV`,
+ * `npm_lifecycle_event`, … DIFFERENTLY per yarn script, and that env leaked into
+ * the fingerprint compute. There are TWO leak surfaces, fixed separately:
+ *   - Layer 2 (SHERLO-1744): the autolinking resolve subprocess inherited the
+ *     ambient env and resolved a different module set per command. Covered by
+ *     the first describe block below (`runShellCommand` is NOT mocked; the real
+ *     subprocess exercises the `envMode: 'replace'` fix).
+ *   - Layer 1 (SHERLO-1746): `@expo/fingerprint` internally spawns its own
+ *     `ExpoConfigLoader.js` to evaluate the app config, which inherited the
+ *     ambient env - so an app.config.js that reads env hashed differently per
+ *     command. The 1744 fixture keys divergence on autolinking ONLY (Layer 1 was
+ *     mocked to a fixed hash), so it could NOT catch this. Covered by the second
+ *     describe block below, which makes the Layer-1 mock ENV-SENSITIVE to stand
+ *     in for such an app.config.js and exercises the `withDeterministicEnv`
+ *     env-swap around `createFingerprintAsync`.
  *
  * These tests compute the base fingerprint via the registration path AND the
  * probe path over ONE fixture tree and ASSERT EQUALITY across:
- *   1. a per-command ambient-env difference (the named root cause), and
+ *   1. a per-command ambient-env difference at Layer 2 (SHERLO-1744),
  *   2. a projectRoot path-form difference ('.'-form vs absolute - the
- *      @expo/fingerprint path-form footgun).
- *
- * `@expo/fingerprint` (Layer 1) is mocked to a fixed hash so the test is fast
- * and isolates Layer 2. `runShellCommand` is deliberately NOT mocked: the real
- * autolinking subprocess is what exercises the env-determinism fix.
+ *      @expo/fingerprint path-form footgun), and
+ *   3. a per-command ambient-env difference at Layer 1 (SHERLO-1746).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFingerprintAsync } from '@expo/fingerprint';
 import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
@@ -42,6 +50,10 @@ let computeBaseFingerprint: typeof import('../baseFingerprint').computeBaseFinge
 let fixtureDir: string;
 let originalCwd: string;
 let originalNodeEnv: string | undefined;
+let originalNpmLifecycleEvent: string | undefined;
+
+/** Fixed hash the Layer-1 mock resolves to for the (env-insensitive) 1744 tests. */
+const LAYER1_FIXED_HASH = 'layer1-fixed-hash';
 
 function writeFile(dir: string, rel: string, content: string): void {
   const full = path.join(dir, rel);
@@ -97,8 +109,12 @@ function runStubUnderEnv(dir: string, nodeEnv: string): string {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  // Reset Layer 1 to the env-INSENSITIVE fixed hash. The 1744 block relies on
+  // this; the 1746 block overrides it with an env-SENSITIVE implementation.
+  vi.mocked(createFingerprintAsync).mockResolvedValue({ hash: LAYER1_FIXED_HASH } as never);
   originalCwd = process.cwd();
   originalNodeEnv = process.env.NODE_ENV;
+  originalNpmLifecycleEvent = process.env.npm_lifecycle_event;
   fixtureDir = buildFixture();
   computeBaseFingerprint = (await import('../baseFingerprint')).computeBaseFingerprint;
 });
@@ -107,6 +123,8 @@ afterEach(() => {
   process.chdir(originalCwd);
   if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = originalNodeEnv;
+  if (originalNpmLifecycleEvent === undefined) delete process.env.npm_lifecycle_event;
+  else process.env.npm_lifecycle_event = originalNpmLifecycleEvent;
   fs.rmSync(fixtureDir, { recursive: true, force: true });
 });
 
@@ -153,6 +171,90 @@ describe('cross-command base fingerprint determinism (SHERLO-1744 AC4)', () => {
       const probe = await computeBaseFingerprint('.', { command: 'staged:check' });
 
       expect(registration.hash).toBe(probe.hash);
+    },
+    RUN_TIMEOUT_MS
+  );
+});
+
+describe('cross-command Layer-1 env determinism (SHERLO-1746)', () => {
+  /**
+   * Make the Layer-1 mock ENV-SENSITIVE: its hash reflects the ambient
+   * `NODE_ENV` and `npm_lifecycle_event`. This stands in for an app.config.js
+   * whose evaluation reads env - exactly what `@expo/fingerprint`'s internal
+   * `ExpoConfigLoader.js` subprocess would observe. Under the env-swap fix the
+   * compute always sees the pinned deterministic env, so the hash is stable
+   * across commands.
+   */
+  beforeEach(() => {
+    vi.mocked(createFingerprintAsync).mockImplementation(
+      async () =>
+        ({
+          hash: `layer1-${process.env.NODE_ENV ?? 'unset'}-${
+            process.env.npm_lifecycle_event ?? 'unset'
+          }`,
+        } as never)
+    );
+  });
+
+  it('sanity: the Layer-1 mock IS ambient-env-sensitive', async () => {
+    // Proves the regression test is meaningful: without the env-swap the mock
+    // genuinely returns a different hash per ambient env, so the fingerprint
+    // WOULD diverge across commands if that env leaked into the compute.
+    process.env.NODE_ENV = 'development';
+    process.env.npm_lifecycle_event = 'test:standard';
+    const dev = await createFingerprintAsync(fixtureDir, {});
+
+    process.env.NODE_ENV = 'production';
+    process.env.npm_lifecycle_event = 'test:bundled';
+    const prod = await createFingerprintAsync(fixtureDir, {});
+
+    expect(dev.hash).not.toBe(prod.hash);
+  });
+
+  it(
+    'registration and probe paths agree despite a per-command Layer-1 ambient-env difference',
+    async () => {
+      // Registration path runs under the test:standard ambient env; the probe
+      // under the test:bundled one - exactly the CI condition that broke the
+      // staged gate. Without the swap the two Layer-1 hashes (and the finals)
+      // diverge; with it both see the pinned NODE_ENV='production'.
+      process.env.NODE_ENV = 'development';
+      process.env.npm_lifecycle_event = 'test:standard';
+      const registration = await computeBaseFingerprint(fixtureDir, { command: 'test:standard' });
+
+      process.env.NODE_ENV = 'production';
+      process.env.npm_lifecycle_event = 'test:bundled';
+      const probe = await computeBaseFingerprint(fixtureDir, { command: 'test:bundled' });
+
+      expect(registration.hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(registration.hash).toBe(probe.hash);
+    },
+    RUN_TIMEOUT_MS
+  );
+
+  it(
+    'is fail-soft on a Layer-1 throw and fully restores process.env (no allowlist leak)',
+    async () => {
+      // A pre-existing, non-allowlisted ambient var and a distinctive NODE_ENV
+      // must both survive the compute untouched - proving the env-swap restores
+      // the EXACT original env on the throwing path, leaking nothing.
+      const marker = 'sherlo-1746-marker-should-survive';
+      process.env.SHERLO_1746_CANARY = marker;
+      process.env.NODE_ENV = 'development';
+
+      vi.mocked(createFingerprintAsync).mockRejectedValue(new Error('boom'));
+
+      const result = await computeBaseFingerprint(fixtureDir, { command: 'test:standard' });
+
+      // (a) fail-soft: unrecoverable Layer-1 error degrades to a null hash.
+      expect(result.hash).toBeNull();
+
+      // (b) env fully restored: the pinned production value did not leak out and
+      // the arbitrary pre-existing var is intact.
+      expect(process.env.NODE_ENV).toBe('development');
+      expect(process.env.SHERLO_1746_CANARY).toBe(marker);
+
+      delete process.env.SHERLO_1746_CANARY;
     },
     RUN_TIMEOUT_MS
   );

--- a/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
+++ b/packages/cli/src/helpers/fingerprint/baseFingerprint.ts
@@ -87,20 +87,77 @@ export type ComputeBaseFingerprintOptions = {
  * (missing @expo/fingerprint, no native dirs, …).  Callers MUST treat a null
  * hash as "stageable flow unavailable" and print the debugMessage.
  *
- * DETERMINISM CONTRACT (SHERLO-1744): over an identical tree, this MUST return
- * the SAME hash no matter which command called it. Two inputs used to break
- * that and are now pinned:
+ * DETERMINISM CONTRACT (SHERLO-1744, SHERLO-1746): over an identical tree, this
+ * MUST return the SAME hash no matter which command called it. Three inputs used
+ * to break that and are now pinned:
  *   1. `projectRoot` path form. `@expo/fingerprint` is path-form-sensitive -
  *      the '.'-form and the absolute form of the SAME tree hash differently
  *      (proved by harness run 29142544470). We `path.resolve()` to an absolute
  *      canonical form before handing it to any layer, so a caller passing '.'
  *      and a caller passing an absolute path agree.
  *   2. The Layer-2 autolinking subprocess environment (see
- *      {@link buildDeterministicAutolinkEnv}).
+ *      {@link buildDeterministicEnv}).
+ *   3. The Layer-1 `@expo/fingerprint` compute environment (SHERLO-1746). The
+ *      library internally spawns `ExpoConfigLoader.js` to evaluate the app
+ *      config, which inherits the CLI's per-command ambient env; an
+ *      app.config.js that reads env would then hash differently per command. We
+ *      swap in the same deterministic env around the library call (see
+ *      {@link withDeterministicEnv}).
  *
  * Set `SHERLO_FINGERPRINT_DEBUG=1` to print the full per-layer breakdown
  * (tagged by command) - permanent, off-by-default observability.
  */
+/** The env mode applied to the Layer-1 compute - surfaced by the debug instrument. */
+const LAYER1_ENV_MODE = 'sanitized';
+
+/**
+ * Run `fn` with `process.env` temporarily replaced by the deterministic env
+ * ({@link buildDeterministicEnv}), restoring the exact original env afterward.
+ *
+ * WHY ENV-SWAP (and not a child process): Layer 1 is
+ * `createFingerprintAsync`, and its BARE path passes `fileHookTransform:
+ * createVersionStrippingTransform()` - a live JS closure that cannot be
+ * serialized across a process boundary. Running the library in a child process
+ * would force us to reimplement/duplicate that transform. Instead we keep
+ * `createFingerprintAsync` IN-PROCESS (the closure works) and control the
+ * ambient env it exposes to the `ExpoConfigLoader.js` subprocess it spawns
+ * internally: an app.config.js that reads env (API urls, feature flags, build
+ * profiles - the standard Expo pattern) then evaluates identically per command.
+ *
+ * The swap is done by IN-PLACE mutation of `process.env` (delete-all +
+ * Object.assign) rather than reassigning `process.env` to a new object: Node
+ * snapshots the live `process.env` object at `child_process` spawn time, so an
+ * in-place mutation is guaranteed to be reflected in the child ExpoConfigLoader
+ * spawn, whereas a reassignment can be missed.
+ *
+ * ASYNC / EXCEPTION / CONCURRENCY SAFETY:
+ *   - Exception-safe: the finally-block restores the original env even when
+ *     `fn` throws; the throw then propagates to the outer try/catch in
+ *     `computeBaseFingerprint`, which returns `{ hash: null }` (fail-soft
+ *     preserved). No allowlist value leaks past this call on any path.
+ *   - Concurrency-safe within the CLI process: `computeBaseFingerprint` is only
+ *     ever `await`ed as a single standalone call in each of its 5 callers
+ *     (registerBase, stagedCheck, testBundled, easBuildOnComplete's
+ *     asyncUploadBuildAndRunTests, uploadOrReuseBuildsAndRunTests). None wraps
+ *     it in `Promise.all`/`Promise.race` or runs other env-reading/subprocess
+ *     work concurrently during the compute (in the two callers that also compute
+ *     a native fingerprint, that work is fully awaited on a preceding line). The
+ *     swap window is also kept as narrow as possible - only the single library
+ *     call is wrapped - further shrinking any theoretical window.
+ */
+async function withDeterministicEnv<T>(fn: () => Promise<T>): Promise<T> {
+  const saved = { ...process.env };
+  const deterministic = buildDeterministicEnv();
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, deterministic);
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
+  }
+}
+
 export async function computeBaseFingerprint(
   projectRoot: string,
   options: ComputeBaseFingerprintOptions = {}
@@ -139,7 +196,13 @@ export async function computeBaseFingerprint(
             fileHookTransform: createVersionStrippingTransform(),
           };
 
-    const fingerprint = await createFingerprintAsync(resolvedProjectRoot, fingerprintOptions);
+    // Layer 1 (SHERLO-1746): swap in the deterministic env around the library
+    // call so the `ExpoConfigLoader.js` subprocess @expo/fingerprint spawns
+    // internally cannot inherit the per-command ambient env. Layer 2 handles its
+    // own env via `runShellCommand` (`envMode: 'replace'`) and is NOT wrapped.
+    const fingerprint = await withDeterministicEnv(() =>
+      createFingerprintAsync(resolvedProjectRoot, fingerprintOptions)
+    );
     layer1Hash = fingerprint.hash;
   } catch (err) {
     // @expo/fingerprint may not be installed, or the project may have no
@@ -189,6 +252,7 @@ export async function computeBaseFingerprint(
     resolvedProjectRoot,
     workflow,
     layer1Hash,
+    layer1EnvMode: LAYER1_ENV_MODE,
     lockfileHashes,
     autolinkedModules,
     finalHash,
@@ -217,6 +281,7 @@ function emitFingerprintDebug(fields: {
   resolvedProjectRoot: string;
   workflow: Workflow;
   layer1Hash: string;
+  layer1EnvMode: string;
   lockfileHashes: string[];
   autolinkedModules: string;
   finalHash: string;
@@ -241,7 +306,12 @@ function emitFingerprintDebug(fields: {
     )
   );
 
-  // Layer 1 - @expo/fingerprint hash.
+  // Layer 1 - @expo/fingerprint hash + the env mode its compute ran under.
+  // `layer1.envMode=sanitized` means the deterministic env-swap (SHERLO-1746)
+  // was in force around the library call, so its internal ExpoConfigLoader
+  // subprocess could not observe the per-command ambient env. Any other value
+  // here would name an env leak - a future regression is one grep away.
+  lines.push(tag(`layer1.envMode=${fields.layer1EnvMode}`));
   lines.push(tag(`layer1.hash=${fields.layer1Hash}`));
 
   // Layer 2 - augmented sources: each lockfile SHA + the sorted autolinked set.
@@ -448,25 +518,31 @@ async function hashLockfiles(projectRoot: string): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 /**
- * Determinism fix #2 (SHERLO-1744): the autolinking resolve subprocess must be
- * COMMAND-INDEPENDENT.
+ * Determinism: any subprocess that participates in the fingerprint must see a
+ * COMMAND-INDEPENDENT environment.
  *
- * `getAutolinkedModules` shells out (`npx react-native config` /
- * `npx expo-modules-autolinking resolve`). By default `executeCommand` spreads
- * the CLI's ENTIRE ambient `process.env` into the child. That ambient env is
- * NOT stable across commands: a package manager injects `NODE_ENV`,
- * `npm_lifecycle_event`, `npm_config_*`, `NODE_OPTIONS`, … that differ depending
- * on which yarn script (test:standard vs staged:check vs test:bundled) launched
- * the CLI. Those leak into the child and can change its resolution / output, so
- * the SAME tree hashes differently per command - the divergent layer that the
- * `SHERLO_FINGERPRINT_DEBUG` instrument names is `layer2.autolinked`.
+ * Ambient `process.env` is NOT stable across commands: a package manager injects
+ * `NODE_ENV`, `npm_lifecycle_event`, `npm_config_*`, `NODE_OPTIONS`, … that
+ * differ depending on which yarn script (test:standard vs staged:check vs
+ * test:bundled) launched the CLI. If any of those leak into a fingerprint-time
+ * subprocess and that subprocess branches on them, the SAME tree hashes
+ * differently per command and the staged gate lookup misses.
  *
- * We run the subprocess with `envMode: 'replace'` and a fixed allowlist of
- * resolution-stable variables, so the autolinked set is identical no matter how
- * the CLI was launched. `NODE_ENV` is pinned so tools that branch dev-vs-prod
- * resolve the same way every time.
+ * This env is the single deterministic environment used by BOTH layers:
+ *   - Layer 2 (SHERLO-1744): the autolinking resolve subprocess
+ *     (`npx react-native config` / `npx expo-modules-autolinking resolve`) runs
+ *     with `envMode: 'replace'` and exactly this env.
+ *   - Layer 1 (SHERLO-1746): `@expo/fingerprint` internally spawns its own
+ *     `ExpoConfigLoader.js` to evaluate the app config; that child inherits the
+ *     CLI's ambient env at spawn time. We swap `process.env` to this same env
+ *     around the `createFingerprintAsync` call (see {@link withDeterministicEnv})
+ *     so an app.config.js that reads env hashes identically per command.
+ *
+ * It is a fixed allowlist of resolution-stable variables plus a pinned
+ * `NODE_ENV='production'`, so tools that branch dev-vs-prod resolve the same way
+ * every time regardless of the launching script.
  */
-const AUTOLINK_ENV_ALLOWLIST = [
+const DETERMINISTIC_ENV_ALLOWLIST = [
   'PATH',
   'HOME',
   'USER',
@@ -487,9 +563,9 @@ const AUTOLINK_ENV_ALLOWLIST = [
   'ComSpec',
 ];
 
-function buildDeterministicAutolinkEnv(): NodeJS.ProcessEnv {
+function buildDeterministicEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
-  for (const key of AUTOLINK_ENV_ALLOWLIST) {
+  for (const key of DETERMINISTIC_ENV_ALLOWLIST) {
     const value = process.env[key];
     if (value !== undefined) env[key] = value;
   }
@@ -508,7 +584,7 @@ function buildDeterministicAutolinkEnv(): NodeJS.ProcessEnv {
  * neither command succeeds (best-effort).
  *
  * The subprocess runs with a deterministic, command-independent environment -
- * see {@link buildDeterministicAutolinkEnv}.
+ * see {@link buildDeterministicEnv}.
  */
 async function getAutolinkedModules(projectRoot: string, workflow: Workflow): Promise<string> {
   try {
@@ -526,7 +602,7 @@ async function getBareAutolinkedModules(projectRoot: string): Promise<string> {
     const output = await runShellCommand({
       command: 'npx react-native config',
       projectRoot,
-      env: buildDeterministicAutolinkEnv(),
+      env: buildDeterministicEnv(),
       envMode: 'replace',
     });
     const config = JSON.parse(output);
@@ -548,7 +624,7 @@ async function getManagedAutolinkedModules(projectRoot: string): Promise<string>
     const output = await runShellCommand({
       command: 'npx expo-modules-autolinking resolve --json',
       projectRoot,
-      env: buildDeterministicAutolinkEnv(),
+      env: buildDeterministicEnv(),
       envMode: 'replace',
     });
     const modules: { podName?: string; npmPackageName?: string; version?: string }[] =
@@ -569,7 +645,7 @@ async function getManagedAutolinkedModules(projectRoot: string): Promise<string>
       const output = await runShellCommand({
         command: 'npx expo config --json',
         projectRoot,
-        env: buildDeterministicAutolinkEnv(),
+        env: buildDeterministicEnv(),
         envMode: 'replace',
       });
       const config = JSON.parse(output);


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1746

## TL;DR

Instrument-proven on the first post-1744 run (sherlo-tester run 29146578009, fp-debug console verbatim): over the SAME resolved projectRoot with IDENTICAL layer2 (364dc4fb) and layer3 (managed), layer1 computes 274ae7b9 during test:standard (stable across two 00-setups 9 minutes apart) but c525808a during test:bundled (stable across all retries) -> final.wire 9a4264ce vs eddc181e -> gate lookup still misses. CLI version confirmed current (2.0.1-test.29145606706). Mechanism: SHERLO-1744's determinism fix sanitized the CLI's OWN layer-2 subprocesses, but layer1 = createFingerprintAsync, and @expo/fingerprint internally SPAWNS its ExpoConfigLoader.js to evaluate the app config IN the project - that child inherits the CLI's ambient process.env, which differs per launching yarn script, and an env-sensitive app-config evaluation (typical Expo pattern) then hashes differently per command. Fix: make the ENTIRE fingerprint computation ambient-env-independent - preferred shape: run computeBaseFingerprint's layer1 (or the whole compute) under the same deterministic env allowlist from 1744 (e.g. compute in a child process spawned with buildDeterministicAutolinkEnv(), or temporarily-swap process.env around createFingerprintAsync with restore in finally), so no library-internal subprocess can observe command-dependent env. Extend the cross-command determinism regression test to cover an env-sensitive app.config.js fixture (the case 1744's test missed - its fixture keyed autolinking, not config, on env).

## Acceptance Criteria

- Layer1's computation (createFingerprintAsync and every subprocess it spawns internally, incl. ExpoConfigLoader) observes a deterministic, command-independent environment - same allowlist+pinned NODE_ENV as SHERLO-1744's buildDeterministicAutolinkEnv; implementation may compute in a sanitized child process or env-swap-with-guaranteed-restore, chosen with evidence and documented (async-safety of the chosen approach explicitly addressed)
- crossCommandDeterminism.test.ts EXTENDED: a fixture whose app.config.js output depends on ambient env (e.g. embeds process.env.NODE_ENV / npm_lifecycle_event) computes IDENTICAL fingerprints via the registration path and the probe path under different ambient envs - the exact case run 29146578009 proved and 1744's fixture (autolinking-keyed) could not catch
- fp-debug output additionally prints the effective env mode (sanitized|ambient) for the layer1 compute so future leaks are one grep away
- Fail-soft preserved and asserted; envMode default stays merge for all non-fingerprint callers; all PR checks green incl. the packed-tarball gate
- After merge: republish @test and @dev, link runs (SHERLO-1725's suites re-validate on @test - the staged category completes on this; npm-latest remains the operator's bundled decision, now 1742+1744+this)

## Additional Context

## Instrument evidence (run 29146578009 console, verbatim values)

| compute | time | projectRoot.resolved | layer1 | layer2 | layer3 | final.wire |
| --- | --- | --- | --- | --- | --- | --- |
| test:standard (base-registry 00-setup) | 08:46:25 | .../staged-ready | 274ae7b9 | 364dc4fb | managed | 9a4264ce |
| test:standard (bundled 00-setup) | 08:55:44 | .../staged-ready | 274ae7b9 | 364dc4fb | managed | 9a4264ce |
| test:bundled probe x3 | 08:57:51+ | .../staged-ready | c525808a | 364dc4fb | managed | eddc181e |

Two stable layer1 values keyed by COMMAND over one directory: not drift, not tree mutation (layer2 lockfile hash identical; earlier rounds proved tree stability at every moment), not version skew (E2E-CLI-VERSION echoed 2.0.1-test.29145606706 at every invocation).

## Why 1744 missed it

1744's determinism fix applied envMode:'replace' to the three runShellCommand call sites the CLI owns (autolinking/config resolution in LAYER 2) - and its regression fixture keyed the AUTOLINKING output on env, which the fix cures. Layer 1 is @expo/fingerprint's own compute: it spawns ExpoConfigLoader.js internally (the same helper SHERLO-1742 made reachable), and that spawn inherits whatever process.env the CLI runs under. An app config whose evaluation reads env (API urls, feature flags, build profiles - the standard Expo pattern, present in the integrated-app-expo fixture) yields per-command config sources -> per-command layer1.

## Scope notes

- Same one-PR shape as 1744: fix + extended regression + observability line; no fingerprint algorithm redesign (SHERLO-1682-owned)
- If env-swap is chosen: it MUST be exception-safe (finally-restore) and concurrency-safe within the CLI process (document why safe or use the child-process shape instead)
- Consumer: SHERLO-1725 holds on the @test republish, same choreography as 1742/1744

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
