### PR TITLE
feat: [Phase 9] Release: apply copy and README, version bump, npm…

### DIFF
--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -67,6 +67,34 @@ import { Button } from 'react-native';
 
 ---
 
+## Mocking
+
+`@sherlo/react-native-storybook` can mock any module a story imports, scoped to that story. Declare mocks under `parameters.sherlo.mocks`; each key is a module specifier (an npm package, a scoped package, a subpath, or a project-root-relative app path), and each value is a factory that receives the real module and returns the exports to replace.
+
+```ts
+const meta = {
+  title: 'Mocking/Factories',
+  parameters: {
+    sherlo: {
+      mocks: {
+        './src/mocking/modules/factories/spread': (original) => ({
+          ...original,
+          color: 'mock-color',
+        }),
+      },
+    },
+  },
+};
+```
+
+Mocks can also be declared in a story's meta (applies to every story in the file) or globally in `.rnstorybook/preview.ts` (applies everywhere); the most specific level wins per module key. A mock only applies while its story is active in a Sherlo test run or interactive Storybook; every other screen gets the real module.
+
+A couple of things to know before you start: mocking `react`, `react-native`, `@storybook/*`, or `@sherlo/*` directly is not allowed (wrap them instead), and mocking a module for the first time needs a Metro restart before it takes effect.
+
+See the full [Module Mocking guide](https://sherlo.io/docs/stories/mocking) for factory patterns, precedence rules, module key edge cases, and known limitations.
+
+---
+
 ## Local Development
 
 The `testing/expo` and `testing/react-native` apps reference `@sherlo/react-native-storybook` via a **committed** pre-packed tarball at `./sherlo-lib/react-native-storybook.tgz`.

--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -342,12 +342,12 @@ function setupMocks(opts) {
   keyToSource.forEach(function (source, key) {
     if (isDeniedKey(key)) {
       throw new Error(
-        '[Sherlo] Cannot mock "' +
+        'Sherlo: "' +
           key +
-          '" (declared in ' +
-          source +
-          '): this module is on the mock deny list because mocking it would break ' +
-          "Storybook's own runtime. Mock a thin wrapper module you own that re-exports it instead."
+          '" cannot be mocked directly. react, react-native, @storybook/*, and @sherlo/* are off-limits. ' +
+          'Create a wrapper module in your own code that re-exports what you need from "' +
+          key +
+          '", then mock the wrapper\'s path instead.'
       );
     }
   });
@@ -368,11 +368,12 @@ function setupMocks(opts) {
       resolved = resolveMockKey(key, projectRoot);
     } catch (_) {
       throw new Error(
-        '[Sherlo] Cannot resolve mocked module "' +
+        'Sherlo: mock key "' +
           key +
-          '" declared in ' +
+          '" in ' +
           source +
-          '. Check the module specifier is spelled correctly and installed.'
+          ' did not resolve to a real module. Check for a typo, confirm the package is installed, ' +
+          'or write the path relative to the project root (with or without a leading "./").'
       );
     }
 

--- a/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
+++ b/packages/react-native-storybook/src/mocking/activateStoryMocks.ts
@@ -23,12 +23,13 @@ function warnUnshimmedKeys(mocks: MockSet): void {
   const plural = unshimmedKeys.length > 1;
 
   const message =
-    `[Sherlo] Mock declared for ${
-      plural ? 'modules' : 'module'
-    } ${keyList} but no shim was generated - ` +
-    `${plural ? 'these mocks' : 'this mock'} will not apply. Fix by either: ` +
-    '(1) restarting Metro so the mock scan picks up the new key, or ' +
-    `(2) adding ${plural ? 'them' : 'it'} to the "mockModules" option in your Sherlo Metro config.`;
+    `Sherlo: mock declared but unshimmed for ${keyList}. ` +
+    `${
+      plural ? 'These mocks' : 'This mock'
+    } will not apply. Restart Metro so the build-time scan ` +
+    `can find ${plural ? 'newly added keys' : 'a newly added key'}, or, if ${
+      plural ? 'the keys are' : 'the key is'
+    } composed at runtime, list ${plural ? 'them' : 'it'} under mockModules in your Sherlo config.`;
 
   console.warn(message);
   RunnerBridge.log(UNSHIMMED_KEYS_LOG, { keys: unshimmedKeys });


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1741

## Phase 9 - Release: apply copy and README (SHERLO-1741)

Final phase of the Module Mocking epic (SHERLO-1732). This PR covers the **code-landing** AC only; the version bump, npm publish, and PR #84 close are operator-gated actions performed outside this PR (see below).

### What this PR does (AC1)
Applies the finalized, content-approved Phase 7 deliverables (merged in `sherlo-content` `deliverables/sherlo-1739/`) into the SDK, verbatim:

- **FG-01 / FG-02 / FG-03 guardrail copy** (`metro/mockShims.js`, `src/mocking/activateStoryMocks.ts`) - the finalized error/warning strings, prefix changed `[Sherlo]` -> `Sherlo:`. FG-03 preserves the existing single-warning / multi-key behaviour, the `UNSHIMMED_KEYS_LOG` constant, and the `RunnerBridge.log` channel.
- **README Mocking section** (`README.md`) - the finalized section, with the guide link pointing at the published docs page `https://sherlo.io/docs/stories/mocking` (shipped in Phase 8).

Unit + bundle lanes green (343 passed, 2 pre-existing skips, 0 failed); lint clean.

### Handled outside this PR (operator-gated)
- **AC2 + AC3 - version bump + npm publish**: the repo's release process is the `release-sherlo-packages.yml` `workflow_dispatch` (lerna fixed-mode bump -> commit to `main` -> `npm publish` -> tag -> GitHub release). The operator dispatches it after this PR merges; npm publish must not run autonomously.
- **AC4 - close PR #84**: closed with a superseded-by-this-epic comment, branch kept.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
