### PR TITLE
feat: CLI: requiredSdkProtocolVersion sends the BASE semver of the…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/readBundledSdkProtocolVersion.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/readBundledSdkProtocolVersion.test.ts
@@ -80,6 +80,45 @@ describe('readBundledSdkProtocolVersion', () => {
     expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
   });
 
+  it('strips a CI-republished test-build suffix down to the base semver', () => {
+    installPackage({
+      name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME,
+      version: '2.0.1-test.29194907781',
+    });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBe('2.0.1');
+  });
+
+  it('strips a dev-build suffix down to the base semver', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: '2.0.1-dev.42' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBe('2.0.1');
+  });
+
+  it('leaves a plain release version unchanged', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: '2.0.1' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBe('2.0.1');
+  });
+
+  it('returns undefined for an unparseable version', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: 'not-a-version' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined for a version missing the patch component', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: '2.0' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined for a version with a non-numeric component', () => {
+    installPackage({ name: SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME, version: '2.x.1' });
+
+    expect(readBundledSdkProtocolVersion(tempDir)).toBeUndefined();
+  });
+
   it('never throws across all failure modes', () => {
     installPackage('{ this is not valid json');
     expect(() => readBundledSdkProtocolVersion(tempDir)).not.toThrow();

--- a/packages/cli/src/commands/testBundled/readBundledSdkProtocolVersion.ts
+++ b/packages/cli/src/commands/testBundled/readBundledSdkProtocolVersion.ts
@@ -6,13 +6,29 @@
  * reader has no such guard: an npm-aliased install
  * (`@sherlo/react-native-storybook@npm:@sherlo-io/react-native-storybook@x`)
  * resolves to a package.json whose `name` differs from the specifier, but
- * whose `version` is still the real protocol-version requirement. Any
+ * whose `version` is still the real protocol-version requirement. The
+ * returned value is the BASE semver (major.minor.patch) of that resolved
+ * version - any prerelease/build-metadata suffix (e.g. the `-test.<run-id>`
+ * or `-dev.<n>` tag a CI-republished build carries) is stripped, since it
+ * marks how the build was produced, not which protocol it implements. Any
  * failure - missing package, unreadable/invalid package.json, missing
- * version field - degrades to `undefined`; this reader never throws.
+ * version field, unparseable version - degrades to `undefined`; this reader
+ * never throws.
  */
 import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { SHERLO_REACT_NATIVE_STORYBOOK_PACKAGE_NAME } from '../../constants';
+
+/**
+ * Matches a leading major.minor.patch triplet followed by a prerelease
+ * (`-...`), build-metadata (`+...`), or end-of-string boundary - so
+ * `2.0.1abc` is rejected rather than truncated to `2.0.1`.
+ */
+const BASE_SEMVER_PATTERN = /^(\d+\.\d+\.\d+)(?:[-+]|$)/;
+
+function toBaseSemver(version: string): string | undefined {
+  return BASE_SEMVER_PATTERN.exec(version)?.[1];
+}
 
 export function readBundledSdkProtocolVersion(projectRoot: string): string | undefined {
   try {
@@ -41,7 +57,7 @@ export function readBundledSdkProtocolVersion(projectRoot: string): string | und
     }
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-    return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+    return typeof packageJson.version === 'string' ? toBaseSemver(packageJson.version) : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1774

## Summary

The bundled compat reader (`readBundledSdkProtocolVersion`) sent the raw installed SDK package version as `requiredSdkProtocolVersion`. For CI-republished builds that version carries a run-id suffix (e.g. `2.0.1-test.29194907781`, `2.0.1-dev.42`), while the registered base APK bakes the plain protocol `2.0.1`. The gate's compat rule is exact-string fail-closed equality, so `2.0.1` != `2.0.1-test.29194907781` produced `sdk-protocol-incompatible` and refused every bundled push.

The suffix is a BUILD TAG from the publish pipeline (same source republished per CI run), not a semver/API divergence: a `2.0.1-test.X` build implements protocol `2.0.1`. Fix is at the SENDER: normalize the resolved version to its base semver before sending. The gate stays exact-match fail-closed on what it receives - correct and unchanged.

## Change

`readBundledSdkProtocolVersion` now returns the BASE semver (major.minor.patch) of the resolved package version, stripping any prerelease (`-...`) or build-metadata (`+...`) suffix:

- `2.0.1-test.29194907781` -> `2.0.1`
- `2.0.1-dev.42` -> `2.0.1`
- `2.0.1` -> `2.0.1` (unchanged)
- unparseable / malformed (`2.0`, `2.x.1`, `not-a-version`) -> `undefined`

A strict `BASE_SEMVER_PATTERN` (`^(\d+\.\d+\.\d+)(?:[-+]|$)`) anchors the full triplet and requires a `-`, `+`, or end-of-string boundary after the patch digit, so `2.0.1abc` degrades to absent rather than truncating to `2.0.1`. The whole reader stays fail-soft: every failure path (missing package, unreadable/invalid package.json, missing version field, now also unparseable version) returns `undefined` and never throws. No gate, API, fixture, or init-validator changes - the sender normalization is the entire scope (reader + tests, 2 files, +58/-3).

## Evidence

Motivating run 29195055352 (CLI 2.0.1-test.29194907781): reader sent the full suffixed string as `requiredSdkProtocolVersion`; registered base APK bakes `2.0.1`; exact-string compat inequality refused all bundled pushes (bundled-fast-path 01/02/03 red in ~8s, base-registry 02 red after cold build). SHERLO-1773 (tolerant reader) already verified cured on that run - this ticket fixes the remaining semantic gap in what the cured reader sends.

This PR extends the SHERLO-1773 unit suite: suffixed-test -> base, suffixed-dev -> base, plain-release passthrough, unparseable -> absent, missing-patch -> absent, non-numeric component -> absent; all existing aliased-install and failure-mode cases stay green. 13/13 tests pass. CI green on head be505e8b:

- checks (cli): pass - run 29196811468
- checks (react-native-storybook): pass - run 29196811468
- lint: pass - run 29196811458
- CodeQL (javascript-typescript, ruby): pass - run 29196810450

## Post-merge plan

Before `task done`:

1. Republish `@sherlo-io/cli` @test and @dev (Release to Test + Release to Dev); comment the published versions on this PR.
2. Joint acceptance with SHERLO-1725: on the republished @test CLI, the 1725-branch run shows `cli/base-registry` spec 02 AND the `cli/bundled-fast-path` suite green - the compat rule passing on a genuinely-matching protocol, populated not absent.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
