### PR TITLE
feat: CLI: staged:check stops fabricating source-derived gateMetad…

### DIFF
--- a/packages/cli/src/commands/stagedCheck/__tests__/stagedCheck.test.ts
+++ b/packages/cli/src/commands/stagedCheck/__tests__/stagedCheck.test.ts
@@ -1,16 +1,17 @@
 /**
- * Tests for the staged:check command (SHERLO-1692).
+ * Tests for the staged:check command (SHERLO-1692, SHERLO-1760).
  *
  * Covers the CI-routing exit-code contract (fast=0, full=1, not-stageable=2),
  * the --json payload shape, and that GITHUB_OUTPUT is always written regardless
  * of --json - the three output forms must never drift apart. The gate is queried
  * through sdkClient.checkStagedGate (SHERLO-1718).
  *
- * A drift-guard test (see "gate metadata is real, not empty") asserts that
- * staged:check constructs gate metadata via the SAME buildBundleForPlatform +
- * buildGateMetadata path test:bundled uses and sends that non-empty metadata to
- * the gate - so a future refactor can never silently reintroduce `{}`, which
- * would make the command answer `full` even on a perfect fingerprint match.
+ * staged:check is a TRUE no-build probe: it never runs a bundler and never opens
+ * a binary, so it must not fabricate any APK-derived identity dimension. The
+ * probe-payload guard below asserts the sent gate metadata carries ONLY the
+ * `derivedFrom: 'none'` marker and no bundleFormat / assetInventory /
+ * hasEmbeddedBundle / sdkProtocolVersion - the deployed gate then rests a `fast`
+ * decision on the fingerprint match alone (SHERLO-1761).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,14 +21,6 @@ const { mockCheckStagedGate } = vi.hoisted(() => ({
 
 vi.mock('@sherlo/sdk-client', () => ({
   default: vi.fn(() => ({ checkStagedGate: mockCheckStagedGate })),
-}));
-
-// staged:check builds a bundle and derives gate metadata through the exact same
-// module test:bundled imports. Mock that module so the unit test never shells out
-// to a real bundler, while still asserting the construction path is exercised.
-vi.mock('../../testBundled/buildBundle', () => ({
-  buildBundleForPlatform: vi.fn(),
-  buildGateMetadata: vi.fn(),
 }));
 
 // Keep the real gate-decision mappers (outcomeToMode / resolveOverallMode /
@@ -64,46 +57,19 @@ import {
   writeGithubOutput as _writeGithubOutput,
 } from '../../../helpers';
 import { computeBaseFingerprint as _computeBaseFingerprint } from '../../../helpers/fingerprint';
-import {
-  buildBundleForPlatform as _buildBundleForPlatform,
-  buildGateMetadata as _buildGateMetadata,
-} from '../../testBundled/buildBundle';
 
 const mockGetPlatformsToTest = vi.mocked(_getPlatformsToTest);
 const mockGetTokenParts = vi.mocked(_getTokenParts);
 const mockGetValidatedCommandParams = vi.mocked(_getValidatedCommandParams);
 const mockWriteGithubOutput = vi.mocked(_writeGithubOutput);
 const mockComputeBaseFingerprint = vi.mocked(_computeBaseFingerprint);
-const mockBuildBundleForPlatform = vi.mocked(_buildBundleForPlatform);
-const mockBuildGateMetadata = vi.mocked(_buildGateMetadata);
 
 let stagedCheck: (passedOptions: any) => Promise<void>;
 let exitSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
 
-/** A realistic non-empty bundle result (matches BundleResult shape). */
-function bundleResult(overrides: Record<string, unknown> = {}): any {
-  return {
-    bundlePath: '/proj/.sherlo/bundled/bundle.ios.js',
-    bundleFormat: 'plain-js',
-    bundleSizeMb: 1.5,
-    bundleHash: 'abc123',
-    assetsDest: undefined,
-    assetInventory: [],
-    bundler: 'expo',
-    ...overrides,
-  };
-}
-
-/** A realistic non-empty GateMetadataInput - what buildGateMetadata produces. */
-const GATE_METADATA = {
-  engineClass: 'hermes',
-  bundleFormat: 'plain-js',
-  hasEmbeddedBundle: true,
-  assetInventory: [],
-  expoUpdatesEnabled: false,
-  buildMetadata: { reactNativeVersion: '0.74.0', buildMode: 'release' },
-};
+/** The ONLY gate metadata a no-build probe may send: the `none` marker, nothing else. */
+const PROBE_METADATA = { derivedFrom: 'none' };
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -122,8 +88,6 @@ beforeEach(async () => {
   } as any);
   mockGetTokenParts.mockReturnValue({ apiToken: 'api', projectIndex: 3, teamId: 'team' });
   mockComputeBaseFingerprint.mockResolvedValue({ hash: 'FP1' } as any);
