### PR TITLE
chore: add expo, eas, screenshot testing npm keywords

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,10 @@
     "react-native",
     "visual regression testing",
     "react native visual testing",
-    "storybook"
+    "storybook",
+    "screenshot testing",
+    "expo",
+    "eas"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -7,7 +7,10 @@
     "react-native",
     "storybook",
     "visual regression testing",
-    "react native visual testing"
+    "react native visual testing",
+    "screenshot testing",
+    "expo",
+    "eas"
   ],
   "license": "MIT",
   "author": "Sherlo",


### PR DESCRIPTION
## Summary

Adds three missing npm keywords to both public packages (`@sherlo/react-native-storybook` and `sherlo` CLI):

- `screenshot testing`
- `expo`
- `eas`

## Why

- npm search discoverability: npm first-touched 2 of the last 19 sherlo.io signups - cheap to maximize
- Keywords feed the Storybook addon catalog matching and npm/libhunt-style aggregators
- Aligns package metadata with the EAS Build / EAS Update integration story

No code changes - metadata only. Takes effect on next npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)