### PR TITLE
feat: Pyramid migration area 1 of the approved blueprint - Diff Sc…

### DIFF
--- a/packages/cli/src/helpers/__tests__/diffScope/computeChangedFiles.test.ts
+++ b/packages/cli/src/helpers/__tests__/diffScope/computeChangedFiles.test.ts
@@ -74,7 +74,8 @@ describe('computeChangedFiles – bail-to-full conditions', () => {
     expect((result as any).reason).toMatch(/dirty/i);
   });
 
-  it('bails to full when mergeBaseSha is absent (non-PR build)', async () => {
+  // (S3e) push-to-main / non-PR build: no mergeBaseSha -> bail to full.
+  it('bails to full when mergeBaseSha is absent (non-PR build) (S3e)', async () => {
     fixture = GitFixture.create();
     fixture.commitFile('c1');
 
@@ -120,7 +121,9 @@ describe('computeChangedFiles – bail-to-full conditions', () => {
 // ---------------------------------------------------------------------------
 
 describe('computeChangedFiles – successful diff derivation', () => {
-  it('returns only feature-branch-changed files relative to the fork point', async () => {
+  // (S4) PR-event changedFiles derivation: git diff --name-only <mergeBaseSha> <head>
+  // yields exactly the changed files on the feature branch.
+  it('returns only feature-branch-changed files relative to the fork point (S4)', async () => {
     fixture = GitFixture.create();
     const forkPoint = fixture.commitFile('shared-base');
 
@@ -171,7 +174,9 @@ describe('computeChangedFiles – successful diff derivation', () => {
     expect((result as { changedFiles: string[] }).changedFiles).toHaveLength(0);
   });
 
-  it('captures multiple files changed across multiple PR commits', async () => {
+  // (S4) multi-commit variant: the diff still spans the whole feature branch,
+  // not just the last commit.
+  it('captures multiple files changed across multiple PR commits (S4)', async () => {
     fixture = GitFixture.create();
     const forkPoint = fixture.commitFile('base');
 

--- a/packages/cli/src/helpers/__tests__/diffScope/storyImportsStory.test.ts
+++ b/packages/cli/src/helpers/__tests__/diffScope/storyImportsStory.test.ts
@@ -151,6 +151,36 @@ export const Primary = () => <Button />;`
     expect(result).toEqual({ changedFiles: changed });
   });
 
+  // (S2) bail-open conservatism, CLI-side finding: editing a shared non-story
+  // component (SharedButton.tsx, imported by ProductCard.stories.tsx AND
+  // CheckoutScreen.stories.tsx, but not itself a story file) does NOT trigger a
+  // CLI-side bail. changedStories stays empty (SharedButton.tsx fails
+  // STORY_FILE_RE), so checkStoryImportsStory takes the fast path and returns
+  // { changedFiles } unchanged - it has no notion of a component->story edge in
+  // v1. The "full capture" guarantee for this scenario is proven server-side by
+  // the API's non-story-file coarse gate (reason `non-story-file-changed:`,
+  // see computeDiffScopeDecision.unit.test.ts in sherlo-api), not here.
+  it('does NOT bail for a changed shared non-story component (S2) - full capture is enforced by the API coarse gate, not the CLI', () => {
+    fx.write('SharedButton.tsx', `export const SharedButton = () => null;`);
+    fx.write(
+      'ProductCard.stories.tsx',
+      `import { SharedButton } from './SharedButton';
+export default { title: 'ProductCard' };
+export const Primary = () => <SharedButton />;`
+    );
+    fx.write(
+      'CheckoutScreen.stories.tsx',
+      `import { SharedButton } from './SharedButton';
+export default { title: 'CheckoutScreen' };
+export const Primary = () => <SharedButton />;`
+    );
+
+    const changed = ['SharedButton.tsx'];
+    const result = checkStoryImportsStory(fx.dir, changed);
+
+    expect(result).toEqual({ changedFiles: changed });
+  });
+
   it('returns { changedFiles } with non-story file changes alongside story changes when no cross-imports exist', () => {
     fx.write('Button.tsx', `export const Button = () => null;`);
     fx.write(


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1857

## CLI units for demoted Diff Scope 09 scenarios (SHERLO-1857, pyramid area 1)

Names each 09 e2e scenario being demoted to its CLI unit home, **ahead of** the tester spec
cut (sherlo-tester PR #157) so coverage never drops. Merges as part of the same green+approved
batch as the API units (sherlo-api PR #284) and the spec cut.

Test-only diff (2 files). `yarn test` in `packages/cli` = **35 passed**.

- **S3e** (push-to-main / non-PR, missing-changedFiles bail) and **S4** (PR-event changedFiles
  derivation, incl. multi-commit) - labeled in `computeChangedFiles.test.ts`.
- **S6** (story-imports-story, static import) and **S7** (barrel re-export trace) - already
  labeled `(S6)`/`(S7)` in `storyImportsStory.test.ts`; confirmed as the demotion homes.
- **S2 finding**: the CLI does **not** bail for a shared non-story component (it takes the fast
  path); the full-capture guarantee is enforced by the API's non-story-file coarse gate. Added a
  CLI test asserting that exact CLI behavior and pointing S2's enforcement home to the API unit
  (sherlo-api PR #284 · `"...non-story component file (S2)"`).

Full cross-repo traceability table is on sherlo-tester PR #157.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
