### PR TITLE
feat: test:bundled must EXPLAIN its diff-scope decision in its own…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the shared Diff Scope report renderer (SHERLO-1915).
+ *
+ * This is the ONE formatter both the live run and the --dry-run preview print
+ * through, so the assertions here are the load-bearing ones:
+ *   - the inversion pin: a FULL capture with an EMPTY captured-file list renders
+ *     as "EVERY story", NEVER "nothing" (Deliverable 3);
+ *   - tense parity: the live and dry-run blocks are byte-identical once the tense
+ *     words are normalised, asserted DIRECTLY against the formatter rather than by
+ *     eyeballing two snapshots (Deliverable 5.5);
+ *   - the reused side and the "N of M stories in this bundle" relabel that names
+ *     the fraction's universe (Deliverable 4).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  formatDiffScopeBlock,
+  formatDiffScopeReport,
+  type DiffScopePlatformReport,
+} from '../diffScopeReport';
+
+type DecidedBlock = Extract<DiffScopePlatformReport, { kind: 'decided' }>;
+
+function decided(overrides: Partial<DecidedBlock> = {}): DecidedBlock {
+  return {
+    kind: 'decided',
+    platform: 'ios',
+    full: false,
+    capturedStoryFilePaths: [],
+    totalStoriesInBundle: undefined,
+    reason: undefined,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatDiffScopeBlock - the shared per-platform core
+// ---------------------------------------------------------------------------
+
+describe('formatDiffScopeBlock', () => {
+  it('renders a partial capture with its fraction, reused side, story list, and verbatim reason', () => {
+    const block = decided({
+      platform: 'ios',
+      full: false,
+      capturedStoryFilePaths: [
+        'src/components/Storefront/Storefront.stories.tsx',
+        'src/components/Cart/Cart.stories.tsx',
+      ],
+      totalStoriesInBundle: 22,
+      reason: 'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx',
+    });
+
+    const live = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    // The fraction NAMES ITS UNIVERSE - "in this bundle", not the --include scope.
+    expect(live).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
+    // Reused = M - N = 20, shown as its own line.
+    expect(live).toContain(
+      'Reused the other 20 (already photographed on the base build, not re-shot here).'
+    );
+    expect(live).toContain('Stories captured:');
+    expect(live).toContain('• src/components/Storefront/Storefront.stories.tsx');
+    expect(live).toContain('• src/components/Cart/Cart.stories.tsx');
+    // Reason is byte-for-byte the server string.
+    expect(live).toContain(
+      'Reason: captured 2 - closure changed via src/components/Storefront/SharedButton.tsx'
+    );
+  });
+
+  it('THE INVERSION PIN: a FULL capture with an EMPTY list renders "EVERY story", never "nothing"', () => {
+    // full: true is "everything"; the empty capturedStoryFilePaths must never be
+    // read as "nothing" - the single worst misread this formatter guards.
+    const block = decided({
+      platform: 'ios',
+      full: true,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 12,
+      reason: 'main-branch',
+    });
+
+    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
+    expect(out).toContain('Reason: main-branch');
+    // None of the "nothing" / partial renderings may leak.
+    expect(out).not.toContain('nothing');
+    expect(out).not.toContain('captured 0');
+    expect(out).not.toContain('Stories captured:');
+    expect(out).not.toContain('Reused');
+  });
+
+  it('renders a PARTIAL zero-capture as "nothing captured" with the whole bundle reused', () => {
+    const block = decided({
+      platform: 'android',
+      full: false,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 22,
+      reason: 'captured 0 - no module changes reach any story',
+    });
+
+    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    expect(out).toContain('🤖 Android - captured 0 of 22 stories in this bundle');
+    expect(out).toContain(
+      'Nothing your changes touch reaches a story, so all 22 were reused from the base build.'
+    );
+    expect(out).toContain('Reason: captured 0 - no module changes reach any story');
+    // A partial-zero is NOT a full capture.
+    expect(out).not.toContain('EVERY story');
+    expect(out).not.toContain('Stories captured:');
+  });
+
+  it('degrades to a bare count (no "of M", no reused line) when the bundle has no manifest', () => {
+    const block = decided({
+      platform: 'ios',
+      full: false,
+      capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+      totalStoriesInBundle: undefined,
+      reason: 'captured 1 - closure changed via src/a/a.ts',
+    });
+
+    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    expect(out).toContain('🍎 iOS - captured 1 story');
+    expect(out).not.toContain(' of ');
+    expect(out).not.toContain('Reused');
+    expect(out).toContain('• src/a/A.stories.tsx');
+  });
+
+  it('omits the reason line entirely when no reason is given (live ladder rung 3)', () => {
+    const block = decided({
+      platform: 'ios',
+      full: false,
+      capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+      totalStoriesInBundle: 4,
+      reason: undefined,
+    });
+
+    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    expect(out).toContain('captured 1 of 4 stories in this bundle');
+    expect(out).not.toContain('Reason:');
+  });
+
+  it('bounds the story list and summarises the remainder', () => {
+    const paths = Array.from({ length: 25 }, (_, i) => `src/s${i}/S${i}.stories.tsx`);
+    const block = decided({
+      platform: 'ios',
+      full: false,
+      capturedStoryFilePaths: paths,
+      totalStoriesInBundle: 30,
+      reason: 'captured 25 - many changed',
+    });
+
+    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+
+    expect(out).toContain('• src/s0/S0.stories.tsx');
+    expect(out).toContain('• src/s19/S19.stories.tsx');
+    // Path 20 (the 21st) is past the cap of 20.
+    expect(out).not.toContain('• src/s20/S20.stories.tsx');
+    expect(out).toContain('• ... and 5 more');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tense parity - live and dry-run read identically apart from tense
+// ---------------------------------------------------------------------------
+
+describe('tense parity (Deliverable 5.5)', () => {
+  /** Rewrite a would-capture block into its captured form using ONLY tense words. */
+  function normaliseTense(wouldLines: string[]): string[] {
+    return wouldLines.map((line) =>
+      line
+        .replace('would capture', 'captured')
+        .replace('Would reuse', 'Reused')
+        .replace('would be reused', 'were reused')
+        .replace('Stories to capture:', 'Stories captured:')
+    );
+  }
+
+  const cases: Array<[string, DecidedBlock]> = [
+    [
+      'partial with captures',
+      decided({
+        full: false,
+        capturedStoryFilePaths: ['src/a/A.stories.tsx', 'src/b/B.stories.tsx'],
+        totalStoriesInBundle: 22,
+        reason: 'captured 2 - closure changed via src/a/a.ts',
+      }),
+    ],
+    [
+      'partial zero',
+      decided({
+        full: false,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: 'captured 0',
+      }),
+    ],
+    ['full capture', decided({ full: true, capturedStoryFilePaths: [], reason: 'main-branch' })],
+    [
+      'no-manifest degrade',
+      decided({
+        full: false,
+        capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+        reason: 'captured 1',
+      }),
+    ],
+  ];
+
+  it.each(cases)('%s reads identically once tense is normalised', (_name, block) => {
+    const would = formatDiffScopeBlock(block, 'would-capture');
+    const captured = formatDiffScopeBlock(block, 'captured');
+
+    // The ONLY difference between the two tenses is the tense words themselves.
+    expect(normaliseTense(would)).toEqual(captured);
+    // Sanity: the tense genuinely changed the raw text (nothing is a no-op).
+    expect(would.join('\n')).not.toEqual(captured.join('\n'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDiffScopeReport - headers, footer, mode -> tense
+// ---------------------------------------------------------------------------
+
+describe('formatDiffScopeReport', () => {
+  const partial: DiffScopePlatformReport = decided({
+    platform: 'ios',
+    full: false,
+    capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+    totalStoriesInBundle: 4,
+    reason: 'captured 1 - closure changed via src/a/a.ts',
+  });
+
+  it('dry-run mode uses the preview header/footer and the "would capture" tense', () => {
+    const out = formatDiffScopeReport('dry-run', [partial]);
+
+    expect(out).toContain('📋 Diff Scope preview - dry run (no build created)');
+    expect(out).toContain('iOS - would capture 1 of 4 stories in this bundle');
+    expect(out).toContain('This is a preview: no build was created and nothing was uploaded.');
+  });
+
+  it('live mode uses the live header (no preview footer) and the "captured" tense', () => {
+    const out = formatDiffScopeReport('live', [partial]);
+
+    expect(out).toContain('📋 Diff Scope - what this run photographed');
+    expect(out).toContain('iOS - captured 1 of 4 stories in this bundle');
+    expect(out).not.toContain('This is a preview');
+  });
+
+  it('renders a mix of one full and one partial platform', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'ios',
+        full: true,
+        capturedStoryFilePaths: [],
+        reason: 'native-changed',
+      }),
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: ['src/x/X.stories.tsx'],
+        totalStoriesInBundle: 8,
+        reason: 'captured 1 - closure changed via src/x.tsx',
+      }),
+    ]);
+
+    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
+    expect(out).toContain('Reason: native-changed');
+    expect(out).toContain('🤖 Android - captured 1 of 8 stories in this bundle');
+    expect(out).toContain('• src/x/X.stories.tsx');
+  });
+
+  it('renders a dry-run bail-open as "a real run would capture EVERY story"', () => {
+    const out = formatDiffScopeReport('dry-run', [
+      { kind: 'bailed-open', platform: 'ios', reason: 'network exploded' },
+    ]);
+
+    expect(out).toContain('🍎 iOS - preview unavailable; a real run would capture EVERY story');
+    expect(out).toContain('Reason: network exploded');
+  });
+});

--- a/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
@@ -78,7 +78,10 @@ describe('formatDryRunPreview', () => {
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
     expect(output).toContain('Diff Scope preview - dry run (no build created)');
-    expect(output).toContain('iOS - would capture 2 of 5 stories');
+    // The fraction NAMES ITS UNIVERSE - "in this bundle", not the --include scope.
+    expect(output).toContain('iOS - would capture 2 of 5 stories in this bundle');
+    // Reused side (M - N = 3) is now shown alongside the captured side.
+    expect(output).toContain('Would reuse the other 3');
     expect(output).toContain('• src/components/Storefront/Storefront.stories.tsx');
     expect(output).toContain('• src/components/Cart/Cart.stories.tsx');
     // Reason printed EXACTLY as the server returned it - no re-rendering.
@@ -88,7 +91,7 @@ describe('formatDryRunPreview', () => {
     expect(output).toContain('no build was created and nothing was uploaded');
   });
 
-  it('renders a PARTIAL zero-capture as "capture nothing" with its verbatim reason', () => {
+  it('renders a PARTIAL zero-capture as "nothing captured" with its verbatim reason', () => {
     const decision: DryRunPlatformDecision = {
       platform: 'android',
       isFullCapture: false,
@@ -99,8 +102,8 @@ describe('formatDryRunPreview', () => {
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('Android - would capture 0 of 5 stories');
-    expect(output).toContain('a real run would capture nothing');
+    expect(output).toContain('Android - would capture 0 of 5 stories in this bundle');
+    expect(output).toContain('so all 5 would be reused from the base build');
     expect(output).toContain('captured 0 - no module changes reach any story');
     // A partial-zero is NOT a full capture.
     expect(output).not.toContain('EVERY story');

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -433,3 +433,308 @@ describe('--dry-run', () => {
     logSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Live Diff Scope report (SHERLO-1915): the command EXPLAINS its own decision.
+// ---------------------------------------------------------------------------
+
+describe('live Diff Scope report', () => {
+  const ANDROID_DEVICE = { ...IOS_DEVICE, id: 'test-pixel' };
+
+  /** A module manifest whose story-closure count is `storyCount` (the "M"). */
+  function manifest(storyCount: number): any {
+    const storyClosures: Record<string, unknown> = {};
+    for (let i = 0; i < storyCount; i++) storyClosures[`story-${i}`] = {};
+    return {
+      raw: Buffer.from('{"v":1}'),
+      parsed: { version: 1, header: {}, moduleHashes: {}, storyClosures },
+    };
+  }
+
+  /** Wire up every mock for a live run; per-test overrides refine from here. */
+  function setup({
+    platforms = ['ios'],
+    include,
+    storyCount = 22,
+    openBuildReturn,
+  }: {
+    platforms?: Array<'ios' | 'android'>;
+    include?: string[];
+    storyCount?: number;
+    openBuildReturn: any;
+  }): void {
+    mockGetValidatedCommandParams.mockReturnValue({
+      projectRoot: '/proj',
+      token: 'token-value',
+      devices: platforms.map((p) => (p === 'ios' ? IOS_DEVICE : ANDROID_DEVICE)),
+      wait: false,
+    } as any);
+    mockGetPlatformsToTest.mockReturnValue(platforms as any);
+    mockComputeBaseFingerprint.mockResolvedValue({ hash: 'BASE_FP' } as any);
+    mockCheckStagedGate.mockResolvedValue({ outcome: 'fast', diff: [] });
+    mockBuildBundleForPlatform.mockResolvedValue(
+      bundleResult({ moduleManifest: manifest(storyCount) })
+    );
+    mockBuildGateMetadata.mockResolvedValue({ engineClass: 'hermes' } as any);
+    mockGetTokenParts.mockReturnValue({ apiToken: 'api', projectIndex: 3, teamId: 'team' });
+    mockGetStagedUploadUrls.mockResolvedValue({
+      stagedPresignedUploadUrls: Object.fromEntries(
+        platforms.map((p) => [p, { jsBundle: { s3Key: `js-${p}`, url: `http://s3/${p}` } }])
+      ),
+    });
+    mockUploadStagedArtifacts.mockResolvedValue({ jsBundleS3Key: 'js-key' });
+    mockGetBuildRunConfig.mockReturnValue(
+      Object.fromEntries(platforms.map((p) => [p, { devices: [], s3Key: 'unset' }])) as any
+    );
+    if (include) {
+      mockGetBuildRunConfig.mockReturnValue({
+        include,
+        ...Object.fromEntries(platforms.map((p) => [p, { devices: [], s3Key: 'unset' }])),
+      } as any);
+    }
+    mockGetGitInfo.mockResolvedValue({ commitHash: 'c', branchName: 'b', commitName: 'm' } as any);
+    mockOpenBuild.mockResolvedValue(openBuildReturn);
+    mockGetAppBuildUrl.mockReturnValue('http://app/build');
+    mockPrintResultsUrl.mockImplementation(() => {});
+  }
+
+  function printed(logSpy: ReturnType<typeof vi.spyOn>): string {
+    return logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+  }
+
+  it('renders a partial capture WITH a per-platform reason: fraction, reused side, list, reason', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      storyCount: 22,
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: {
+            isFullCapture: false,
+            platforms: {
+              ios: {
+                reason:
+                  'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx',
+              },
+            },
+          },
+        },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: {
+                full: false,
+                storyFilePaths: [
+                  'src/components/Storefront/Storefront.stories.tsx',
+                  'src/components/Cart/Cart.stories.tsx',
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('📋 Diff Scope - what this run photographed');
+    expect(out).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
+    expect(out).toContain(
+      'Reused the other 20 (already photographed on the base build, not re-shot here).'
+    );
+    expect(out).toContain('Stories captured:');
+    expect(out).toContain('• src/components/Storefront/Storefront.stories.tsx');
+    expect(out).toContain('• src/components/Cart/Cart.stories.tsx');
+    expect(out).toContain(
+      'Reason: captured 2 - closure changed via src/components/Storefront/SharedButton.tsx'
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('renders a full capture, taking the reason from fullCaptureTriggerReason (ladder rung 2)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: { isFullCapture: true, fullCaptureTriggerReason: 'native-changed' },
+        },
+        buildRun: {
+          config: { ios: { devices: [], captureScope: { full: true, storyFilePaths: [] } } },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
+    expect(out).toContain('Reason: native-changed');
+    // Inversion: an empty list on a full capture is "everything", never "nothing".
+    expect(out).not.toContain('captured 0');
+    expect(out).not.toContain('nothing');
+
+    logSpy.mockRestore();
+  });
+
+  it('renders a partial WITHOUT a reason (forward-compat degrade): counts + list, no reason line', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      storyCount: 8,
+      openBuildReturn: {
+        // diffScopeInfo has NO per-platform reason yet (api PR not landed), and this
+        // is not a full capture, so the reason line is omitted entirely.
+        build: { index: 7, diffScopeInfo: { isFullCapture: false } },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - captured 1 of 8 stories in this bundle');
+    expect(out).toContain('• src/x/X.stories.tsx');
+    // The block renders in full; it simply carries no reason line.
+    expect(out).not.toContain('Reason:');
+
+    logSpy.mockRestore();
+  });
+
+  it('prints NOTHING about diff scope when captureScope is absent (Diff Scope v2 off / older API)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      openBuildReturn: {
+        build: { index: 7 },
+        buildRun: { config: { ios: { devices: [] } } }, // no captureScope
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    // Silence is correct: no header, no per-platform block, no assertion of a decision.
+    expect(out).not.toContain('Diff Scope');
+    expect(out).not.toContain('captured');
+
+    logSpy.mockRestore();
+  });
+
+  it('renders a mix: one full platform, one partial platform', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      platforms: ['ios', 'android'],
+      storyCount: 10,
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: {
+            isFullCapture: false,
+            fullCaptureTriggerReason: 'native-changed',
+            platforms: { android: { reason: 'captured 1 - closure changed via src/x.tsx' } },
+          },
+        },
+        buildRun: {
+          config: {
+            ios: { devices: [], captureScope: { full: true, storyFilePaths: [] } },
+            android: {
+              devices: [],
+              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
+    expect(out).toContain('Reason: native-changed');
+    expect(out).toContain('🤖 Android - captured 1 of 10 stories in this bundle');
+    expect(out).toContain('• src/x/X.stories.tsx');
+    expect(out).toContain('Reason: captured 1 - closure changed via src/x.tsx');
+
+    logSpy.mockRestore();
+  });
+
+  // Deliverable 5.1: the fraction is MANIFEST-denominated, so --include never moves
+  // it. Same M, same "2 of 22 in this bundle" label, whether include is unset,
+  // matches a subset, or matches nothing.
+  it.each([
+    ['no --include', undefined],
+    ['--include matching a subset', ['Sanity', 'Storefront']],
+    ['--include matching nothing', ['DoesNotExist']],
+  ])('the fraction is unchanged by %s (tier-1 relabel invariant)', async (_name, include) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      include: include as string[] | undefined,
+      storyCount: 22,
+      openBuildReturn: {
+        build: { index: 7, diffScopeInfo: { isFullCapture: false } },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: {
+                full: false,
+                storyFilePaths: ['src/a/A.stories.tsx', 'src/b/B.stories.tsx'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    // The exact label is pinned so the invariant is stated, not inferred.
+    expect(out).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
+
+    logSpy.mockRestore();
+  });
+
+  // Deliverable 5.2: this task is DISPLAY ONLY. The openBuild request (the decision
+  // inputs) must not move because the response now carries a diff-scope decision.
+  it('does NOT alter the openBuild request or the buildRunConfig when printing the report', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: { isFullCapture: false, platforms: { ios: { reason: 'captured 1 - x' } } },
+        },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const openBuildArg = mockOpenBuild.mock.calls[0][0];
+    // Nothing about the decision inputs moved: no diff-scope field is sent, and the
+    // request carries only the staged wiring it always did.
+    expect('captureScope' in openBuildArg.buildRunConfig.ios).toBe(false);
+    expect('diffScopeInfo' in openBuildArg).toBe(false);
+    expect(openBuildArg.buildRunConfig.ios.s3Key).toBe(ASYNC_UPLOAD_S3_KEY_PLACEHOLDER);
+    expect(openBuildArg.buildRunConfig.ios.jsBundleS3Key).toBe('js-key');
+
+    logSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/testBundled/diffScopeReport.ts
+++ b/packages/cli/src/commands/testBundled/diffScopeReport.ts
@@ -1,0 +1,251 @@
+/**
+ * The ONE Diff Scope report renderer, shared by BOTH the live test:bundled run
+ * and its --dry-run preview (SHERLO-1915).
+ *
+ * A Diff Scope decision photographs only the stories a change can affect and
+ * reuses the base build's photos for the rest. Before this module, the live run
+ * printed NOTHING about that decision and the dry run had its own formatter, so a
+ * developer learned the outcome only from the dashboard. This module renders a
+ * per-platform block that reads IDENTICALLY in both modes except for TENSE: the
+ * dry run says "would capture", the live run says "captured". Tense is a
+ * parameter ({@link CaptureTense}), never a second implementation - two
+ * formatters that can drift is the exact failure this module exists to prevent.
+ *
+ * THE INVERSION HAZARD (read twice): a FULL capture (`full: true`) means EVERY
+ * story was in scope, EVEN THOUGH its captured-file list is empty. Empty-list on
+ * a full capture is "everything", NOT "nothing". {@link formatDiffScopeBlock}
+ * branches on `full` FIRST and never infers "nothing" from an empty list. The
+ * ONLY block that renders as "nothing captured" is a PARTIAL capture whose list
+ * is empty (`full: false`, no paths).
+ *
+ * THE FRACTION NAMES ITS UNIVERSE (tier-1 relabel): "N of M stories in this
+ * bundle". M is the WHOLE bundle's story set, NOT the `--include` scope. The
+ * scope filter runs on-device against story titles; the CLI cannot honestly
+ * scope this count at bundle time, so the wording says "in this bundle" to stop
+ * a developer running `--include ...` from reading M as their scope.
+ *
+ * Server reasons are printed VERBATIM. This module never invents, rewords, or
+ * re-derives a reason; a reason it is not given is simply omitted.
+ */
+import { Platform } from '@sherlo/api-types';
+import { PLATFORM_LABEL } from '../../constants';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The tense the report reads in. The decision is identical in both modes; only
+ * the verbs change. `would-capture` = the dry-run preview ("would capture");
+ * `captured` = the live run ("captured").
+ */
+export type CaptureTense = 'would-capture' | 'captured';
+
+/** Which run is printing. Selects the header/footer and the tense. */
+export type DiffScopeMode = 'dry-run' | 'live';
+
+/**
+ * One platform's Diff Scope outcome, as the report consumes it. Both callers map
+ * their own data into this shape, so the rendering below is the single source of
+ * truth for how a decision reads.
+ */
+export type DiffScopePlatformReport =
+  | {
+      kind: 'decided';
+      platform: Platform;
+      /**
+       * true = EVERY story was in scope (a full capture). The captured-file list
+       * is empty in that case and MUST render as "every story", never "nothing"
+       * (the inversion hazard). false = the partial closure-diff below.
+       */
+      full: boolean;
+      /**
+       * Story SOURCE FILE paths that were captured. Empty on a full capture
+       * (means "everything"); may also be empty on a partial capture that reaches
+       * no story (means "nothing"). Ignored when `full` is true.
+       */
+      capturedStoryFilePaths: string[];
+      /**
+       * M: the total number of stories in THIS bundle (the manifest's story-file
+       * count). Absent when no manifest was produced - the fraction then degrades
+       * to a bare count with no "of M" and no reuse line.
+       */
+      totalStoriesInBundle?: number;
+      /**
+       * The server's reason, printed VERBATIM. Absent -> no reason line (the live
+       * reason ladder can land here; the dry run always carries one).
+       */
+      reason?: string;
+    }
+  | {
+      // Dry-run only: the decision query could not give a trustworthy answer, so
+      // the safe preview is "a real run would capture everything".
+      kind: 'bailed-open';
+      platform: Platform;
+      reason: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** The most story-file paths a block lists before it summarises the remainder. */
+const MAX_LISTED_STORIES = 20;
+
+const HEADER: Record<DiffScopeMode, string> = {
+  'dry-run': '📋 Diff Scope preview - dry run (no build created)',
+  live: '📋 Diff Scope - what this run photographed',
+};
+
+/**
+ * One line, printed once under the header, that introduces the idea before the
+ * per-platform blocks assume it. Someone who has never heard of Diff Scope can
+ * read this and know what will and will not be photographed.
+ */
+const EXPLAINER =
+  "Diff Scope photographs only the stories your changes can affect; the rest reuse the base build's photos.";
+
+/**
+ * Render the whole report: header, explainer, one block per platform, and (dry
+ * run only) a footer stating nothing was created. Returned as a plain string the
+ * caller prints as-is and tests assert on directly.
+ */
+export function formatDiffScopeReport(
+  mode: DiffScopeMode,
+  platforms: DiffScopePlatformReport[]
+): string {
+  const tense: CaptureTense = mode === 'dry-run' ? 'would-capture' : 'captured';
+
+  const lines: string[] = [HEADER[mode], EXPLAINER];
+
+  for (const platform of platforms) {
+    lines.push('');
+    lines.push(
+      ...(platform.kind === 'bailed-open'
+        ? formatBailedOpenBlock(platform.platform, platform.reason)
+        : formatDiffScopeBlock(platform, tense))
+    );
+  }
+
+  if (mode === 'dry-run') {
+    lines.push('');
+    lines.push('This is a preview: no build was created and nothing was uploaded.');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render ONE decided platform block in the given tense. This is the shared core
+ * both modes read identically apart from tense - it takes no header, footer, or
+ * mode, only the decision and the tense.
+ */
+export function formatDiffScopeBlock(
+  block: Extract<DiffScopePlatformReport, { kind: 'decided' }>,
+  tense: CaptureTense
+): string[] {
+  const heading = `${platformEmoji(block.platform)} ${PLATFORM_LABEL[block.platform]}`;
+  const verb = VERBS[tense];
+  const lines: string[] = [];
+
+  // INVERSION GUARD: `full` is checked FIRST. A full capture is "every story",
+  // even with an empty captured-file list - never let the empty list read as
+  // "nothing". Only the partial branch below can render "nothing captured".
+  if (block.full) {
+    lines.push(`${heading} - ${verb.capture} EVERY story in this bundle`);
+    pushReason(lines, block.reason);
+    return lines;
+  }
+
+  const captured = block.capturedStoryFilePaths.length;
+  const total = block.totalStoriesInBundle;
+
+  if (total === undefined) {
+    // No manifest -> no denominator and no honest reuse count. Degrade to a bare
+    // captured count; still list the captured stories and the reason below.
+    lines.push(`${heading} - ${verb.capture} ${captured} ${captured === 1 ? 'story' : 'stories'}`);
+  } else {
+    // The fraction names its universe ("in this bundle") so M is never misread as
+    // the --include scope.
+    lines.push(`${heading} - ${verb.capture} ${captured} of ${total} stories in this bundle`);
+    const reused = total - captured;
+    if (captured === 0) {
+      lines.push(
+        `   Nothing your changes touch reaches a story, so all ${total} ${verb.reusedAll} from the base build.`
+      );
+    } else if (reused > 0) {
+      lines.push(
+        `   ${verb.reuseOther} the other ${reused} (already photographed on the base build, not re-shot here).`
+      );
+    }
+  }
+
+  if (captured > 0) {
+    lines.push(`   ${verb.listLabel}`);
+    for (const line of listStoryFiles(block.capturedStoryFilePaths)) {
+      lines.push(line);
+    }
+  }
+
+  pushReason(lines, block.reason);
+  return lines;
+}
+
+/* ========================================================================== */
+
+/**
+ * Verb forms per tense. This is the ONLY place the two modes diverge - every
+ * other character a block prints is identical.
+ */
+const VERBS: Record<
+  CaptureTense,
+  {
+    capture: string;
+    reuseOther: string;
+    reusedAll: string;
+    listLabel: string;
+  }
+> = {
+  'would-capture': {
+    capture: 'would capture',
+    reuseOther: 'Would reuse',
+    reusedAll: 'would be reused',
+    listLabel: 'Stories to capture:',
+  },
+  captured: {
+    capture: 'captured',
+    reuseOther: 'Reused',
+    reusedAll: 'were reused',
+    listLabel: 'Stories captured:',
+  },
+};
+
+function platformEmoji(platform: Platform): string {
+  return platform === 'android' ? '🤖' : '🍎';
+}
+
+function pushReason(lines: string[], reason: string | undefined): void {
+  // Printed VERBATIM; absent -> no reason line at all.
+  if (reason) lines.push(`   Reason: ${reason}`);
+}
+
+/** The bounded bullet list of captured story files, with an overflow summary. */
+function listStoryFiles(paths: string[]): string[] {
+  const shown = paths.slice(0, MAX_LISTED_STORIES).map((p) => `     • ${p}`);
+  const hidden = paths.length - shown.length;
+  if (hidden > 0) shown.push(`     • ... and ${hidden} more`);
+  return shown;
+}
+
+/**
+ * Dry-run only: the preview could not get a trustworthy answer for this
+ * platform, so it states the safe outcome - a real run would capture everything.
+ * Always future tense; a live run never bails open.
+ */
+function formatBailedOpenBlock(platform: Platform, reason: string): string[] {
+  const heading = `${platformEmoji(platform)} ${PLATFORM_LABEL[platform]}`;
+  return [
+    `${heading} - preview unavailable; a real run would capture EVERY story`,
+    `   Reason: ${reason}`,
+  ];
+}

--- a/packages/cli/src/commands/testBundled/dryRun.ts
+++ b/packages/cli/src/commands/testBundled/dryRun.ts
@@ -26,7 +26,6 @@
  */
 import { Platform } from '@sherlo/api-types';
 import reporting from '../../helpers/reporting';
-import { PLATFORM_LABEL } from '../../constants';
 import type { GitInfo } from '../../helpers/getGitInfo';
 import type { BundleResult } from './buildBundle';
 import {
@@ -35,6 +34,7 @@ import {
   type DryRunPlatformDecision,
   type DryRunPlatformRequest,
 } from './dryRunDecision';
+import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -143,73 +143,31 @@ export default runDryRunPreview;
 // ---------------------------------------------------------------------------
 
 /**
- * Render the whole dry-run preview as a plain-text block (no color - the caller
- * prints it as-is, and tests assert on it directly). Header, one block per
- * platform, then a footer making the read-only nature explicit.
+ * Render the whole dry-run preview by mapping each platform's preview onto the
+ * shared {@link formatDiffScopeReport}. The dry run and the live run print the
+ * SAME per-platform block; only the tense (here: "would capture") and the
+ * preview header/footer differ, and both live in that one shared module.
  */
 export function formatDryRunPreview(previews: DryRunPlatformPreview[]): string {
-  const lines: string[] = [];
+  const platforms: DiffScopePlatformReport[] = previews.map((preview) =>
+    preview.status === 'bailed-open'
+      ? { kind: 'bailed-open', platform: preview.platform, reason: preview.reason }
+      : decisionToReport(preview.decision)
+  );
 
-  lines.push('📋 Diff Scope preview - dry run (no build created)');
-
-  for (const preview of previews) {
-    lines.push('');
-    if (preview.status === 'bailed-open') {
-      lines.push(...formatBailedOpen(preview.platform, preview.reason));
-    } else {
-      lines.push(...formatDecided(preview.decision));
-    }
-  }
-
-  lines.push('');
-  lines.push('This is a preview: no build was created and nothing was uploaded.');
-
-  return lines.join('\n');
+  return formatDiffScopeReport('dry-run', platforms);
 }
 
 /* ========================================================================== */
 
-function formatDecided(decision: DryRunPlatformDecision): string[] {
-  const label = PLATFORM_LABEL[decision.platform];
-  const emoji = decision.platform === 'android' ? '🤖' : '🍎';
-
-  // isFullCapture = "a real run would capture EVERYTHING for this platform".
-  // capturedStoryFilePaths is empty here and must NEVER be rendered as an empty
-  // list / "captures nothing" - that inversion is the single worst misread.
-  if (decision.isFullCapture) {
-    return [`${emoji} ${label} - would capture EVERY story`, `   Reason: ${decision.reason}`];
-  }
-
-  const captured = decision.capturedStoryFilePaths.length;
-  const count =
-    decision.totalStories !== undefined
-      ? `${captured} of ${decision.totalStories} stories`
-      : `${captured} ${captured === 1 ? 'story' : 'stories'}`;
-
-  const lines = [`${emoji} ${label} - would capture ${count}`];
-
-  if (captured > 0) {
-    lines.push('   Story files:');
-    for (const filePath of decision.capturedStoryFilePaths) {
-      lines.push(`     • ${filePath}`);
-    }
-  } else {
-    // A PARTIAL capture that reaches no story genuinely captures nothing (this is
-    // NOT the isFullCapture branch above).
-    lines.push('   No module changes reach any story - a real run would capture nothing.');
-  }
-
-  // Reason is printed VERBATIM (path-legible server string).
-  lines.push(`   Reason: ${decision.reason}`);
-
-  return lines;
-}
-
-function formatBailedOpen(platform: Platform, reason: string): string[] {
-  const label = PLATFORM_LABEL[platform];
-  const emoji = platform === 'android' ? '🤖' : '🍎';
-  return [
-    `${emoji} ${label} - preview unavailable; a real run would capture EVERY story`,
-    `   Reason: ${reason}`,
-  ];
+/** Map a server decision onto the shared per-platform report shape. */
+function decisionToReport(decision: DryRunPlatformDecision): DiffScopePlatformReport {
+  return {
+    kind: 'decided',
+    platform: decision.platform,
+    full: decision.isFullCapture,
+    capturedStoryFilePaths: decision.capturedStoryFilePaths,
+    totalStoriesInBundle: decision.totalStories,
+    reason: decision.reason,
+  };
 }

--- a/packages/cli/src/commands/testBundled/dryRunDecision.ts
+++ b/packages/cli/src/commands/testBundled/dryRunDecision.ts
@@ -31,7 +31,7 @@ import sdkClient from '@sherlo/sdk-client';
 import { Platform } from '@sherlo/api-types';
 import reporting from '../../helpers/reporting';
 import type { GitInfo } from '../../helpers/getGitInfo';
-import type { ValidatedModuleManifest } from './readModuleManifest';
+import { countBundleStories, type ValidatedModuleManifest } from './readModuleManifest';
 
 // ---------------------------------------------------------------------------
 // Contract-mirrored wire types (SHERLO-1895 Phase C)
@@ -209,7 +209,7 @@ export async function requestDryRunDecision(
   const totalByPlatform = new Map<Platform, number>();
   for (const p of input.platforms) {
     if (p.manifest) {
-      totalByPlatform.set(p.platform, Object.keys(p.manifest.parsed.storyClosures).length);
+      totalByPlatform.set(p.platform, countBundleStories(p.manifest));
     }
   }
 

--- a/packages/cli/src/commands/testBundled/readModuleManifest.ts
+++ b/packages/cli/src/commands/testBundled/readModuleManifest.ts
@@ -130,4 +130,20 @@ export function readValidatedModuleManifest(projectRoot: string): ValidatedModul
   };
 }
 
+/**
+ * The number of stories THIS build's manifest carries - the "M" in every Diff
+ * Scope "N of M" fraction. It is the count of story closures the serializer
+ * recorded, keyed by story SOURCE FILE. This is the ONE definition of M; both
+ * the live and dry-run Diff Scope reports (SHERLO-1915) count it through here so
+ * the two modes can never disagree on the denominator.
+ *
+ * Note this counts the WHOLE bundle's story set, NOT the `--include` / `--exclude`
+ * scope: the scope filter runs on-device against story TITLES, while the manifest
+ * is keyed by file paths, so the CLI has no honest way to scope this number at
+ * bundle time. The report wording names the number "in this bundle" to say so.
+ */
+export function countBundleStories(manifest: ValidatedModuleManifest): number {
+  return Object.keys(manifest.parsed.storyClosures).length;
+}
+
 export default readValidatedModuleManifest;

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -46,6 +46,8 @@ import { parseStagedGateRefusal, FALLBACK_LINE, type StagedGateRefusal } from '.
 import { getOnStaleMode, handleStaleBase } from './onStale';
 import uploadStagedArtifacts, { type StagedUploadKeys } from './uploadStagedArtifacts';
 import { runDryRunPreview } from './dryRun';
+import { countBundleStories } from './readModuleManifest';
+import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
 /**
  * The per-platform staged build config plus the SHERLO-1894 `manifestS3Key` the api
@@ -57,6 +59,31 @@ import { runDryRunPreview } from './dryRun';
  * republishes with the field.
  */
 type PlatformConfigWithManifest = { manifestS3Key?: string };
+
+/**
+ * The per-platform Diff Scope decision the server records at openBuild, read
+ * forward-compatibly off the openBuild response (SHERLO-1915). Two fields are
+ * involved and BOTH are declared locally + read defensively, the same pattern as
+ * {@link PlatformConfigWithManifest} and the optional `computeDiffScopeDryRun`
+ * method - the published @sherlo/api-types this repo typechecks against does not
+ * carry them yet, so a cast to `any` is avoided in favour of a precise local
+ * extension. Absent at runtime -> the live report degrades cleanly (see below).
+ *
+ * - `captureScope` on the per-platform buildRun config: the captured set this
+ *   run selected. `full: true` means EVERY story was in scope (an empty
+ *   `storyFilePaths` in that case means "everything", not "nothing"). Absent for
+ *   a platform -> the report says NOTHING about it (the server made no decision).
+ * - `diffScopeInfo.platforms[platform].reason`: the path-legible closure-diff
+ *   string, byte-identical to the dashboard's. The api department selects this in
+ *   a parallel PR; until it lands the field is absent and the reason ladder falls
+ *   through to `fullCaptureTriggerReason` or omits the reason entirely.
+ */
+type CaptureScope = { full: boolean; storyFilePaths?: string[] };
+type PlatformConfigWithCaptureScope = { captureScope?: CaptureScope };
+type DiffScopeInfoWithPlatformReasons = {
+  fullCaptureTriggerReason?: string;
+  platforms?: Partial<Record<Platform, { reason?: string }>>;
+};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -318,6 +345,12 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
 
   printResultsUrl(url);
 
+  // The command now EXPLAINS its own Diff Scope decision (SHERLO-1915): which
+  // stories this run captured, which it reused from the base, and why - read
+  // straight off the openBuild response, no extra API call. Prints nothing for a
+  // platform the server made no decision for (Diff Scope v2 off, or older API).
+  printLiveDiffScopeReport({ openBuildReturn, bundles, platformsToTest });
+
   if (commandParams.wait) {
     const exitCode = await waitForBuildResult({
       token: commandParams.token,
@@ -339,6 +372,85 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
 export default testBundled;
 
 /* ========================================================================== */
+
+/**
+ * Print this run's Diff Scope decision, per platform, straight off the openBuild
+ * response (SHERLO-1915). No extra API call: `captureScope` carries the captured
+ * set and `diffScopeInfo` carries the reason. Renders through the SAME shared
+ * formatter the dry run uses, so the two modes read identically apart from tense.
+ *
+ * A platform the server made no decision for (no `captureScope`) is skipped
+ * entirely - silence, never an invented "captured everything". If NO platform
+ * has a decision, nothing is printed at all.
+ */
+function printLiveDiffScopeReport({
+  openBuildReturn,
+  bundles,
+  platformsToTest,
+}: {
+  openBuildReturn: Awaited<ReturnType<ReturnType<typeof sdkClient>['openBuild']>>;
+  bundles: Partial<Record<Platform, BundleResult>>;
+  platformsToTest: Platform[];
+}): void {
+  const diffScopeInfo = openBuildReturn.build.diffScopeInfo as
+    | DiffScopeInfoWithPlatformReasons
+    | undefined;
+
+  const platforms: DiffScopePlatformReport[] = [];
+  for (const platform of platformsToTest) {
+    const platformConfig = openBuildReturn.buildRun?.config?.[platform] as
+      | PlatformConfigWithCaptureScope
+      | undefined;
+    const captureScope = platformConfig?.captureScope;
+
+    // No decision recorded for this platform -> stay silent. Asserting "captured
+    // everything" here would claim a decision the server never made.
+    if (!captureScope) continue;
+
+    const manifest = bundles[platform]?.moduleManifest;
+    platforms.push({
+      kind: 'decided',
+      platform,
+      // INVERSION GUARD: full === true is "every story", regardless of the list.
+      full: captureScope.full,
+      // A full capture selects everything; its per-story list is not meaningful.
+      capturedStoryFilePaths: captureScope.full ? [] : captureScope.storyFilePaths ?? [],
+      // M is the whole bundle's story set, counted the ONE canonical way.
+      totalStoriesInBundle: manifest ? countBundleStories(manifest) : undefined,
+      reason: resolveLiveReason({ platform, full: captureScope.full, diffScopeInfo }),
+    });
+  }
+
+  if (platforms.length === 0) return;
+
+  console.log('\n' + formatDiffScopeReport('live', platforms));
+}
+
+/**
+ * The reason ladder, in strict order (SHERLO-1915). The reason is byte-identical
+ * to the persisted server decision or absent - never CLI-invented:
+ *   1. the per-platform closure-diff reason, when present -> verbatim;
+ *   2. else, on a FULL capture only, the build-wide fullCaptureTriggerReason;
+ *   3. else -> omitted.
+ */
+function resolveLiveReason({
+  platform,
+  full,
+  diffScopeInfo,
+}: {
+  platform: Platform;
+  full: boolean;
+  diffScopeInfo: DiffScopeInfoWithPlatformReasons | undefined;
+}): string | undefined {
+  const perPlatformReason = diffScopeInfo?.platforms?.[platform]?.reason;
+  if (perPlatformReason) return perPlatformReason;
+
+  if (full && diffScopeInfo?.fullCaptureTriggerReason) {
+    return diffScopeInfo.fullCaptureTriggerReason;
+  }
+
+  return undefined;
+}
 
 function parseWaitTimeout(raw: string | undefined): number | undefined {
   if (!raw) return undefined;


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1915

## What this does

`test:bundled` now EXPLAINS its Diff Scope decision in its own stdout, on LIVE runs and on `--dry-run`. Before this, a developer learned the capture decision only from the dashboard or the API record - the command that triggered the decision never stated it.

Live output for a partial capture (verbatim, produced by running the formatter):

```
📋 Diff Scope - what this run photographed
Diff Scope photographs only the stories your changes can affect; the rest reuse the base build's photos.

🍎 iOS - captured 2 of 22 stories in this bundle
   Reused the other 20 (already photographed on the base build, not re-shot here).
   Stories captured:
     • src/components/Storefront/Card.stories.tsx
     • src/components/Storefront/Banner.stories.tsx
   Reason: captured 2 - closure changed via src/components/Storefront/SharedButton.tsx
```

The dry run prints the same block in future tense (`would capture` / `Would reuse` / `Stories to capture:`) plus the existing preview header and footer. A zero-capture partial reads `captured 0 of 22 stories in this bundle` followed by `Nothing your changes touch reaches a story, so all 22 were reused from the base build.`

## How

**ONE shared formatter.** `diffScopeReport.ts` renders the per-platform block; both the live path and the dry-run path call it. Tense is a parameter, not a second implementation - a test asserts the two modes are character-identical once tense words are normalised, plus a sanity check that the tense genuinely changed something. Two formatters that can drift is the failure this ticket exists to prevent.

**Live data comes off the openBuild response, no extra API call.** `buildRun.config[platform].captureScope` carries the captured set; `build.diffScopeInfo` carries the reason.

**The reason ladder is strict and never CLI-invented:**
1. `diffScopeInfo.platforms[platform].reason` when present, printed verbatim;
2. else, on a FULL capture only, `fullCaptureTriggerReason`;
3. else the reason line is omitted entirely.

A reason is byte-identical to the persisted server decision or absent. A CLI-computed reason that disagreed with the dashboard would be worse than no reason.

**A platform with no `captureScope` prints nothing at all.** Silence is correct - asserting "captured everything" would claim a decision the server never made.

**Reused count is derived locally as M minus N.** `capturedSnapshotCount` / `inheritedSnapshotCount` exist on `diffScopeInfo` but are filled at closeBuild, so they are absent at openBuild time. M is the manifest story-closure count, now behind a single `countBundleStories()` so live and dry-run can never disagree on the denominator.

## Tier 1, as ruled

The `N of M` fraction is RELABELLED to name its universe (`N of M stories in this bundle`), not made scope-aware. The scope filter runs on-device against story TITLES while the manifest is keyed by source FILE PATHS, so the CLI cannot honestly compute a scope-filtered fraction at bundle time. Tier 2 (story-title metadata in the manifest, plus a picomatch matcher shared with the runner) would touch 3-4 repos and the versioned ancestor-compared manifest schema; it stays parked in the ticket body.

A test pins the invariant directly: the fraction is unchanged by `--include` unset, `--include` matching a subset, and `--include` matching nothing. The invariant is stated, not inferred.

## Companion API change

sherlo-api PR #295 adds `platforms { isFullCapture reason capturedStoryFilePaths }` to `BuildFragment.diffScopeInfo`. The SDL already exposed it; only the client selection was missing, and GraphQL returns only what the fragment selects.

The CLI here reads that field forward-compatibly - present, it is used; absent, the ladder falls through. So this PR is not blocked on that one.

## RELEASE TAIL - read this before calling a missing reason a bug

The CLI gains the live per-platform `reason` only after `@sherlo/sdk-client` (and its `@sherlo/common-client` dependency, which holds BuildFragment) is republished with PR #295 and the CLI is rebuilt against it.

That npm republish is **NOT automatic on merge to `dev`**. It happens only via a manual `release_to_prod` `workflow_dispatch` run with a non-empty `PACKAGE_VERSION` input, publishing to the npm `latest` dist-tag. Merging to `dev` only drops a private S3 tarball under `sherlo-packages/dev/`.

Until that republish-and-rebuild lands, an older CLI pinned to a pre-1915 sdk-client shows no per-platform reason on a PARTIAL capture. That absence is expected, not a regression.

## Deliberate tension, flagged rather than silently resolved

The AC asks for PM-readable wording AND for the reason to be byte-consistent with the dashboard. On a full capture that reason is a machine rung code such as `native-changed`. It is printed VERBATIM: the ticket is explicit that reasons are never re-rendered, and the e2e asserts them verbatim, so prose-ifying it would break byte-consistency. The surrounding prose carries the PM-readability instead.

## Testing

- 527 CLI tests pass. New `diffScopeReport.test.ts` covers the inversion pin (a FULL capture with an empty list renders "EVERY story", never "nothing"), the reused side, the no-manifest degrade, the omitted-reason rung, list bounding, tense parity, and the mixed full/partial case.
- `testBundled.test.ts` adds the live-output cases (full, partial with reason, partial without reason, `captureScope` absent, mixed platforms), the `--include` invariant, and a display-only pin asserting the openBuild request and `buildRunConfig` did not move.

## Known-unrelated failures, verified not caused by this change

- `packagedFingerprint.test.ts` fails because it shells out to a real `ncc` build, which fails on 4 PRE-EXISTING `@sherlo/api-types` symbol-skew errors (`bundleFormat`, `GateDerivation`) in `stagedGateRefusal.ts`, `stagedGate.ts`, and `gateMetadata.ts` - all files untouched here. `npx tsc --noEmit` returns exactly those 4 and ZERO in the 8 files this PR touches. Root cause is the gitignored, locally-generated `sherlo-lib/` vendor tarballs lagging CLI source; it is a local-checkout condition, not a `dev` break.
- The pre-push gate reported `spawn /bin/sh ENOENT` for this repo, which is a harness environment error rather than a test result.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
