### PR TITLE
feat: Diff Scope v2 Phase D: the story - B-series e2e scenarios (t…

### DIFF
--- a/packages/cli/src/commands/testBundled/dryRunDecision.ts
+++ b/packages/cli/src/commands/testBundled/dryRunDecision.ts
@@ -235,7 +235,7 @@ export async function requestDryRunDecision(
     throw new Error('The Diff Scope dry-run decision returned no platform results.');
   }
 
-  return result.platforms.map((r) => ({
+  return result.platforms.map((r: DiffScopeDryRunPlatformResult) => ({
     platform: r.platform,
     isFullCapture: r.isFullCapture,
     // Defensive: the SDL guarantees a list, but never render undefined as a list.


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1896

## What
One-line type annotation on the dry-run decision mapper to unblock the strict CLI build.

`packages/cli/src/commands/testBundled/dryRunDecision.ts:238` - annotate the `.map` callback param: `(r)` -> `(r: DiffScopeDryRunPlatformResult)` (the file's own type at line 71, already the declared element type of `result.platforms` at line 87). No behavior change.

## Why
Under `packages/cli`'s build (`ncc build ... && tsc --emitDeclarationOnly`, `strict: true`), `r` was implicitly `any` (TS7006) and `tsc` aborted. This blocked building the sherlo CLI from source (a prerequisite of SHERLO-1896's from-source e2e path) and left sherlo main's `release_to_test` RED.

## Why Phase C's CI missed it (Director rider 1)
sherlo#204's `checks (cli)` job went green because its typecheck step runs `tsc --noEmit -p packages/cli`, which did not surface this implicit-any parameter - whereas the release build's `tsc --emitDeclarationOnly` (declaration emit) does. The PR gate's typecheck mode structurally diverges from the build's, so the gate could not have caught it.

## Follow-up recommendation (Director rider 2 - NOT in this PR)
Add a `tsc --emitDeclarationOnly` (or a real `packages/cli` build) step to `pr_checks.yml` so the PR gate matches the release build's strictness. Filed as a follow-up, deliberately kept out of this surgically-scoped fix.

## Testing
Verified by the developer dept via `tsc --emitDeclarationOnly` (the exact failing path) + vitest; diff/type re-verified. Authoritative CI gate: this PR's `pr_checks`.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
