### PR TITLE
feat: SDK mocking must be opt-in and inert by default before 2.1.0 ships

### DIFF
--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -71,6 +71,13 @@ import { Button } from 'react-native';
 
 `@sherlo/react-native-storybook` can mock any module a story imports, scoped to that story. Declare mocks under `parameters.sherlo.mocks`; each key is a module specifier (an npm package, a scoped package, a subpath, or a project-root-relative app path), and each value is a factory that receives the real module and returns the exports to replace.
 
+> Mocking is experimental and **off** by default, so a normal App Store / Play Store build ships zero mocking code. Opt in per build profile by passing `experimentalMocks: true` to `withStorybook` in your Metro config. Leave it **off** (or unset) for your production build profile.
+
+```js
+// metro.config.js
+module.exports = withStorybook(config, { experimentalMocks: true });
+```
+
 ```ts
 const meta = {
   title: 'Mocking/Factories',

--- a/packages/react-native-storybook/metro/applySherloTransforms.js
+++ b/packages/react-native-storybook/metro/applySherloTransforms.js
@@ -199,9 +199,13 @@ function applySherloTransforms(result, opts) {
   var cacheDir = path.dirname(wrapperPath);
 
   // ---- Module Mocking (SHERLO-1734 Phase 2) ----
-  // Gated entirely behind enabled !== false (EB-01): when disabled we scan
-  // nothing, emit no shims, and install no resolver branch.
-  var mockingEnabled = !(opts && opts.enabled === false);
+  // Gated entirely behind the opt-in `experimentalMocks` flag (SHERLO-1764):
+  // default OFF, so a normal store release ships zero mocking artifacts. When the
+  // flag is absent or false we scan nothing, emit no shims, and install no
+  // resolver branch, and the `./mocking` runtime stays unreachable from the bundle.
+  // This is INDEPENDENT of `opts.enabled`, which gates the storybook-disabled
+  // polyfill path below and must not influence mocking either way.
+  var mockingEnabled = !!(opts && opts.experimentalMocks);
   var mocksDir = null;
   var mockedPathToShim = null;
   var mockedPathToKey = null;

--- a/packages/react-native-storybook/metro/mockShims.js
+++ b/packages/react-native-storybook/metro/mockShims.js
@@ -338,43 +338,52 @@ function setupMocks(opts) {
     }
   }
 
-  // 2. Enforce the deny list (FG-02).
-  keyToSource.forEach(function (source, key) {
-    if (isDeniedKey(key)) {
-      throw new Error(
-        'Sherlo: "' +
-          key +
-          '" cannot be mocked directly. react, react-native, @storybook/*, and @sherlo/* are off-limits. ' +
-          'Create a wrapper module in your own code that re-exports what you need from "' +
-          key +
-          '", then mock the wrapper\'s path instead.'
-      );
-    }
-  });
-
-  // 3. Rewrite the mocks directory from scratch so no stale shims survive.
+  // 2. Rewrite the mocks directory from scratch so no stale shims survive.
   var mocksDir = path.join(cacheDir, 'mocks');
   fs.rmSync(mocksDir, { recursive: true, force: true });
   fs.mkdirSync(mocksDir, { recursive: true });
 
-  // 4. Resolve each key (FG-01) and emit its shim.
+  // 3. Resolve each key and emit its shim.
+  //
+  // A bad key (deny-listed or unresolvable) must NEVER fail the build (SHERLO-1765 B4):
+  // metro config is evaluated in the client's production build pipeline, so a throw here
+  // would fail a store build on a typo in a Sherlo story fixture. Instead we warn-and-skip:
+  // emit a clear console.warn naming the key AND its source, skip that key (no shim, no map
+  // entry), and continue with the rest. A skipped key still surfaces at runtime via the FG-03
+  // unshimmed-key tripwire.
   var mockedPathToShim = new Map();
   var mockedPathToKey = new Map();
   var shimPaths = [];
 
   keyToSource.forEach(function (source, key) {
+    // Deny list (FG-02): react, react-native, @storybook/*, and @sherlo/* are off-limits.
+    if (isDeniedKey(key)) {
+      console.warn(
+        '[Sherlo] Skipping mock key "' +
+          key +
+          '" in ' +
+          source +
+          ': react, react-native, @storybook/*, and @sherlo/* cannot be mocked directly. ' +
+          'Create a wrapper module in your own code that re-exports what you need from "' +
+          key +
+          '", then mock the wrapper\'s path instead.'
+      );
+      return;
+    }
+
     var resolved;
     try {
       resolved = resolveMockKey(key, projectRoot);
     } catch (_) {
-      throw new Error(
-        'Sherlo: mock key "' +
+      console.warn(
+        '[Sherlo] Skipping mock key "' +
           key +
           '" in ' +
           source +
-          ' did not resolve to a real module. Check for a typo, confirm the package is installed, ' +
+          ': it did not resolve to a real module. Check for a typo, confirm the package is installed, ' +
           'or write the path relative to the project root (with or without a leading "./").'
       );
+      return;
     }
 
     var shimPath = path.join(mocksDir, shimFileName(key));

--- a/packages/react-native-storybook/metro/withStorybook.d.ts
+++ b/packages/react-native-storybook/metro/withStorybook.d.ts
@@ -1,3 +1,33 @@
-declare function withStorybook(config: any, options?: Record<string, unknown>): any;
+export interface WithStorybookOptions {
+  /**
+   * Whether Storybook is enabled for this build. When `false`, Sherlo installs the
+   * storybook-disabled polyfill instead of the full one. Unrelated to mocking.
+   */
+  enabled?: boolean;
+
+  /** Path to the Storybook config directory (e.g. `./.storybook`). */
+  configPath?: string;
+
+  /**
+   * Opt in to the experimental module-mocking pipeline (SHERLO-1764). Default `false`.
+   *
+   * When `false` (the default) no story mock scan runs, no shims are emitted, no
+   * resolver redirect is installed, and the `./mocking` runtime never reaches the
+   * bundle - so a normal App Store / Play Store release ships zero mocking artifacts.
+   * Set to `true` only in Storybook/testing build lanes where `parameters.sherlo.mocks`
+   * should take effect.
+   */
+  experimentalMocks?: boolean;
+
+  /**
+   * Extra mock keys the static story scan cannot see (keys composed at runtime).
+   * Only has an effect when `experimentalMocks` is `true`.
+   */
+  mockModules?: string[];
+
+  [key: string]: unknown;
+}
+
+declare function withStorybook(config: any, options?: WithStorybookOptions): any;
 export default withStorybook;
 export { withStorybook };

--- a/packages/react-native-storybook/src/__tests__/applySherloTransforms.test.ts
+++ b/packages/react-native-storybook/src/__tests__/applySherloTransforms.test.ts
@@ -247,7 +247,7 @@ describe('applySherloTransforms – emitDependencyGraphSidecar (via customSerial
     const fakeSerializer = () => 'BYTES';
     const result = applySherloTransforms(
       { projectRoot: tmpDir, resolver: {}, serializer: { customSerializer: fakeSerializer } },
-      { enabled: true }
+      { experimentalMocks: true }
     );
 
     // The mocked module is in the graph because its shim requires it; model that

--- a/packages/react-native-storybook/src/__tests__/bundle/mockBundle.test.ts
+++ b/packages/react-native-storybook/src/__tests__/bundle/mockBundle.test.ts
@@ -6,9 +6,9 @@
 //
 // JS-only lane (no device/emulator): it builds a tiny fixture app with REAL
 // Metro programmatically and asserts on the bundle output:
-//   - enabled: true  -> the mock shim is present (the mocked import was
-//                       redirected through createMockable).
-//   - enabled: false -> zero mocking artifacts (EB-01 at bundle level).
+//   - experimentalMocks: true  -> the mock shim is present (the mocked import was
+//                                 redirected through createMockable).
+//   - experimentalMocks: false -> zero mocking artifacts (opt-in gate off, SHERLO-1764).
 //
 // This runs under `yarn test` alongside the unit tests, so a red bundle lane
 // fails the PR.
@@ -87,7 +87,7 @@ function createFixture(): string {
   return root;
 }
 
-async function buildBundle(root: string, opts: { enabled: boolean }): Promise<string> {
+async function buildBundle(root: string, opts: { experimentalMocks: boolean }): Promise<string> {
   const baseConfig = await getDefaultConfig(root);
 
   // Metro's own runtime/polyfills and babel helpers live in the repo
@@ -95,7 +95,7 @@ async function buildBundle(root: string, opts: { enabled: boolean }): Promise<st
   // against both. Use the node crawler (watchman does not cover the OS temp dir)
   // and disable caches so each build is fresh.
   const repoNodeModules = path.dirname(path.dirname(require.resolve('metro-runtime/package.json')));
-  // The @sherlo package dir, so the sherlo polyfill.js (added for enabled:true)
+  // The @sherlo package dir, so the sherlo polyfill.js (added for the enabled path)
   // is crawlable.
   const packageRoot = path.resolve(__dirname, '../../..');
   baseConfig.watchFolders = [root, repoNodeModules, packageRoot];
@@ -121,11 +121,11 @@ describe('bundle lane - module mocking shims in real Metro output', () => {
   const TIMEOUT = 120_000;
 
   it(
-    'enabled: true -> the mocked import is redirected through a createMockable shim',
+    'experimentalMocks: true -> the mocked import is redirected through a createMockable shim',
     async () => {
       const root = createFixture();
       try {
-        const code = await buildBundle(root, { enabled: true });
+        const code = await buildBundle(root, { experimentalMocks: true });
 
         // The shim's body (a createMockable call for the mocked key) is bundled.
         expect(code).toContain('createMockable');
@@ -145,11 +145,11 @@ describe('bundle lane - module mocking shims in real Metro output', () => {
   );
 
   it(
-    'enabled: false -> the bundle contains zero mocking artifacts (EB-01)',
+    'experimentalMocks: false -> the bundle contains zero mocking artifacts (opt-in gate off)',
     async () => {
       const root = createFixture();
       try {
-        const code = await buildBundle(root, { enabled: false });
+        const code = await buildBundle(root, { experimentalMocks: false });
 
         // The real module is bundled directly, with no shim indirection.
         expect(code).toContain('MOCKED_LIB_REAL_MODULE');

--- a/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/activationLifecycle.test.ts
@@ -1,6 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets these mocks install
+// (the guard no-ops in 'default'; activation lifecycle is only exercised under test).
 vi.mock('../../SherloModule', () => ({
   default: {
-    getMode: vi.fn().mockReturnValue('default'),
+    getMode: vi.fn().mockReturnValue('testing'),
   },
 }));
 

--- a/packages/react-native-storybook/src/__tests__/mocking/callableExport.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/callableExport.test.ts
@@ -1,0 +1,87 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
+import createMockable from '../../mocking/createMockable';
+import { activateMocks, clearMocks } from '../../mocking/registry';
+
+afterEach(() => {
+  clearMocks();
+});
+
+// SHERLO-1765 B1: modules whose CJS export is itself a function (`module.exports = fn`,
+// axios-style) must stay callable AND constructable through the shim - both when a mock is
+// active and when mocks are dormant. Before the apply/construct traps existed, the Proxy over
+// a plain object was non-callable, so any such module shipped a latent TypeError into the
+// client's production bundle.
+describe('createMockable - callable-export modules (B1)', () => {
+  it('stays callable when mocks are dormant, falling through to the real function', () => {
+    // module.exports = function () { ... }
+    const realFn = Object.assign((a: number, b: number) => a + b, { flavor: 'real' });
+    const mockable = createMockable('pkg/callable-dormant', realFn as never) as typeof realFn;
+
+    // Callable with no active mock -> the real function runs.
+    expect(mockable(2, 3)).toBe(5);
+    // Own properties on the function still read through the get trap.
+    expect(mockable.flavor).toBe('real');
+  });
+
+  it('routes calls to the mock when the active mock resolves to a callable', () => {
+    const realFn = (a: number, b: number) => a + b;
+    const mockable = createMockable('pkg/callable-mocked', realFn as never) as typeof realFn;
+
+    // A top-level function mock is a FACTORY (resolveMockExports calls it with the real
+    // module), so a callable replacement is supplied as a factory that RETURNS the callable.
+    activateMocks({ 'pkg/callable-mocked': (() => (a: number, b: number) => a * b) as never });
+
+    // The mock function replaces the call.
+    expect(mockable(2, 3)).toBe(6);
+
+    clearMocks();
+    // Back to the real function once cleared.
+    expect(mockable(2, 3)).toBe(5);
+  });
+
+  it('falls through to the real function when the active mock is a non-callable object', () => {
+    const realFn = Object.assign((a: number, b: number) => a + b, { extra: () => 'real-extra' });
+    const mockable = createMockable('pkg/callable-objmock', realFn as never) as typeof realFn;
+
+    // Mock replaces one property but is not itself callable -> calls fall through to real,
+    // mirroring the per-property fall-through of the get/has traps.
+    activateMocks({ 'pkg/callable-objmock': { extra: () => 'mock-extra' } as never });
+
+    expect(mockable(4, 5)).toBe(9); // call falls through to the real function
+    expect((mockable as { extra: () => string }).extra()).toBe('mock-extra'); // property is mocked
+  });
+
+  it('stays constructable when dormant - `new shim()` builds a real instance', () => {
+    class Real {
+      tag = 'real';
+      constructor(public value: number) {}
+    }
+    const Mockable = createMockable('pkg/ctor-dormant', Real as never) as typeof Real;
+
+    const instance = new Mockable(7);
+    expect(instance.value).toBe(7);
+    expect(instance.tag).toBe('real');
+    expect(instance).toBeInstanceOf(Real);
+  });
+
+  it('routes construction to the mock when the active mock resolves to a constructor', () => {
+    class Real {
+      kind = 'real';
+    }
+    class Mock {
+      kind = 'mock';
+    }
+    const Mockable = createMockable('pkg/ctor-mocked', Real as never) as typeof Real;
+
+    // Factory returning the replacement constructor (a bare class would be read as a factory
+    // and invoked without `new`, throwing) - this is how a callable/class export is mocked.
+    activateMocks({ 'pkg/ctor-mocked': (() => Mock) as never });
+
+    const instance = new Mockable();
+    expect((instance as { kind: string }).kind).toBe('mock');
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/classes.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/classes.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import { activateMocks, clearMocks } from '../../mocking/registry';
 

--- a/packages/react-native-storybook/src/__tests__/mocking/closures.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/closures.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import { activateMocks, clearMocks } from '../../mocking/registry';
 import { IMPORTED_CONSTANT, ImportedHelper, otherModuleReal } from './fixtures';

--- a/packages/react-native-storybook/src/__tests__/mocking/createMockable.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/createMockable.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import {
   activateMocks,

--- a/packages/react-native-storybook/src/__tests__/mocking/factories.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/factories.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import { activateMocks, clearMocks } from '../../mocking/registry';
 

--- a/packages/react-native-storybook/src/__tests__/mocking/interop.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/interop.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import createMockable from '../../mocking/createMockable';
 import { activateMocks, clearMocks } from '../../mocking/registry';
 

--- a/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/metroMockLayer.test.ts
@@ -503,7 +503,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
     const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
       'expo-localization': realPath,
@@ -530,7 +533,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { '@scope/pkg': {}, 'libpkg/submodule': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const scopedReal = path.join(root, 'node_modules', '@scope', 'pkg', 'index.js');
     const subReal = path.join(root, 'node_modules', 'libpkg', 'submodule.js');
     const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
@@ -565,7 +571,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { '@react-native-async-storage/async-storage': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     // Metro resolves the import to the react-native entry, NOT the main entry.
     const metroEntry = path.join(
       root,
@@ -598,7 +607,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { './src/utils/localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const realPath = path.join(root, 'src', 'utils', 'localization.ts');
     // Importer uses a relative specifier that Metro resolves to the same file.
     const ctx = makeContext(path.join(root, 'src', 'screens', 'Home.tsx'), {
@@ -620,7 +632,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'src/utils/localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const realPath = path.join(root, 'src', 'utils', 'localization.ts');
     // Importer uses a relative specifier that Metro resolves to the same file.
     const ctx = makeContext(path.join(root, 'src', 'screens', 'Home.tsx'), {
@@ -654,7 +669,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { './src/Plat': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const iosCtx = makeContext(path.join(root, 'src', 'App.tsx'), {
       './Plat': path.join(root, 'src', 'Plat.ios.tsx'),
     });
@@ -679,7 +697,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
     // Origin is a file INSIDE node_modules (a transitive dependency).
     const ctx = makeContext(path.join(root, 'node_modules', 'some-lib', 'index.js'), {
@@ -701,7 +722,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
     const shimPath = path.join(
       root,
@@ -727,7 +751,7 @@ describe('applySherloTransforms resolver redirect', () => {
 
     const result = applySherloTransforms(
       { projectRoot: root, resolver: {} },
-      { enabled: true, mockModules: ['native-only-lib'] }
+      { experimentalMocks: true, mockModules: ['native-only-lib'] }
     );
     const realPath = path.join(root, 'node_modules', 'native-only-lib', 'index.js');
     const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { 'native-only-lib': realPath });
@@ -747,7 +771,10 @@ describe('applySherloTransforms resolver redirect', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
     const shimPath = path.join(
       root,
       'node_modules',
@@ -768,46 +795,78 @@ describe('applySherloTransforms resolver redirect', () => {
     expect(resolved.filePath).toBe(otherReal); // unrelated import untouched
   });
 
-  it('FG-01: an unresolvable mock key fails config naming the story file AND key', () => {
+  it('FG-01 (B4): an unresolvable mock key warns-and-skips (never throws), naming the story file AND key', () => {
     const root = mkProject('sherlo-fg01-');
+    writePackage(root, 'installed-lib', 'index.js', { 'index.js': 'module.exports = {};' });
     writeFile(
       root,
       'src/Broken.stories.tsx',
-      `export const S = { parameters: { sherlo: { mocks: { 'not-installed-pkg': {} } } } };`
+      `export const S = { parameters: { sherlo: { mocks: { 'not-installed-pkg': {}, 'installed-lib': {} } } } };`
     );
 
-    let error: Error | null = null;
-    try {
-      applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
-    } catch (e) {
-      error = e as Error;
-    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A bad key must never fail the build - this call must not throw.
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
+
+    const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+    const badWarning = warnings.find((m) => m.includes('not-installed-pkg'));
+
+    // The good key still resolved and redirects; the bad key was skipped (no shim).
+    const realPath = path.join(root, 'node_modules', 'installed-lib', 'index.js');
+    const badShim = path.join(
+      root,
+      'node_modules',
+      '.cache',
+      'sherlo',
+      'mocks',
+      mockShims.shimFileName('not-installed-pkg')
+    );
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { 'installed-lib': realPath });
+    const goodResolved = result.resolver.resolveRequest(ctx, 'installed-lib', 'ios');
+    const badShimExists = fs.existsSync(badShim);
+    warnSpy.mockRestore();
     cleanup(root);
 
-    expect(error).not.toBeNull();
-    expect(error!.message).toContain('not-installed-pkg');
-    expect(error!.message).toContain('Broken.stories.tsx');
+    expect(badWarning).toBeDefined();
+    expect(badWarning).toContain('not-installed-pkg');
+    expect(badWarning).toContain('Broken.stories.tsx');
+    expect(badWarning).toContain('[Sherlo]');
+    expect(badShimExists).toBe(false); // skipped: no shim emitted for the bad key
+    expect(goodResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks')); // others still resolve
   });
 
-  it('FG-02: a deny-listed key fails with guidance to mock a wrapper module', () => {
+  it('FG-02 (B4): a deny-listed key warns-and-skips (never throws) with wrapper-module guidance', () => {
     const root = mkProject('sherlo-fg02-');
+    writePackage(root, 'installed-lib', 'index.js', { 'index.js': 'module.exports = {};' });
     writeFile(
       root,
       'src/Bad.stories.tsx',
-      `export const S = { parameters: { sherlo: { mocks: { 'react-native': {} } } } };`
+      `export const S = { parameters: { sherlo: { mocks: { 'react-native': {}, 'installed-lib': {} } } } };`
     );
 
-    let error: Error | null = null;
-    try {
-      applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
-    } catch (e) {
-      error = e as Error;
-    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
+
+    const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+    const denyWarning = warnings.find((m) => m.includes('react-native'));
+
+    const realPath = path.join(root, 'node_modules', 'installed-lib', 'index.js');
+    const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), { 'installed-lib': realPath });
+    const goodResolved = result.resolver.resolveRequest(ctx, 'installed-lib', 'ios');
+    warnSpy.mockRestore();
     cleanup(root);
 
-    expect(error).not.toBeNull();
-    expect(error!.message).toContain('react-native');
-    expect(error!.message.toLowerCase()).toContain('wrapper');
+    expect(denyWarning).toBeDefined();
+    expect(denyWarning).toContain('react-native');
+    expect(denyWarning!.toLowerCase()).toContain('wrapper');
+    expect(denyWarning).toContain('[Sherlo]');
+    expect(goodResolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks')); // others still resolve
   });
 });
 
@@ -844,7 +903,10 @@ describe('mockShims - workspace package resolution (MK-05)', () => {
       `export const S = { parameters: { sherlo: { mocks: { '@myorg/ui': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: true });
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
 
     // Metro resolves the import through the symlinked node_modules path.
     const metroPath = path.join(root, 'node_modules', '@myorg', 'ui', 'index.js');
@@ -915,7 +977,7 @@ describe('applySherloTransforms - composes with a pre-existing resolveRequest wr
 
     const result = applySherloTransforms(
       { projectRoot: root, resolver: { resolveRequest: existingResolveRequest } },
-      { enabled: true }
+      { experimentalMocks: true }
     );
     return { root, result, svgComponentPath, routerVirtualPath };
   }
@@ -957,12 +1019,49 @@ describe('applySherloTransforms - composes with a pre-existing resolveRequest wr
 });
 
 // ---------------------------------------------------------------------------
-// EB-01 - enabled:false contributes nothing
+// SHERLO-1764 - experimentalMocks opt-in gate (default OFF)
 // ---------------------------------------------------------------------------
 
-describe('EB-01: enabled:false disables the mocking system entirely', () => {
-  it('emits no shims and installs no resolver redirect', () => {
-    const root = mkProject('sherlo-eb01-');
+describe('experimentalMocks opt-in gate (SHERLO-1764)', () => {
+  // Every off-case (flag absent, flag false, and the unrelated enabled:false) must
+  // emit no shims and install no resolver redirect - the whole mocking pipeline is
+  // dormant unless the caller explicitly opts in.
+  const OFF_CASES: Array<[string, Record<string, unknown>]> = [
+    ['flag absent (default)', {}],
+    ['experimentalMocks: false', { experimentalMocks: false }],
+    ['enabled: true but no experimentalMocks', { enabled: true }],
+    ['enabled: false', { enabled: false }],
+  ];
+
+  OFF_CASES.forEach(([label, opts]) => {
+    it(`${label}: no scan, no shims, no resolver redirect`, () => {
+      const root = mkProject('sherlo-gate-off-');
+      writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
+      writeFile(
+        root,
+        'src/Comp.stories.tsx',
+        `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
+      );
+
+      const result = applySherloTransforms({ projectRoot: root, resolver: {} }, opts);
+
+      const mocksDir = path.join(root, 'node_modules', '.cache', 'sherlo', 'mocks');
+      const mocksDirExists = fs.existsSync(mocksDir);
+
+      const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
+      const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
+        'expo-localization': realPath,
+      });
+      const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+      cleanup(root);
+
+      expect(mocksDirExists).toBe(false); // no shims emitted
+      expect(resolved.filePath).toBe(realPath); // no redirect - reaches the real module
+    });
+  });
+
+  it('experimentalMocks: true: scans, emits a shim, and redirects the mocked import', () => {
+    const root = mkProject('sherlo-gate-on-');
     writePackage(root, 'expo-localization', 'index.js', { 'index.js': 'module.exports = {};' });
     writeFile(
       root,
@@ -970,19 +1069,20 @@ describe('EB-01: enabled:false disables the mocking system entirely', () => {
       `export const S = { parameters: { sherlo: { mocks: { 'expo-localization': {} } } } };`
     );
 
-    const result = applySherloTransforms({ projectRoot: root, resolver: {} }, { enabled: false });
-
-    const mocksDir = path.join(root, 'node_modules', '.cache', 'sherlo', 'mocks');
-    const mocksDirExists = fs.existsSync(mocksDir);
+    const result = applySherloTransforms(
+      { projectRoot: root, resolver: {} },
+      { experimentalMocks: true }
+    );
 
     const realPath = path.join(root, 'node_modules', 'expo-localization', 'index.js');
     const ctx = makeContext(path.join(root, 'src', 'Screen.tsx'), {
       'expo-localization': realPath,
     });
     const resolved = result.resolver.resolveRequest(ctx, 'expo-localization', 'ios');
+    const shimExists = fs.existsSync(resolved.filePath);
     cleanup(root);
 
-    expect(mocksDirExists).toBe(false); // no shims emitted
-    expect(resolved.filePath).toBe(realPath); // no redirect - reaches the real module
+    expect(resolved.filePath).toContain(path.join('.cache', 'sherlo', 'mocks')); // redirected
+    expect(shimExists).toBe(true);
   });
 });

--- a/packages/react-native-storybook/src/__tests__/mocking/modeGuard.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/modeGuard.test.ts
@@ -1,0 +1,88 @@
+// SHERLO-1765 B2: activation must no-op outside 'testing' and 'storybook' modes. The guard
+// lives in registry.activateMocks (the single choke point); activateStoryMocks delegates to it,
+// so both public entry points are covered. This suite drives getMode across all three modes.
+const { mockGetMode } = vi.hoisted(() => ({ mockGetMode: vi.fn() }));
+
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: mockGetMode },
+}));
+
+// RunnerBridge is only reached by activateStoryMocks' unshimmed-key warning; stub it so the
+// guard tests don't depend on the native bridge.
+vi.mock('../../helpers/RunnerBridge', () => ({
+  default: { log: vi.fn(), send: vi.fn() },
+}));
+
+import createMockable from '../../mocking/createMockable';
+import { activateMocks, clearMocks } from '../../mocking/registry';
+import { activateStoryMocks } from '../../mocking/activateStoryMocks';
+
+afterEach(() => {
+  clearMocks();
+  mockGetMode.mockReset();
+});
+
+// Returns the value the shim serves for `prop` right now (mock override if active, else real).
+function makeMockable(key: string) {
+  const real = { greet: () => 'real' };
+  const mockable = createMockable(key, real) as typeof real;
+  return { mockable, mock: { [key]: { greet: () => 'mocked' } } };
+}
+
+describe('activateMocks mode guard (B2)', () => {
+  it('no-ops in "default" mode - the mock is never installed', () => {
+    mockGetMode.mockReturnValue('default');
+    const { mockable, mock } = makeMockable('pkg/guard-default');
+
+    activateMocks(mock);
+
+    expect(mockable.greet()).toBe('real');
+  });
+
+  it('installs the mock in "testing" mode', () => {
+    mockGetMode.mockReturnValue('testing');
+    const { mockable, mock } = makeMockable('pkg/guard-testing');
+
+    activateMocks(mock);
+
+    expect(mockable.greet()).toBe('mocked');
+  });
+
+  it('installs the mock in "storybook" mode', () => {
+    mockGetMode.mockReturnValue('storybook');
+    const { mockable, mock } = makeMockable('pkg/guard-storybook');
+
+    activateMocks(mock);
+
+    expect(mockable.greet()).toBe('mocked');
+  });
+});
+
+describe('activateStoryMocks mode guard (B2 - direct entry point)', () => {
+  it('no-ops in "default" mode', () => {
+    mockGetMode.mockReturnValue('default');
+    const { mockable, mock } = makeMockable('pkg/story-guard-default');
+
+    activateStoryMocks(mock);
+
+    expect(mockable.greet()).toBe('real');
+  });
+
+  it('installs the mock in "testing" mode', () => {
+    mockGetMode.mockReturnValue('testing');
+    const { mockable, mock } = makeMockable('pkg/story-guard-testing');
+
+    activateStoryMocks(mock);
+
+    expect(mockable.greet()).toBe('mocked');
+  });
+
+  it('installs the mock in "storybook" mode', () => {
+    mockGetMode.mockReturnValue('storybook');
+    const { mockable, mock } = makeMockable('pkg/story-guard-storybook');
+
+    activateStoryMocks(mock);
+
+    expect(mockable.greet()).toBe('mocked');
+  });
+});

--- a/packages/react-native-storybook/src/__tests__/mocking/registry.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/registry.test.ts
@@ -1,3 +1,8 @@
+// 'testing' so the SHERLO-1765 B2 activation mode guard lets activateMocks install.
+vi.mock('../../SherloModule', () => ({
+  default: { getMode: () => 'testing' },
+}));
+
 import {
   activateMocks,
   clearMocks,

--- a/packages/react-native-storybook/src/__tests__/mocking/storyMockActivation.test.ts
+++ b/packages/react-native-storybook/src/__tests__/mocking/storyMockActivation.test.ts
@@ -29,13 +29,15 @@ function setupView({
   storyMocks,
   globalMocks,
   readyUpfront,
+  title = 'Mocking/Config',
 }: {
   storyMocks?: Record<string, unknown>;
   globalMocks?: Record<string, unknown>;
   readyUpfront?: boolean;
+  title?: string;
 }): { view: StorybookView; storyId: string; becomeReady: () => Promise<void> } {
   const fileExports = {
-    default: { title: 'Mocking/Config' },
+    default: { title },
     Default: storyMocks ? { parameters: { sherlo: { mocks: storyMocks } } } : {},
   };
   const req = Object.assign((_filename: string) => fileExports, {
@@ -74,8 +76,10 @@ function setupView({
     await readyPromise; // flush the ready() .then re-apply before the test asserts
   };
 
-  // toId('Mocking/Config', 'Default')
-  return { view, storyId: 'mocking-config--default', becomeReady };
+  // toId(title, 'Default') - kebab-cases the title the same way Storybook does for
+  // the simple ASCII titles these tests use.
+  const storyId = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}--default`;
+  return { view, storyId, becomeReady };
 }
 
 afterEach(() => {
@@ -156,5 +160,35 @@ describe('activateMocksForStory - global mocks are robust to preview readiness (
     activateMocksForStory(view, undefined);
 
     expect(mockable.flag).toBe('real');
+  });
+});
+
+describe('activateMocksForStory - stale re-apply guard (SHERLO-1765 B3)', () => {
+  it('a superseded activation’s late ready() continuation does not install its mocks', async () => {
+    const mockable = createMockable('pkg/stale', { v: 'real' }) as { v: string };
+
+    // Story A boots with a GLOBAL-level mock, preview NOT ready yet. Its meta/story pass sees
+    // no readable global params, so it schedules a ready() re-apply that would fold in v:'A'.
+    const a = setupView({
+      title: 'Mocking/Stale-A',
+      globalMocks: { 'pkg/stale': { v: 'A' } },
+    });
+    activateMocksForStory(a.view, a.storyId);
+    expect(mockable.v).toBe('real'); // A's global not applied yet (preview not ready)
+
+    // Before A's preview resolves, story B supersedes it with a STORY-level mock that applies
+    // synchronously - this is the current, on-screen story.
+    const b = setupView({
+      title: 'Mocking/Stale-B',
+      storyMocks: { 'pkg/stale': { v: 'B' } },
+    });
+    activateMocksForStory(b.view, b.storyId);
+    expect(mockable.v).toBe('B'); // B is now active
+
+    // A's preview finally becomes ready. Its deferred continuation must bail (A was superseded);
+    // if it re-applied it would clobber B (wrong-screenshot risk) or, worse, reset to real.
+    await a.becomeReady();
+
+    expect(mockable.v).toBe('B'); // still B - the stale continuation was ignored
   });
 });

--- a/packages/react-native-storybook/src/getStorybook/storyMockActivation.ts
+++ b/packages/react-native-storybook/src/getStorybook/storyMockActivation.ts
@@ -39,6 +39,13 @@ function applyStoryMocks(view: StorybookView, storyId: string): void {
   activateStoryMocks(storyMeta?.mocks ?? {});
 }
 
+// Monotonic id for the latest activation. Each activateMocksForStory call bumps it and
+// captures its own value; a deferred ready() continuation only re-applies when its captured
+// value is still the latest. Without this, the async re-apply for a story that was already
+// superseded/torn down could re-install its mocks on top of the current story (SHERLO-1765 B3),
+// producing a wrong-screenshot capture.
+let activationGeneration = 0;
+
 /**
  * Install `storyId`'s merged mock set. Meta/story mocks apply immediately; global
  * mocks fold in once the preview is ready (see file header). Safe to call before the
@@ -47,6 +54,8 @@ function applyStoryMocks(view: StorybookView, storyId: string): void {
 export function activateMocksForStory(view: StorybookView, storyId: string | undefined): void {
   if (!storyId) return;
 
+  const generation = (activationGeneration += 1);
+
   applyStoryMocks(view, storyId);
 
   // If the preview has not yet composed its project (global) params, the pass above
@@ -54,7 +63,12 @@ export function activateMocksForStory(view: StorybookView, storyId: string | und
   const preview = getPreview(view);
   if (preview && !preview.storyStoreValue && typeof preview.ready === 'function') {
     preview.ready().then(
-      () => applyStoryMocks(view, storyId),
+      () => {
+        // A newer activation ran while we awaited ready() - this one is stale, so
+        // re-applying now would clobber the current story's mocks. Bail out.
+        if (generation !== activationGeneration) return;
+        applyStoryMocks(view, storyId);
+      },
       () => {
         // best effort - meta/story mocks are already active from the first pass
       }

--- a/packages/react-native-storybook/src/mocking/createMockable.ts
+++ b/packages/react-native-storybook/src/mocking/createMockable.ts
@@ -65,13 +65,17 @@ function createMockable<T extends ModuleExports>(key: string, realModule: T): T 
     apply(_target, thisArg, args) {
       const mock = resolveMockExports(key, realModule);
       const callee = typeof mock === 'function' ? mock : realModule;
-      return Reflect.apply(callee as (...fnArgs: unknown[]) => unknown, thisArg, args);
+      return Reflect.apply(callee as unknown as (...fnArgs: unknown[]) => unknown, thisArg, args);
     },
 
     construct(_target, args, newTarget) {
       const mock = resolveMockExports(key, realModule);
       const ctor = typeof mock === 'function' ? mock : realModule;
-      return Reflect.construct(ctor as new (...ctorArgs: unknown[]) => object, args, newTarget);
+      return Reflect.construct(
+        ctor as unknown as new (...ctorArgs: unknown[]) => object,
+        args,
+        newTarget
+      );
     },
   }) as T;
 }

--- a/packages/react-native-storybook/src/mocking/createMockable.ts
+++ b/packages/react-native-storybook/src/mocking/createMockable.ts
@@ -6,15 +6,28 @@ const hasOwn = (obj: ModuleExports, prop: PropertyKey): boolean =>
 
 // Wraps `realModule` in a Proxy that serves the active mock's exports (per property, falling
 // through export-by-export to the real module) and passes everything through unchanged when no
-// mock is active. The Proxy targets a plain, always-extensible delegate rather than `realModule`
+// mock is active. The Proxy targets an always-extensible delegate rather than `realModule`
 // itself, so trap results are never constrained by invariants coming from a frozen or sealed
 // real module.
+//
+// The delegate is a FUNCTION, not a plain object: a Proxy can only carry `apply`/`construct`
+// traps when its target is callable. This is what keeps callable-export modules
+// (`module.exports = fn`, axios-style) callable and constructable through the shim - without a
+// function target the shim would be a silent non-callable object in the client's bundle (a
+// TypeError the moment user code calls it, even with mocks dormant).
 function createMockable<T extends ModuleExports>(key: string, realModule: T): T {
   // Runs once, when the shim module is first evaluated - proof that `key` is really
   // mockable at runtime. Read by the FG-03 declared-but-unshimmed tripwire.
   registerShimmedKey(key);
 
-  const delegate: ModuleExports = {};
+  // A BOUND function, deliberately. It is callable AND constructable (so the apply/construct
+  // traps are valid) yet - unlike a plain function - it has no own `prototype` property. A plain
+  // function's `prototype` is a NON-configurable own property, which the ownKeys and
+  // getOwnPropertyDescriptor traps below would then be forced to report (or would illegally hide),
+  // tripping the Proxy invariants. A bound function's only own props (`length`, `name`) are
+  // configurable, so hiding them is legal and the trap behavior stays identical to a plain object.
+  // eslint-disable-next-line no-extra-bind
+  const delegate = function sherloMockableDelegate() {}.bind(null) as unknown as ModuleExports;
 
   return new Proxy(delegate, {
     get(_target, prop) {
@@ -43,6 +56,22 @@ function createMockable<T extends ModuleExports>(key: string, realModule: T): T 
       // The delegate target has no own properties, so any descriptor we report must claim
       // configurable: true - otherwise the Proxy invariant check throws a TypeError.
       return descriptor && { ...descriptor, configurable: true };
+    },
+
+    // Callable-export fall-through, mirroring the get/has traps: when a mock is active and its
+    // exports are themselves callable, calls/constructs route to the mock; otherwise they fall
+    // through to the real module. If neither is callable the engine raises its own "not a
+    // function" / "not a constructor" error at the call site, exactly as the real module would.
+    apply(_target, thisArg, args) {
+      const mock = resolveMockExports(key, realModule);
+      const callee = typeof mock === 'function' ? mock : realModule;
+      return Reflect.apply(callee as (...fnArgs: unknown[]) => unknown, thisArg, args);
+    },
+
+    construct(_target, args, newTarget) {
+      const mock = resolveMockExports(key, realModule);
+      const ctor = typeof mock === 'function' ? mock : realModule;
+      return Reflect.construct(ctor as new (...ctorArgs: unknown[]) => object, args, newTarget);
     },
   }) as T;
 }

--- a/packages/react-native-storybook/src/mocking/registry.ts
+++ b/packages/react-native-storybook/src/mocking/registry.ts
@@ -1,4 +1,5 @@
 import { MockSet, ModuleExports } from './types';
+import SherloModule from '../SherloModule';
 
 type Activation = {
   mocks: MockSet;
@@ -13,7 +14,18 @@ let activeActivation: Activation | null = null;
 const shimmedKeys = new Set<string>();
 
 // Installs the mock set for one story, replacing any previously active set.
+//
+// Defense-in-depth (SHERLO-1765 B2): activation is a no-op outside 'testing' and
+// 'storybook' modes, mirroring the guard in helpers/RunnerBridge/actions/log.ts.
+// A production app reports 'default', so even a stray activation call there leaves
+// every createMockable trap passing straight through to the real module. This is
+// the single choke point - activateStoryMocks delegates here, so both public entry
+// points are covered. Interactive 'storybook' mode is a legitimate mock context and
+// is intentionally NOT blocked.
 function activateMocks(mocks: MockSet): void {
+  const mode = SherloModule.getMode();
+  if (mode !== 'testing' && mode !== 'storybook') return;
+
   activeActivation = { mocks, resolved: new Map() };
 }
 

--- a/testing/expo/metro.config.js
+++ b/testing/expo/metro.config.js
@@ -35,5 +35,8 @@ const customConfig = {
 // Apply Storybook wrapper to the extended config
 module.exports = withStorybook(customConfig, {
   enabled: true,
+  // Opt in to the experimental module-mocking pipeline so parameters.sherlo.mocks
+  // takes effect here (this app is a device-validation harness for the mocking matrix).
+  experimentalMocks: true,
   configPath: path.resolve(__dirname, './.rnstorybook'),
 });

--- a/testing/react-native/metro.config.js
+++ b/testing/react-native/metro.config.js
@@ -32,5 +32,8 @@ const customConfig = mergeConfig(defaultConfig, {
 
 module.exports = withStorybook(customConfig, {
   enabled: true,
+  // Opt in to the experimental module-mocking pipeline so parameters.sherlo.mocks
+  // takes effect here (this app is a device-validation harness for the mocking matrix).
+  experimentalMocks: true,
   configPath: path.resolve(__dirname, './.storybook'),
 });


### PR DESCRIPTION
🔁 **Loop channel PR for SHERLO-1763**

This draft PR is the single communication channel for this loop task (SHERLO-1728).
All `[loop:*]` dialogue lives here; the task branch is the cross-repo join key.
It starts as a draft on an empty bootstrap commit and is promoted to ready on the first real push.

https://sherlo-io.atlassian.net/browse/SHERLO-1763