### PR TITLE
feat: [Bug] Global-level mocks do not activate in the release-lane…

### DIFF
--- a/packages/react-native-storybook/src/__tests__/mocking/storyMockActivation.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/storyMockActivation.test.ts
@@ -1,0 +1,160 @@
+vi.mock('../../SherloModule', () => ({
+  default: {
+    getMode: vi.fn().mockReturnValue('testing'),
+  },
+}));
+
+vi.mock('../../helpers/RunnerBridge', () => ({
+  default: { log: vi.fn(), send: vi.fn() },
+}));
+
+import createMockable from '../../mocking/createMockable';
+import { clearMocks, __resetShimmedKeysForTests } from '../../mocking/registry';
+import { activateMocksForStory } from '../../getStorybook/storyMockActivation';
+import type { StorybookView } from '../../types';
+
+// SHERLO-1749: global-level mocks (declared in .rnstorybook/preview.ts) live only in
+// view._preview.storyStoreValue.projectAnnotations, which Storybook composes
+// ASYNCHRONOUSLY during preview init. On a fresh boot (the single-story release capture,
+// or an interactive session that lands directly on a mocked story) the activation used
+// to read those params synchronously - before the preview was ready - so global mocks
+// resolved to {} while meta/story mocks (from the synchronously-loaded story exports)
+// worked. activateMocksForStory now applies meta/story mocks immediately and re-applies
+// once view._preview.ready() resolves, folding in global mocks before the story renders.
+
+// Builds a STORIES require.context with a single titled story plus a controllable
+// preview whose project (global) params only become readable once it is "ready" -
+// exactly Storybook's async preview-init timing.
+function setupView({
+  storyMocks,
+  globalMocks,
+  readyUpfront,
+}: {
+  storyMocks?: Record<string, unknown>;
+  globalMocks?: Record<string, unknown>;
+  readyUpfront?: boolean;
+}): { view: StorybookView; storyId: string; becomeReady: () => Promise<void> } {
+  const fileExports = {
+    default: { title: 'Mocking/Config' },
+    Default: storyMocks ? { parameters: { sherlo: { mocks: storyMocks } } } : {},
+  };
+  const req = Object.assign((_filename: string) => fileExports, {
+    keys: () => ['./Config.stories.tsx'],
+  });
+  (globalThis as any).STORIES = [{ directory: './src', req }];
+
+  // The composed project annotations Storybook makes available only once ready.
+  const projectAnnotations = {
+    parameters: globalMocks ? { sherlo: { mocks: globalMocks } } : {},
+  };
+
+  let resolveReady: () => void = () => {};
+  const readyPromise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+
+  const preview: {
+    storyStoreValue: unknown;
+    ready: () => Promise<void>;
+  } = {
+    // Populated once the preview is ready - undefined before then (fresh boot).
+    storyStoreValue: readyUpfront ? { projectAnnotations } : undefined,
+    ready: () => readyPromise,
+  };
+  if (readyUpfront) resolveReady();
+
+  const view = {
+    _storyIndex: { entries: {} },
+    _preview: preview,
+  } as unknown as StorybookView;
+
+  const becomeReady = async (): Promise<void> => {
+    preview.storyStoreValue = { projectAnnotations };
+    resolveReady();
+    await readyPromise; // flush the ready() .then re-apply before the test asserts
+  };
+
+  // toId('Mocking/Config', 'Default')
+  return { view, storyId: 'mocking-config--default', becomeReady };
+}
+
+afterEach(() => {
+  clearMocks();
+  __resetShimmedKeysForTests();
+  vi.clearAllMocks();
+  delete (globalThis as any).STORIES;
+});
+
+describe('activateMocksForStory - global mocks are robust to preview readiness (SHERLO-1749)', () => {
+  it('folds in a global-level mock once the preview becomes ready (release-capture regression)', async () => {
+    const mockable = createMockable('pkg/config', { flag: 'real' });
+    const { view, storyId, becomeReady } = setupView({
+      globalMocks: { 'pkg/config': { flag: 'global' } },
+    });
+
+    activateMocksForStory(view, storyId);
+
+    // Preview not ready yet: project params are unreadable, so the global mock has NOT
+    // applied - this is the exact state that used to leak into the story render (CP-01
+    // reading `real`).
+    expect(mockable.flag).toBe('real');
+
+    await becomeReady();
+
+    // Once the preview composes project annotations, the re-apply folds the global mock in.
+    expect(mockable.flag).toBe('global');
+  });
+
+  it('applies meta/story-level mocks synchronously, before the preview is ready', () => {
+    const mockable = createMockable('pkg/switch', { label: 'real' });
+    const { view, storyId } = setupView({
+      storyMocks: { 'pkg/switch': { label: 'story' } },
+      globalMocks: { 'pkg/other': {} },
+    });
+
+    activateMocksForStory(view, storyId);
+
+    // No await: story-level mocks come from the synchronously-loaded exports and must
+    // apply on the first pass, independent of preview readiness.
+    expect(mockable.label).toBe('story');
+  });
+
+  it('keeps story-level precedence over global-level for the same key after the re-apply', async () => {
+    const mockable = createMockable('pkg/switch', { label: 'real' });
+    const { view, storyId, becomeReady } = setupView({
+      storyMocks: { 'pkg/switch': { label: 'story' } },
+      globalMocks: { 'pkg/switch': { label: 'global' } },
+    });
+
+    activateMocksForStory(view, storyId);
+    expect(mockable.label).toBe('story');
+
+    await becomeReady();
+
+    // The ready re-apply must not let global clobber the story-level value: story > global.
+    expect(mockable.label).toBe('story');
+  });
+
+  it('applies global-level mocks on the first pass when the preview is already ready', () => {
+    // The interactive storyChanged case (and any post-ready activation): storyStoreValue
+    // already exists, so no wait is scheduled and the global mock applies immediately.
+    const mockable = createMockable('pkg/config', { flag: 'real' });
+    const { view, storyId } = setupView({
+      globalMocks: { 'pkg/config': { flag: 'global' } },
+      readyUpfront: true,
+    });
+
+    activateMocksForStory(view, storyId);
+
+    expect(mockable.flag).toBe('global');
+  });
+
+  it('is a no-op when storyId is undefined', () => {
+    const mockable = createMockable('pkg/config', { flag: 'real' });
+    const { view } = setupView({ globalMocks: { 'pkg/config': { flag: 'global' } } });
+
+    activateMocksForStory(view, undefined);
+
+    expect(mockable.flag).toBe('real');
+  });
+});