-  mockBuildBundleForPlatform.mockResolvedValue(bundleResult());
-  mockBuildGateMetadata.mockResolvedValue(GATE_METADATA as any);
 
   const mod = await import('../stagedCheck');
   stagedCheck = mod.default;
@@ -136,10 +100,10 @@ describe('staged:check exit-code contract', () => {
 
     await expect(stagedCheck({})).rejects.toThrow('process.exit(0)');
     expect(exitSpy).toHaveBeenCalledWith(0);
-    // Sends the REAL gate metadata built for this platform - never empty `{}`.
+    // Sends ONLY the `none` derivation marker - never a fabricated dimension.
     expect(mockCheckStagedGate).toHaveBeenCalledWith({
       baseFingerprint: 'FP1',
-      gateMetadata: GATE_METADATA,
+      gateMetadata: PROBE_METADATA,
       platform: 'ios',
       projectIndex: 3,
       teamId: 'team',
@@ -154,7 +118,7 @@ describe('staged:check exit-code contract', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('exits 2 for mode=not-stageable', async () => {
+  it('exits 2 for mode=not-stageable when no base is registered for the fingerprint', async () => {
     mockGetPlatformsToTest.mockReturnValue(['android'] as any);
     mockCheckStagedGate.mockResolvedValue({ outcome: 'not-stageable', diff: [] });
 
@@ -180,26 +144,6 @@ describe('staged:check exit-code contract', () => {
     await expect(stagedCheck({})).rejects.toThrow('process.exit(2)');
     expect(exitSpy).toHaveBeenCalledWith(2);
     expect(mockCheckStagedGate).not.toHaveBeenCalled();
-  });
-
-  it('exits 2 (not-stageable) and never crashes when bundling fails', async () => {
-    mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
-    // buildBundleForPlatform throws a user-facing, multi-line message for a
-    // non-stageable project (Hermes bytecode, version floor, ...).
-    mockBuildBundleForPlatform.mockRejectedValue(
-      new Error('Hermes bytecode (.hbc) bundle detected.\n\nStaged uploads require plain JS.')
-    );
-
-    await expect(stagedCheck({})).rejects.toThrow('process.exit(2)');
-    expect(exitSpy).toHaveBeenCalledWith(2);
-    // The gate is never queried when there is nothing stageable to describe.
-    expect(mockCheckStagedGate).not.toHaveBeenCalled();
-
-    // The reason is collapsed to a single, GITHUB_OUTPUT-safe line.
-    const written = mockWriteGithubOutput.mock.calls[0][0] as Record<string, string>;
-    expect(written.mode).toBe('not-stageable');
-    expect(written.reason).toContain('Hermes bytecode');
-    expect(written.reason).not.toContain('\n');
   });
 
   it('takes the worst outcome across platforms (one full + one fast -> full)', async () => {
@@ -254,47 +198,29 @@ describe('output forms stay in sync', () => {
   });
 });
 
-// Drift guard (Director review, PR #180): staged:check MUST construct real gate
-// metadata via the same code path test:bundled uses and send it to the gate. An
-// empty `{}` makes every field comparison a mismatch, so the command could never
-// answer `fast` against a genuinely registered base (violates AC1). A client-mock
-// alone cannot catch that regression - these assertions verify the
-// metadata-CONSTRUCTION path, not just the gate's return handling.
-describe('gate metadata is real, not empty (drift guard)', () => {
-  it('builds a bundle and derives metadata per platform via the test:bundled path', async () => {
+// Probe-payload guard (SHERLO-1760): staged:check is a NO-BUILD probe. It must
+// never bundle and never fabricate a binary-identity dimension it cannot know
+// without opening an APK. The gate excludes none-marked dims from the identity
+// diff, so any fabricated dimension here would be dead weight at best and, before
+// SHERLO-1761, forced a false `full` on a byte-identical workspace. These
+// assertions pin the honest, marker-only payload so a refactor cannot silently
+// reintroduce a source-derived estimate.
+describe('probe payload is marker-only (no fabricated identity dimensions)', () => {
+  it('sends derivedFrom: none and NOTHING else per platform', async () => {
     mockGetPlatformsToTest.mockReturnValue(['android', 'ios'] as any);
     mockCheckStagedGate.mockResolvedValue({ outcome: 'fast', diff: [] });
 
     await expect(stagedCheck({})).rejects.toThrow('process.exit(0)');
 
-    // The SAME construction functions test:bundled imports are exercised, once
-    // per platform - not re-implemented locally.
-    expect(mockBuildBundleForPlatform).toHaveBeenCalledWith({
-      projectRoot: '/proj',
-      platform: 'android',
-    });
-    expect(mockBuildBundleForPlatform).toHaveBeenCalledWith({
-      projectRoot: '/proj',
-      platform: 'ios',
-    });
-    expect(mockBuildGateMetadata).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectRoot: '/proj',
-        platform: 'android',
-        bundleResult: expect.any(Object),
-      })
-    );
-  });
-
-  it('forwards the constructed metadata to the gate (never an empty object)', async () => {
-    mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
-    mockCheckStagedGate.mockResolvedValue({ outcome: 'fast', diff: [] });
-
-    await expect(stagedCheck({})).rejects.toThrow('process.exit(0)');
-
-    const sent = mockCheckStagedGate.mock.calls[0][0].gateMetadata;
-    // Exactly the object buildGateMetadata returned - and it is non-empty.
-    expect(sent).toBe(GATE_METADATA);
-    expect(Object.keys(sent).length).toBeGreaterThan(0);
+    for (const call of mockCheckStagedGate.mock.calls) {
+      const sent = call[0].gateMetadata;
+      expect(sent).toEqual({ derivedFrom: 'none' });
+      // No binary-identity / bundle-derived facts a no-build probe cannot know.
+      expect(sent).not.toHaveProperty('bundleFormat');
+      expect(sent).not.toHaveProperty('assetInventory');
+      expect(sent).not.toHaveProperty('hasEmbeddedBundle');
+      expect(sent).not.toHaveProperty('sdkProtocolVersion');
+      expect(sent).not.toHaveProperty('engineClass');
+    }
   });
 });

--- a/packages/cli/src/commands/stagedCheck/stagedCheck.ts
+++ b/packages/cli/src/commands/stagedCheck/stagedCheck.ts
@@ -1,8 +1,8 @@
 /**
  * staged:check command (SHERLO-1692) - a CI routing probe for the staged fast
  * path. Answers mode=fast|full|not-stageable (+ a human reason) WITHOUT
- * uploading or opening a build, so it can run right after dependency install
- * with no build artifacts on hand.
+ * building anything, so it can run right after dependency install with no build
+ * artifacts - and no bundler run - on hand.
  *
  * The outcome is a ROUTING decision, not a pass/fail result: every mode below
  * exits cleanly via reportAndExit's contractual code (see ./constants) rather
@@ -12,19 +12,20 @@
  *
  * The gate check goes through `sdkClient.checkStagedGate` (SHERLO-1718), called
  * once per configured platform. It sends the source-computed base fingerprint
- * AND real per-platform gate metadata: staged:check builds a production plain-JS
- * bundle and derives gate metadata via the SAME `buildBundleForPlatform` +
- * `buildGateMetadata` path test:bundled uses, so the two commands construct
- * identical metadata and cannot drift. The gate's comparators treat a
- * one-side-undefined field as a mismatch, so sending empty metadata would force
- * `full` even on a perfect fingerprint match - real metadata is what lets a
- * genuinely matching base answer `fast`.
+ * and gate metadata marked `derivedFrom: 'none'` carrying NO binary-identity
+ * dimensions. A no-build probe cannot open an APK, so it must not fabricate
+ * APK-derived facts; SHERLO-1761 excludes none/source-marked dimensions from the
+ * identity diff and rests the decision on the fingerprint match alone. On a
+ * match the deployed gate returns `fast` from the fingerprint; otherwise it
+ * returns `full-build-needed` (a real native change) or `not-stageable` (no base
+ * registered for this fingerprint yet).
  *
- * Building a plain-JS bundle is NOT a native build artifact - it is exactly what
- * test:bundled already does post-install, so the "runnable without build
- * artifacts" property is preserved; only a NATIVE binary is disallowed. If
- * bundling fails (e.g. not a stageable project), the command still exits cleanly
- * as not-stageable rather than throwing into the CLI error path.
+ * staged:check does NOT bundle: real bundling (and the Hermes/RAM/version-floor
+ * stageability checks that come with it) is deferred to `test:bundled`, which
+ * re-validates by actually building and falls back to `test:standard` if the
+ * project turns out not to be bundle-stageable. A probe that optimistically
+ * routes `fast` therefore never leaks a broken run - test:bundled is the gate
+ * that catches it.
  */
 import sdkClient from '@sherlo/sdk-client';
 import { GateMetadata, Platform } from '@sherlo/api-types';
@@ -38,10 +39,9 @@ import {
   resolveOverallMode,
   type StagedMode,
 } from '../../helpers';
-import { computeBaseFingerprint } from '../../helpers/fingerprint';
+import { computeBaseFingerprint, type GateMetadataInput } from '../../helpers/fingerprint';
 import { Options } from '../../types';
 import { JSON_OPTION } from '../../constants';
-import { buildBundleForPlatform, buildGateMetadata } from '../testBundled/buildBundle';
 import reportAndExit, { type PlatformDecision } from './output';
 import { THIS_COMMAND } from './constants';
 
@@ -93,40 +93,17 @@ async function stagedCheck(passedOptions: Options<THIS_COMMAND>): Promise<void> 
     level: 'info',
   });
 
-  // Ask the gate per platform. checkStagedGate is per-platform. staged:check
-  // builds a plain-JS bundle and derives REAL gate metadata via the same path
-  // test:bundled uses, then sends it so a genuinely matching base can answer
-  // `fast` (empty metadata would force `full` on every field comparison).
+  // A no-build probe carries NO binary-identity dimensions - only the `none`
+  // derivation marker. The deployed gate excludes none-marked dimensions from
+  // the identity diff and answers `fast` on a fingerprint match alone.
+  const gateMetadata: GateMetadataInput = { derivedFrom: 'none' };
+
+  // Ask the gate per platform. checkStagedGate is per-platform.
   const decisions: PlatformDecision[] = [];
   for (const platform of platforms) {
-    let gateMetadata: GateMetadata;
-    try {
-      const bundleResult = await buildBundleForPlatform({
-        projectRoot: commandParams.projectRoot,
-        platform,
-      });
-      gateMetadata = (await buildGateMetadata({
-        projectRoot: commandParams.projectRoot,
-        platform,
-        bundleResult,
-      })) as GateMetadata;
-    } catch (err) {
-      // Bundling failed (not a stageable project, Hermes bytecode, version floor,
-      // ...). Preserve the no-crash contract: exit cleanly as not-stageable rather
-      // than throwing into the CLI error path.
-      const message = err instanceof Error ? err.message : String(err);
-      return reportAndExit({
-        jsonOutput,
-        mode: 'not-stageable',
-        reason: `${platform}: cannot build a stageable bundle - ${firstLine(message)}`,
-        baseFingerprint,
-        platforms: [],
-      });
-    }
-
     const { outcome, diff } = await client.checkStagedGate({
       baseFingerprint,
-      gateMetadata,
+      gateMetadata: gateMetadata as GateMetadata,
       platform,
       projectIndex,
       teamId,
@@ -169,16 +146,4 @@ function platformReason(
   }
 
   return `${platform}: this project can't use the staged fast path`;
-}
-
-/**
- * Collapse a multi-line, user-facing bundler error down to its first non-empty
- * line so the routing `reason` stays single-line for GITHUB_OUTPUT / --json.
- */
-function firstLine(message: string): string {
-  const line = message
-    .split('\n')
-    .map((l) => l.trim())
-    .find((l) => l.length > 0);
-  return line ?? message.trim();
 }

--- a/packages/cli/src/commands/testBundled/__tests__/buildBundle.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/buildBundle.test.ts
@@ -17,7 +17,8 @@ import {
   computeBaseFingerprint,
   stripVersionLines,
 } from '../../../helpers/fingerprint/baseFingerprint';
-import { buildBundleForPlatform } from '../buildBundle';
+import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from '../buildBundle';
+import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../../constants';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -608,6 +609,85 @@ describe('baseFingerprint version suppression (SHERLO-1690 AC)', () => {
 // ---------------------------------------------------------------------------
 // No __DEV__ check (design §5 - removed because unreliable)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// buildGateMetadata - honest, source-marked, bundle-comparable dimensions
+// ---------------------------------------------------------------------------
+
+describe('buildGateMetadata (test:bundled = source)', () => {
+  /** A minimal BundleResult standing in for a freshly built plain-JS bundle. */
+  function bundleResult(overrides: Partial<BundleResult> = {}): BundleResult {
+    return {
+      bundlePath: '/tmp/bundle.android.js',
+      bundleFormat: 'plain-js',
+      bundleSizeMb: 1.2,
+      bundleHash: 'deadbeef',
+      assetsDest: '/tmp/assets.android',
+      assetInventory: ['drawable/icon.png', 'raw/data.json'],
+      bundler: 'rn',
+      ...overrides,
+    };
+  }
+
+  /** Resolve package versions by name so the two getPackageVersion reads differ. */
+  function mockVersions(versions: Record<string, string | null>) {
+    mockGetPackageVersion.mockImplementation((name: string) =>
+      name in versions ? versions[name] : null
+    );
+  }
+
+  it('marks source, sends bundle-derivable dims + the SDK-protocol compat input', async () => {
+    mockVersions({
+      'react-native': '0.76.0',
+      [SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME]: '2.0.1',
+    });
+
+    const result = bundleResult();
+    const metadata = await buildGateMetadata({
+      projectRoot: tempDir,
+      platform: 'android' as Platform,
+      bundleResult: result,
+    });
+
+    // Honest derivation marker - the gate excludes source-marked dims from the
+    // binary-identity diff.
+    expect(metadata.derivedFrom).toBe('source');
+    // Bundle-derivable identity dims.
+    expect(metadata.bundleFormat).toBe('plain-js');
+    expect(metadata.assetInventory).toEqual(result.assetInventory);
+    // Source/config signals.
+    expect(metadata.engineClass).toBe('hermes'); // RN >= 0.70 default, no jsc config
+    expect(metadata.expoUpdatesEnabled).toBe(false);
+    expect(metadata.buildMetadata).toEqual({
+      reactNativeVersion: '0.76.0',
+      buildMode: 'release',
+    });
+    // The SDK-protocol version is the bundle REQUIREMENT (compat input), read
+    // from the installed @sherlo/react-native-storybook package version.
+    expect(metadata.requiredSdkProtocolVersion).toBe('2.0.1');
+
+    // Binary-only facts a bundle cannot know are DROPPED, not fabricated.
+    expect(metadata).not.toHaveProperty('hasEmbeddedBundle');
+    // The baked binary-identity sdkProtocolVersion is never sent from a bundle.
+    expect(metadata).not.toHaveProperty('sdkProtocolVersion');
+  });
+
+  it('omits the SDK-protocol compat input when the package is not installed (absent, not fabricated)', async () => {
+    mockVersions({
+      'react-native': '0.76.0',
+      [SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME]: null, // getPackageVersion -> null
+    });
+
+    const metadata = await buildGateMetadata({
+      projectRoot: tempDir,
+      platform: 'android' as Platform,
+      bundleResult: bundleResult(),
+    });
+
+    expect(metadata.derivedFrom).toBe('source');
+    expect(metadata).not.toHaveProperty('requiredSdkProtocolVersion');
+  });
+});
 
 describe('no __DEV__ check', () => {
   it('does NOT refuse a bundle containing __DEV__ = true string', async () => {

--- a/packages/cli/src/commands/testBundled/buildBundle.ts
+++ b/packages/cli/src/commands/testBundled/buildBundle.ts
@@ -23,6 +23,7 @@ import {
 import detectBundler from '../../commands/showError/detectBundler';
 import { detectEntryFile } from '../../commands/showError/detectBundler';
 import getPackageVersion from '../../commands/init/requirements/getPackageVersion';
+import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../constants';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -247,10 +248,23 @@ export async function buildBundleForPlatform({
 /**
  * Construct the per-platform {@link GateMetadataInput} for a bundled run.
  *
- * Unlike test:standard which extracts gate metadata from a built binary via
- * {@link extractGateMetadata}, the bundled flow constructs it from project
- * config + the bundle we just built.  The shape is identical so the API
- * resolver compares fields field-for-field.
+ * test:standard extracts BINARY-derived gate metadata from a built APK/IPA via
+ * {@link extractGateMetadata}. The bundled flow has no binary, so it marks its
+ * metadata `derivedFrom: 'source'` and sends ONLY what the JS bundle + project
+ * config honestly know:
+ *   - `bundleFormat` sniffed from the bundle we just built,
+ *   - `assetInventory` from Metro's `--assets-dest` output,
+ *   - `engineClass` / `expoUpdatesEnabled` / `buildMetadata.*` read from project
+ *     config (source signals; the gate excludes source-marked dims from the
+ *     identity diff, so they are honest observability, never a fabricated match).
+ *
+ * It deliberately does NOT send the binary-only identity facts a bundle can only
+ * guess: no `hasEmbeddedBundle` (always-true fabrication) and no baked
+ * `sdkProtocolVersion`. Instead it sends the bundle-REQUIRED SDK protocol
+ * version as the explicit `requiredSdkProtocolVersion` compat input, resolved
+ * from the installed @sherlo/react-native-storybook package (whose version IS
+ * the protocol version). If the package is not installed it is sent ABSENT -
+ * never fabricated.
  */
 export async function buildGateMetadata({
   projectRoot,
@@ -268,19 +282,19 @@ export async function buildGateMetadata({
     platform,
   });
 
-  const sdkProtocolVersion = readSdkProtocolVersion(projectRoot);
+  const requiredSdkProtocolVersion =
+    getPackageVersion(SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME) ?? undefined;
 
   const rnVersion = getPackageVersion('react-native');
   const expoSdkVer = getExpoSdkVersion(projectRoot);
 
   return {
+    derivedFrom: 'source',
     engineClass,
     bundleFormat: bundleResult.bundleFormat,
-    // A bundled run always has a bundle (we just built it).
-    hasEmbeddedBundle: true,
     assetInventory: bundleResult.assetInventory,
     expoUpdatesEnabled,
-    ...(sdkProtocolVersion ? { sdkProtocolVersion } : {}),
+    ...(requiredSdkProtocolVersion ? { requiredSdkProtocolVersion } : {}),
     buildMetadata: {
       ...(rnVersion ? { reactNativeVersion: rnVersion } : {}),
       ...(expoSdkVer !== null ? { expoSdkVersion: String(expoSdkVer) } : {}),
@@ -522,19 +536,4 @@ async function detectExpoUpdatesEnabled({
   }
 
   return false;
-}
-
-// ---------------------------------------------------------------------------
-// SDK protocol version
-// ---------------------------------------------------------------------------
-
-function readSdkProtocolVersion(projectRoot: string): string | undefined {
-  const sherloJsonPath = path.join(projectRoot, 'assets', 'sherlo.json');
-  try {
-    const raw = fs.readFileSync(sherloJsonPath, 'utf8');
-    const parsed = JSON.parse(raw);
-    return parsed.version;
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/cli/src/helpers/fingerprint/__tests__/extractGateMetadata.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/extractGateMetadata.test.ts
@@ -1,0 +1,60 @@
+/**
+ * test:standard binary-derivation regression (SHERLO-1760).
+ *
+ * extractGateMetadata is the ONLY gate-metadata constructor for the test:standard
+ * registration path, and its metadata IS genuinely read out of the compiled
+ * APK/IPA. This test pins that it marks the metadata `derivedFrom: 'binary'`.
+ *
+ * SHERLO-1761 diffs binary-marked and legacy-unmarked metadata IDENTICALLY, so
+ * the explicit marker is behavior-preserving - it only makes the derivation
+ * honest at the type level; the gate outcome is unchanged.
+ *
+ * All binary IO is mocked to fail soft, so the extractor takes its default
+ * branches instantly (no real unzip / tar / aapt subprocesses) and the test is
+ * about the MARKER, not what any field could read from a real binary.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  '../getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInArchive',
+  () => ({
+    default: vi.fn().mockRejectedValue(new Error('no archive in test')),
+    detectTarVersion: vi.fn().mockResolvedValue('BSD'),
+  })
+);
+
+vi.mock(
+  '../getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInDirectory',
+  () => ({
+    default: vi.fn().mockRejectedValue(new Error('no directory in test')),
+  })
+);
+
+vi.mock('../runShellCommand', () => ({
+  default: vi.fn().mockRejectedValue(new Error('no shell in test')),
+}));
+
+vi.mock('../../commands/init/requirements/getPackageVersion', () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+import { extractGateMetadata } from '../gateMetadata';
+
+describe('extractGateMetadata (test:standard = binary)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks metadata derivedFrom: binary', async () => {
+    const metadata = await extractGateMetadata({
+      binaryPath: '/tmp/whatever.apk',
+      platform: 'android',
+      projectRoot: '/tmp',
+      bundlePath: 'assets/index.android.bundle',
+    });
+
+    expect(metadata.derivedFrom).toBe('binary');
+    // Fail-soft defaults - the point is the marker, not these values.
+    expect(metadata.buildMetadata?.buildMode).toBe('release');
+  }, 30_000);
+});

--- a/packages/cli/src/helpers/fingerprint/__tests__/notStageable.test.ts
+++ b/packages/cli/src/helpers/fingerprint/__tests__/notStageable.test.ts
@@ -18,6 +18,7 @@ import type { GateMetadataInput } from '../gateMetadata';
 // ---------------------------------------------------------------------------
 
 const PASSING_METADATA: GateMetadataInput = {
+  derivedFrom: 'binary',
   engineClass: 'hermes',
   bundleFormat: 'hbc',
   hasEmbeddedBundle: true,

--- a/packages/cli/src/helpers/fingerprint/gateMetadata.ts
+++ b/packages/cli/src/helpers/fingerprint/gateMetadata.ts
@@ -9,7 +9,7 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { Platform } from '@sherlo/api-types';
+import { GateDerivation, Platform } from '@sherlo/api-types';
 import accessFileInArchive, {
   detectTarVersion,
 } from '../getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInArchive';
@@ -27,21 +27,45 @@ export type EngineClass = 'hermes' | 'jsc';
 /** Bundle format detected from the embedded bundle bytes. */
 export type BundleFormat = 'hbc' | 'plain-js' | 'ram';
 
+/**
+ * How a probe's gate metadata was derived (SHERLO-1761). Re-exported from the
+ * wire contract so the CLI and the gate name the derivations identically:
+ *   - 'binary' - read out of a compiled APK/IPA (test:standard registration).
+ *   - 'source' - estimated from the source tree + JS bundle (test:bundled).
+ *   - 'none'   - a no-build probe carrying no identity metadata (staged:check).
+ */
+export type { GateDerivation };
+
 export type GateMetadataInput = {
+  /**
+   * How this metadata was derived. REQUIRED so every construction site must
+   * state its provenance - the compiler then guarantees no path silently omits
+   * or fabricates. The gate excludes source/none-marked dimensions from the
+   * binary-identity diff, so only 'binary' metadata is compared field-for-field
+   * against the stored (always binary-derived) base.
+   */
+  derivedFrom: GateDerivation;
   /** Runtime engine of the shell - derived from project config, NOT bundle sniff. */
-  engineClass: EngineClass;
+  engineClass?: EngineClass;
   /** Bundle format sniffed from the embedded bundle header. */
-  bundleFormat: BundleFormat;
-  /** Whether an embedded JS bundle exists at the platform-default path. */
-  hasEmbeddedBundle: boolean;
-  /** Sorted list of asset paths/names recorded in the binary. */
-  assetInventory: string[];
+  bundleFormat?: BundleFormat;
+  /** Whether an embedded JS bundle exists at the platform-default path (binary-only fact). */
+  hasEmbeddedBundle?: boolean;
+  /** Sorted list of asset paths/names recorded in the binary or produced by Metro. */
+  assetInventory?: string[];
   /** Whether expo-updates is detected as enabled on this platform. */
-  expoUpdatesEnabled: boolean;
-  /** Sherlo SDK protocol version read from assets/sherlo.json. */
+  expoUpdatesEnabled?: boolean;
+  /** Sherlo SDK protocol version BAKED into the binary - a binary-identity dimension. */
   sdkProtocolVersion?: string;
+  /**
+   * SDK protocol version the JS bundle REQUIRES (SHERLO-1761 compat input, NOT
+   * an identity dimension). Source-derivable, checked by the gate's compat rule
+   * against the base APK's baked `sdkProtocolVersion`; never folded into the
+   * identity diff. Absent -> the compat rule does not apply.
+   */
+  requiredSdkProtocolVersion?: string;
   /** RN / Expo SDK versions, build mode - best-effort. */
-  buildMetadata: BuildMetadata;
+  buildMetadata?: BuildMetadata;
 };
 
 export type BuildMetadata = {
@@ -153,6 +177,10 @@ export async function extractGateMetadata({
   });
 
   return {
+    // Read out of a compiled APK/IPA - the genuine binary identity the stored
+    // base is compared against. Behavior-preserving vs. the legacy unmarked CLI:
+    // SHERLO-1761 diffs binary-marked and absent-marker metadata identically.
+    derivedFrom: 'binary',
     engineClass,
     bundleFormat,
     hasEmbeddedBundle,

--- a/packages/cli/src/helpers/fingerprint/index.ts
+++ b/packages/cli/src/helpers/fingerprint/index.ts
@@ -6,7 +6,13 @@ export {
   checkRamBundle,
   deriveEngineClass,
 } from './gateMetadata';
-export type { GateMetadataInput, EngineClass, BundleFormat, BuildMetadata } from './gateMetadata';
+export type {
+  GateMetadataInput,
+  GateDerivation,
+  EngineClass,
+  BundleFormat,
+  BuildMetadata,
+} from './gateMetadata';
 export { checkStageable } from './notStageable';
 export type { StageableCheck } from './notStageable';
 export { registerBase } from './registerBase';

--- a/packages/cli/src/helpers/fingerprint/registerBase.ts
+++ b/packages/cli/src/helpers/fingerprint/registerBase.ts
@@ -154,7 +154,7 @@ export async function registerBase(params: RegisterBaseParams): Promise<Register
       `  hasEmbeddedBundle: ${gateMetadata.hasEmbeddedBundle}\n` +
       `  expoUpdatesEnabled: ${gateMetadata.expoUpdatesEnabled}\n` +
       `  sdkProtocolVersion: ${gateMetadata.sdkProtocolVersion ?? 'unknown'}\n` +
-      `  assets: ${gateMetadata.assetInventory.length} items`
+      `  assets: ${gateMetadata.assetInventory?.length ?? 0} items`
   );
 
   return {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1760

## What changed and why

This is the CLI (probe-side) half of the layer-14 cross-derivation fix. The probe-kind-aware staged gate already ships on env test (the sherlo-api companion, SHERLO-1761): it understands a derivation marker and excludes source/none-marked dimensions from the binary-identity diff. Until now the CLI's no-build probes fabricated APK-native facts they cannot actually know (plain-js vs the base's hbc, 6 source-path assets vs 928 compiled res/ assets, an absent-vs-baked SDK protocol), and the gate faithfully diffed those derivation mismatches into a false `full` even on a byte-identical, fingerprint-matched workspace, making the fast path structurally unreachable. This PR stops the fabrication: each command now sends only what it honestly knows, marked with its derivation, so the live gate can answer `fast` on a genuine match.

## What each command now sends (the three derivations)

- **staged:check** -> `derivedFrom: 'none'` and NOTHING else. It is now a true no-build probe: it no longer runs a bundler at all, and rests the gate decision on the fingerprint match alone. Real bundling and the Hermes/RAM/version-floor stageability checks are deferred to test:bundled, which re-validates by actually building (so an optimistic `fast` never leaks a broken run).
- **test:bundled** -> `derivedFrom: 'source'`, sending only honestly bundle-derivable dimensions: `bundleFormat` sniffed from the bundle it just built and `assetInventory` from Metro's `--assets-dest`, plus source-config signals (engineClass, expoUpdatesEnabled, buildMetadata) that the gate excludes from the identity diff. It sends the bundle-required SDK protocol version as the explicit `requiredSdkProtocolVersion` compat input, resolved from the installed `@sherlo/react-native-storybook` package version (absent when the package is not installed, never guessed).
- **test:standard** -> unchanged binary derivation, now explicitly marked `derivedFrom: 'binary'`. Behavior-preserving: the gate diffs binary-marked and legacy-unmarked metadata identically, so the explicit marker only makes the provenance honest at the type level.

`derivedFrom` is a REQUIRED field on the CLI-side `GateMetadataInput`, so the compiler forces every construction site to declare its provenance; no path can silently omit or fabricate.

## Deleted fabrication paths

- staged:check's hidden plain-JS bundle build and its `buildGateMetadata` call, plus the now-dead `firstLine` bundler-error helper.
- test:bundled's always-true `hasEmbeddedBundle` fabrication and the baked `sdkProtocolVersion` source guess (`readSdkProtocolVersion`, deleted).

## Test evidence

- `tsc --noEmit` clean, `lint` 0 errors, full vitest suite green (verified in isolation; the only local full-run failures were import/hook timeouts under machine contention, not assertion failures).
- New/updated tests at every touchpoint: staged:check probe-payload guard (marker-only, no fabricated dims), test:bundled source-marked dims + compat-input-present and compat-input-absent cases, test:standard binary-marker regression, and the required-field fixture update.
- Green CI on head `40524137` across both affected workspaces, which proves the new api-types contract resolves end to end:
  - checks (cli): https://github.com/sherlo-io/sherlo/actions/runs/29190165456
  - checks (react-native-storybook): https://github.com/sherlo-io/sherlo/actions/runs/29190165456
  - lint: https://github.com/sherlo-io/sherlo/actions/runs/29190165477
  - Analyze (CodeQL, js-ts + ruby): https://github.com/sherlo-io/sherlo/actions/runs/29190163971

## Post-merge plan (joint acceptance)

1. Fire Release to Test and Release to Dev in this repo to republish the CLI (published version noted here after the run).
2. The SHERLO-1725 branch's E2E specs `cli/base-registry/01-staged-check` and `02-second-project` re-fire against the republished @test CLI; those going green is the joint acceptance evidence shared with the sherlo-api companion ticket.

Jira: https://sherlo-io.atlassian.net/browse/SHERLO-1760

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
