### PR TITLE
feat: CLI: tolerant SDK protocol-version read for the bundled comp…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/buildBundle.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/buildBundle.test.ts
@@ -18,7 +18,6 @@ import {
   stripVersionLines,
 } from '../../../helpers/fingerprint/baseFingerprint';
 import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from '../buildBundle';
-import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../../constants';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -37,15 +36,21 @@ vi.mock('../../init/requirements/getPackageVersion', () => ({
   default: vi.fn(),
 }));
 
+vi.mock('../readBundledSdkProtocolVersion', () => ({
+  readBundledSdkProtocolVersion: vi.fn(),
+}));
+
 // The local imports resolve the mocked modules because vi.mock is hoisted.
 import detectBundlerDefault from '../../showError/detectBundler';
 import { detectEntryFile as detectEntryFileNamed } from '../../showError/detectBundler';
 import getPackageVersionDefault from '../../init/requirements/getPackageVersion';
+import { readBundledSdkProtocolVersion } from '../readBundledSdkProtocolVersion';
 
 const mockExecSync = vi.mocked(execSync);
 const mockDetectBundler = vi.mocked(detectBundlerDefault);
 const mockDetectEntryFile = vi.mocked(detectEntryFileNamed);
 const mockGetPackageVersion = vi.mocked(getPackageVersionDefault);
+const mockReadBundledSdkProtocolVersion = vi.mocked(readBundledSdkProtocolVersion);
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -629,7 +634,7 @@ describe('buildGateMetadata (test:bundled = source)', () => {
     };
   }
 