--- a/packages/react-native-storybook/src/getStorybook/components/TestingMode/TestingMode.tsx
+++ b/packages/react-native-storybook/src/getStorybook/components/TestingMode/TestingMode.tsx
@@ -8,8 +8,7 @@ import useTestAllStories from './useTestAllStories';
 import SherloModule from '../../../SherloModule';
 import deepmerge from 'deepmerge';
 import { MetadataProvider, MetadataProviderRef } from './MetadataProvider';
-import { enumerateStories } from '../../../storybook/adapter';
-import { activateStoryMocks } from '../../../mocking';
+import { activateMocksForStory } from '../../storyMockActivation';
 
 setupErrorSilencing();
 
@@ -31,11 +30,12 @@ function TestingMode({
   // render-body call, not an effect, so it runs before any child component's effects
   // (React flushes child effects before the parent's). Guarded to run once per boot;
   // each story capture is a fresh app boot, so there is at most one story to activate.
+  // activateMocksForStory applies meta/story mocks now and folds in global mocks once
+  // the preview is ready (see storyMockActivation).
   const mocksActivatedRef = useRef(false);
   if (!mocksActivatedRef.current && nextSnapshot) {
     mocksActivatedRef.current = true;
-    const storyMeta = enumerateStories(view).find((story) => story.id === nextSnapshot.storyId);
-    activateStoryMocks(storyMeta?.mocks ?? {});
+    activateMocksForStory(view, nextSnapshot.storyId);
   }
 
   useTestAllStories({

--- a/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
+++ b/packages/react-native-storybook/src/getStorybook/interactiveMockActivation.ts
@@ -25,13 +25,13 @@
  * (e.g. inspect.initialStoryId) would serve REAL values until the user navigated away
  * and back. We therefore activate the initial story's mocks IMMEDIATELY when tracking
  * starts, using the same activation path as the storyChanged handler so the two can
- * never diverge. Story- and meta-level mocks resolve synchronously here (they come from
- * the story exports, already loaded); global-level mocks depend on the preview being
- * ready and are handled elsewhere.
+ * never diverge. Story- and meta-level mocks resolve synchronously; global-level mocks
+ * fold in once the preview is ready - activateMocksForStory (the shared path used by
+ * the testing-capture entry point too) handles both.
  */
 import { StorybookView } from '../types';
-import { enumerateStories } from '../storybook/adapter';
-import { activateStoryMocks, clearMocks } from '../mocking';
+import { activateMocksForStory } from './storyMockActivation';
+import { clearMocks } from '../mocking';
 
 const STORY_CHANGED = 'storyChanged';
 
@@ -53,20 +53,9 @@ function extractStoryId(args: unknown[]): string | undefined {
   return undefined;
 }
 
-/**
- * Install the merged mock set for `storyId` (or clear it when the story has no mocks).
- * The single activation path shared by the initial-story activation and the
- * storyChanged handler, so the two can never resolve mocks differently.
- */
-function activateMocksForStory(storyId: string | undefined): void {
-  if (!storyId || !trackedView) return;
-
-  const storyMeta = enumerateStories(trackedView).find((story) => story.id === storyId);
-  activateStoryMocks(storyMeta?.mocks ?? {});
-}
-
 function handleStoryChanged(...args: unknown[]): void {
-  activateMocksForStory(extractStoryId(args));
+  if (!trackedView) return;
+  activateMocksForStory(trackedView, extractStoryId(args));
 }
 
 /**
@@ -85,7 +74,7 @@ export function startInteractiveMockActivation(
   trackedChannel = channel;
   trackedView = view;
   channel.on(STORY_CHANGED, handleStoryChanged as (...args: unknown[]) => void);
-  activateMocksForStory(initialStoryId);
+  activateMocksForStory(view, initialStoryId);
 }
 
 /** Call when Storybook is torn down / left: stop tracking and clear the active mock set. */

--- a/packages/react-native-storybook/src/getStorybook/storyMockActivation.ts
+++ b/packages/react-native-storybook/src/getStorybook/storyMockActivation.ts
@@ -1,0 +1,63 @@
+/**
+ * The single path for installing ONE story's merged mock set, shared by both
+ * activation entry points: the testing-capture path (TestingMode.tsx) and the
+ * interactive initial-story path (interactiveMockActivation.ts). Routing both
+ * through here means global-level mocks can never activate in one but not the other.
+ *
+ * WHY GLOBAL MOCKS NEED A SECOND PASS
+ * A story's mocks are merged from three levels (global > meta > story - see
+ * enumerateStories / mergeMockSet). Meta- and story-level mocks come from the story
+ * exports, which are loaded synchronously, so they apply on the first pass. Global-level
+ * mocks live ONLY in the app's `.rnstorybook/preview.ts`, which Storybook composes into
+ * view._preview.storyStoreValue.projectAnnotations ASYNCHRONOUSLY during preview init.
+ *
+ * On a fresh boot (the single-story release capture, or an interactive session that
+ * lands directly on a mocked story) the first pass runs BEFORE that composition, so
+ * enumerateStories reads empty project params and global mocks resolve to {}. We
+ * therefore re-apply once view._preview.ready() resolves - the exact point Storybook
+ * populates storyStoreValue.projectAnnotations - which lands before the story renders.
+ */
+import { StorybookView } from '../types';
+import { enumerateStories } from '../storybook/adapter';
+import { activateStoryMocks } from '../mocking';
+
+// The live preview fields we rely on. `ready()` resolves once the StoryStore -
+// and thus projectAnnotations (global params) - exists; `storyStoreValue` is
+// present iff that has already happened. Reached through a cast, like the other
+// internal preview access in adapter.ts / getStorybook.tsx.
+interface PreviewInternal {
+  ready?: () => Promise<unknown>;
+  storyStoreValue?: unknown;
+}
+
+function getPreview(view: StorybookView): PreviewInternal | undefined {
+  return (view as unknown as { _preview?: PreviewInternal })._preview;
+}
+
+function applyStoryMocks(view: StorybookView, storyId: string): void {
+  const storyMeta = enumerateStories(view).find((story) => story.id === storyId);
+  activateStoryMocks(storyMeta?.mocks ?? {});
+}
+
+/**
+ * Install `storyId`'s merged mock set. Meta/story mocks apply immediately; global
+ * mocks fold in once the preview is ready (see file header). Safe to call before the
+ * story renders - the ready() re-apply completes ahead of the render.
+ */
+export function activateMocksForStory(view: StorybookView, storyId: string | undefined): void {
+  if (!storyId) return;
+
+  applyStoryMocks(view, storyId);
+
+  // If the preview has not yet composed its project (global) params, the pass above
+  // saw none - re-apply once it has, so global-level mocks are included.
+  const preview = getPreview(view);
+  if (preview && !preview.storyStoreValue && typeof preview.ready === 'function') {
+    preview.ready().then(
+      () => applyStoryMocks(view, storyId),
+      () => {
+        // best effort - meta/story mocks are already active from the first pass
+      }
+    );
+  }
+}

--- a/packages/react-native-storybook/src/storybook/adapter.ts
+++ b/packages/react-native-storybook/src/storybook/adapter.ts
@@ -264,10 +264,15 @@ function readStoryEntries(): Array<{
 // Preview-level (global) parameters, sourced from Storybook's live preview object.
 //
 // On device the app's `.rnstorybook/preview.ts` annotations are composed into
-// view._preview.storyStoreValue.projectAnnotations once the preview is ready
-// (which it always is by the time enumerateStories runs - during testing capture
-// or interactive selection). This is the SAME merged project object that
-// getStorybook.tsx reads via view._preview, and it carries `parameters.sherlo.mocks`.
+// view._preview.storyStoreValue.projectAnnotations, the SAME merged project object
+// getStorybook.tsx reads via view._preview; it carries `parameters.sherlo.mocks`.
+//
+// TIMING: this composition is ASYNCHRONOUS - Storybook populates storyStoreValue
+// during preview init (view._preview.ready() resolves at that point). On a fresh boot,
+// enumerateStories can run BEFORE it, so this returns {} and global-level mocks are
+// absent. That is by design here: callers that must include global mocks (the mock
+// activation path) re-read once the preview is ready - see storyMockActivation. Do NOT
+// assume this is populated on the first call.
 //
 // The old source - require('@storybook/react-native/preview') - resolves to an
 // internal package stub that never carries the user's project annotations, so


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1749

## Summary

Global/project-level `parameters.sherlo.mocks` declared in an app's `.rnstorybook/preview.ts` did not activate in the release-lane (minified `assembleRelease`) per-story capture: CP-01 read the **real** value while meta- and story-level mocks in the same story worked. This fixes it so global mocks activate on device; meta/story precedence is unchanged and the public mocking DX is untouched.

## Root cause

Per-story capture activates a story's merged mock set **synchronously in the render body** of `TestingMode` (once per boot, before any child effect). That path called `enumerateStories(view)` -> `readGlobalParameters(view)`, which reads global params from `view._preview.storyStoreValue.projectAnnotations.parameters`.

But `projectAnnotations` is composed **asynchronously** by Storybook's preview init - the `getProjectAnnotations` override installed in `getStorybook.tsx` is an `async` function whose result the StoryStore resolves later (`view._preview.ready()` resolves at that point). On a fresh single-boot capture (the release lane, and an interactive session that lands directly on a mocked story), the synchronous first-render read wins the race against that async population and sees an empty preview, so global mocks resolve to `{}`. Meta/story mocks survive because they come from synchronously-loaded require.context exports. In the multi-story preview lane the timing differs (navigation-driven re-enumeration after the preview is ready), which is why the defect only reproduced in the single-boot release lane. The old adapter comment asserting the preview is "always ready by the time enumerateStories runs" was the false assumption.

## Fix

New shared path `getStorybook/storyMockActivation.ts#activateMocksForStory(view, storyId)`:
- applies meta/story mocks **immediately** (they are synchronously available), then
- if the preview has not yet composed its project params, **re-applies once `view._preview.ready()` resolves** - the exact point Storybook populates `storyStoreValue.projectAnnotations`, which lands before the story renders - folding in global mocks.

Both activation entry points now route through it, so they can never diverge:
- `TestingMode.tsx` (testing-capture)
- `interactiveMockActivation.ts` (interactive initial-story - this also covers the AC's noted interactive initial-story edge)

The misleading `readGlobalParameters` comment in `adapter.ts` is corrected to document the async timing.

## Test plan

- **Unit regression** (`__tests__/mocking/storyMockActivation.test.ts`, 5 tests): global mock reads `real` before `ready()` and `global` after (the exact CP-01 defect); meta/story mocks apply synchronously; story > global precedence preserved after the re-apply; preview-already-ready path applies global on the first pass; undefined storyId is a no-op. Full SDK suite green (346 passed).
- **Device (android emulator, minified release: `assembleRelease` + `expo export --minify`)**: `mocking-release.test.ts` 2/2 passed. Un-skipped `EB-02 (global precedence)` now PASSES - CP-01 `alpha.origin=global`, CP-04 untouched `=global` (both would be `real` pre-fix); CP-02/03/05/06 pass. Core-subset EB-02 still passes, no regression.

Fixes SHERLO-1749.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