-  /** Resolve package versions by name so the two getPackageVersion reads differ. */
+  /** Resolve getPackageVersion reads (react-native) by name. */
   function mockVersions(versions: Record<string, string | null>) {
     mockGetPackageVersion.mockImplementation((name: string) =>
       name in versions ? versions[name] : null
@@ -637,10 +642,8 @@ describe('buildGateMetadata (test:bundled = source)', () => {
   }
 
   it('marks source, sends bundle-derivable dims + the SDK-protocol compat input', async () => {
-    mockVersions({
-      'react-native': '0.76.0',
-      [SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME]: '2.0.1',
-    });
+    mockVersions({ 'react-native': '0.76.0' });
+    mockReadBundledSdkProtocolVersion.mockReturnValue('2.0.1');
 
     const result = bundleResult();
     const metadata = await buildGateMetadata({
@@ -673,10 +676,8 @@ describe('buildGateMetadata (test:bundled = source)', () => {
   });
 
   it('omits the SDK-protocol compat input when the package is not installed (absent, not fabricated)', async () => {
-    mockVersions({
-      'react-native': '0.76.0',
-      [SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME]: null, // getPackageVersion -> null
-    });
+    mockVersions({ 'react-native': '0.76.0' });
+    mockReadBundledSdkProtocolVersion.mockReturnValue(undefined); // package not installed
 
     const metadata = await buildGateMetadata({
       projectRoot: tempDir,

--- a/packages/cli/src/commands/testBundled/__tests__/readBundledSdkProtocolVersion.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/readBundledSdkProtocolVersion.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for readBundledSdkProtocolVersion - the fail-soft reader that
+ * resolves the SDK protocol version a bundled build requires, tolerant of
+ * npm-aliased installs (name mismatch between specifier and package.json).
+ *
+ * Drives real fs + require.resolve against a scratch node_modules layout -
+ * no module mocking, since the whole point is exercising real resolution.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readBundledSdkProtocolVersion } from '../readBundledSdkProtocolVersion';
+import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../../constants';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-read-sdk-protocol-version-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Create the node_modules/@sherlo/react-native-storybook package under tempDir. */
+function installPackage(packageJsonContent: string | Record<string, unknown> | undefined): void {
+  const packageDir = path.join(tempDir, 'node_modules', SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME);
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = {};');
+
+  if (packageJsonContent !== undefined) {
+    const content =
+      typeof packageJsonContent === 'string'
+        ? packageJsonContent
+        : JSON.stringify(packageJsonContent);
+    fs.writeFileSync(path.join(packageDir, 'package.json'), content);
+  }
+}
+
+describe('readBundledSdkProtocolVersion', () => {
+  it('returns the version for an npm-aliased install whose package.json name differs from the specifier', () => {
+    installPackage({ name: '@sherlo-io/react-native-storybook', version: '2.0.1' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBe('2.0.1');
+  });
+
+  it('returns the version for a matching-name install', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: '1.4.0' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBe('1.4.0');
+  });
+
+  it('returns undefined when the package is not installed', () => {
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined when package.json is unreadable', () => {
+    installPackage(undefined);
+    const packageDir = path.join(
+      tempDir,
+      'node_modules',
+      SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME
+    );
+    // A directory named package.json makes readFileSync throw (EISDIR).
+    fs.mkdirSync(path.join(packageDir, 'package.json'));
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined when package.json is invalid JSON', () => {
+    installPackage('{ this is not valid json');
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined when the version field is absent', () => {
+    installPackage({ name: '@sherlo-io/react-native-storybook' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('never throws across all failure modes', () => {
+    installPackage('{ this is not valid json');
+    expect(() => readBundledSdkProtocolVersion(tempDir)).not.toThrow();
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-read-sdk-protocol-version-'));
+    expect(() => readBundledSdkProtocolVersion(tempDir)).not.toThrow();
+  });
+});

--- a/packages/cli/src/commands/testBundled/buildBundle.ts
+++ b/packages/cli/src/commands/testBundled/buildBundle.ts
@@ -23,7 +23,7 @@ import {
 import detectBundler from '../../commands/showError/detectBundler';
 import { detectEntryFile } from '../../commands/showError/detectBundler';
 import getPackageVersion from '../../commands/init/requirements/getPackageVersion';
-import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../constants';
+import { readBundledSdkProtocolVersion } from './readBundledSdkProtocolVersion';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -282,8 +282,7 @@ export async function buildGateMetadata({
     platform,
   });
 
-  const requiredSdkProtocolVersion =
-    getPackageVersion(SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME) ?? undefined;
+  const requiredSdkProtocolVersion = readBundledSdkProtocolVersion(projectRoot);
 
   const rnVersion = getPackageVersion('react-native');
   const expoSdkVer = getExpoSdkVersion(projectRoot);

--- a/packages/cli/src/commands/testBundled/readBundledSdkProtocolVersion.ts
+++ b/packages/cli/src/commands/testBundled/readBundledSdkProtocolVersion.ts
@@ -1,0 +1,50 @@
+/**
+ * Fail-soft reader for the SDK protocol version a bundled build requires.
+ *
+ * Unlike init's getPackageVersion (which enforces that the located
+ * package.json's `name` matches the specifier and throws otherwise), this
+ * reader has no such guard: an npm-aliased install
+ * (`@sherlo/react-native-storybook@npm:@sherlo-io/react-native-storybook@x`)
+ * resolves to a package.json whose `name` differs from the specifier, but
+ * whose `version` is still the real protocol-version requirement. Any
+ * failure - missing package, unreadable/invalid package.json, missing
+ * version field - degrades to `undefined`; this reader never throws.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../constants';
+
+export function readBundledSdkProtocolVersion(projectRoot: string): string | undefined {
+  try {
+    const packagePath = require.resolve(SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, {
+      paths: [projectRoot],
+    });
+
+    let currentDir = dirname(packagePath);
+    let packageJsonPath: string | undefined;
+    for (;;) {
+      const candidate = join(currentDir, 'package.json');
+      if (existsSync(candidate)) {
+        packageJsonPath = candidate;
+        break;
+      }
+
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+
+    if (!packageJsonPath) {
+      return undefined;
+    }
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export default readBundledSdkProtocolVersion;


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1773

## Summary

buildBundle's requiredSdkProtocolVersion compat input now resolves through a tolerant, fail-soft reader instead of init's strict getPackageVersion. This brings the bundled flow into SHERLO-1760 AC compliance: the compat input is POPULATED when resolvable and degrades to ABSENT (never a hard failure) otherwise.

## Why

SHERLO-1760 wired the explicitly-OPTIONAL requiredSdkProtocolVersion to the pre-existing HARD-THROWING init validator getPackageVersion (buildBundle.ts:285, the '?? undefined' proving graceful-absent intent). That helper returns null only on MODULE_NOT_FOUND; on found-but-name-mismatch it THROWS. The e2e fixture installs the SDK via npm alias (@sherlo/react-native-storybook aliased to @sherlo-io/react-native-storybook@tag), so the located package.json name never matches the specifier and every test:bundled run exited 1 pre-gate ('Package ... was found ... but its package.json is invalid or inaccessible' - a misnomer; the file is valid and present). Production name-matching installs were unaffected.

## The fix

A new tolerant reader, readBundledSdkProtocolVersion.ts, scoped to the bundled compat input: it resolves the package the app actually imports via require.resolve with paths set to projectRoot (also fixing the resolution context to where the app's SDK lives), walks up to the nearest package.json, and returns that version with NO name===specifier guard - so an npm-aliased install yields its REAL published version. Any resolve, read, parse, or absent-version failure degrades to undefined inside a single fail-soft envelope; the bundled flow never throws.

Tolerant-read is deliberately chosen over a bare try/catch that returns undefined: a bare catch would send ABSENT in EVERY bundled e2e run, so the compat rule (sherlo-api gate) would never be exercised end-to-end and a real future protocol incompatibility would go undetected. require.resolve already locates exactly the package the app imports; its package.json version IS the requirement, regardless of the alias name.

Scope discipline held: init's strict getPackageVersion is UNCHANGED (its strictness is init's own contract), the react-native version read one line below keeps its behavior, and there are no fixture or gate changes.

## Tests + CI evidence

Unit tests in readBundledSdkProtocolVersion.test.ts drive real fs plus require.resolve against a scratch node_modules layout: aliased install with name mismatch yields the real version; matching-name install yields the version; missing package, unreadable package.json (EISDIR), invalid JSON, and absent version field each yield undefined; plus a never-throws sweep across the failure modes. The two existing buildGateMetadata cases were updated to mock the new reader (react-native still reads through getPackageVersion).

Local: 65 CLI tests pass across 6 files.

CI on head 5585fd2d - all green:
- checks cli: SUCCESS, run 29194038169
- lint: SUCCESS, run 29194038168
- checks react-native-storybook: SUCCESS, run 29194038169
- Analyze javascript-typescript: SUCCESS, run 29194036903
- Analyze ruby: SUCCESS, run 29194036903

## Post-merge plan (part of the task, defect -3 rule)

Before task done: republish @sherlo-io/cli to @test and @dev (Release to Test plus Release to Dev in this repo), with the published version commented on this PR. Joint acceptance evidence with SHERLO-1725: on the republished @test CLI, the 1725-branch cli/base-registry run shows spec 02 green AND the compat input POPULATED (the gate exercised with a real version, not absent); the SHERLO-1725 executor self-checks and re-fires on the republish.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
