### PR TITLE
feat: test:bundled diff-scope output polish (operator direction):…

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
@@ -55,7 +55,7 @@ describe('approved output (verbatim)', () => {
     expect(out).toBe(
       [
         '📸 Capture plan',
-        '  🤖 Android - capturing 1 of 22 stories, reusing 21 from the previous build',
+        '  🤖 Android - capturing 1 of 22 stories in this bundle, reusing 21 from the previous build',
         '     why: Sanity/Hello.stories.tsx changed',
         '     stories:',
         '       • Sanity/Hello',
@@ -84,7 +84,7 @@ describe('approved output (verbatim)', () => {
     expect(out).toBe(
       [
         '📸 Capture plan',
-        '  🤖 Android - capturing 6 of 22 stories, reusing 16 from the previous build',
+        '  🤖 Android - capturing 6 of 22 stories in this bundle, reusing 16 from the previous build',
         '     why: SharedButton.tsx changed',
         '     stories:',
         '       • Storefront/CheckoutScreen',
@@ -158,9 +158,9 @@ describe('approved output (verbatim)', () => {
     expect(out).toBe(
       [
         '📸 Capture plan',
-        '  🤖 Android - capturing all 22 stories',
+        '  🤖 Android - capturing all 22 stories in this bundle',
         '     why: first build - nothing to compare against yet',
-        '  🍎 iOS - capturing all 22 stories',
+        '  🍎 iOS - capturing all 22 stories in this bundle',
         '     why: native code changed - everything re-shot',
       ].join('\n')
     );
@@ -187,7 +187,7 @@ describe('approved output (verbatim)', () => {
     expect(out).toBe(
       [
         '📸 Capture plan',
-        '  🍎 iOS - capturing 1 of 22 stories, reusing 21 from the previous build',
+        '  🍎 iOS - capturing 1 of 22 stories in this bundle, reusing 21 from the previous build',
         '     why: ProductCardPlatformNote.ios.tsx changed',
         '     stories:',
         '       • Storefront/ProductCard',
@@ -211,7 +211,7 @@ describe('approved output (verbatim)', () => {
     expect(out).toBe(
       [
         '📸 Capture plan',
-        '  🤖 Android - capturing all 22 stories',
+        '  🤖 Android - capturing all 22 stories in this bundle',
         "     ! couldn't compute what changed - capturing everything to be safe",
       ].join('\n')
     );
@@ -243,7 +243,9 @@ describe('formatDiffScopeBlock', () => {
 
     const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toBe(['  🍎 iOS - capturing all 12 stories', '     why: main-branch'].join('\n'));
+    expect(out).toBe(
+      ['  🍎 iOS - capturing all 12 stories in this bundle', '     why: main-branch'].join('\n')
+    );
     // None of the "nothing" / partial renderings may leak.
     expect(out).not.toContain('nothing');
     expect(out).not.toContain('capturing 0');
@@ -309,11 +311,36 @@ describe('formatDiffScopeBlock', () => {
 
     expect(out).toBe(
       [
-        '  🤖 Android - capturing all 1 story',
+        '  🤖 Android - capturing all 1 story in this bundle',
         '     why: first build - nothing to compare against yet',
       ].join('\n')
     );
     expect(out).not.toContain('all 1 stories');
+  });
+
+  it('EMPTY MANIFEST at M === 0: a full capture reads "capturing all 0 stories in this bundle"', () => {
+    // M = 0 is a real, reachable edge: readValidatedModuleManifest accepts an empty
+    // storyClosures object, so countBundleStories returns 0. A full capture then
+    // still renders through the M !== undefined branch - "all 0 stories in this
+    // bundle" (plural at 0), NOT the no-manifest "all stories" degrade.
+    const block = decided({
+      platform: 'android',
+      full: true,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 0,
+      reason: 'first build - nothing to compare against yet',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toBe(
+      [
+        '  🤖 Android - capturing all 0 stories in this bundle',
+        '     why: first build - nothing to compare against yet',
+      ].join('\n')
+    );
+    // M is present (0), so it must NOT fall through to the bare "all stories" degrade.
+    expect(out).not.toContain('capturing all stories');
   });
 
   it('SINGULAR at M === 1: a zero-capture reads "all 1 story reused", not "all 1 stories reused"', () => {
@@ -349,7 +376,7 @@ describe('formatDiffScopeBlock', () => {
 
     expect(out).toBe(
       [
-        '  🤖 Android - capturing 1 of 1 stories',
+        '  🤖 Android - capturing 1 of 1 stories in this bundle',
         '     why: Sanity/Hello.stories.tsx changed',
         '     stories:',
         '       • Sanity/Hello',
@@ -387,7 +414,7 @@ describe('formatDiffScopeBlock', () => {
 
     expect(out).toBe(
       [
-        '  🍎 iOS - capturing 1 of 4 stories, reusing 3 from the previous build',
+        '  🍎 iOS - capturing 1 of 4 stories in this bundle, reusing 3 from the previous build',
         '     stories:',
         '       • A/A',
       ].join('\n')

--- a/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/diffScopeReport.test.ts
@@ -1,16 +1,22 @@
 /**
- * Tests for the shared Diff Scope report renderer (SHERLO-1915).
+ * Tests for the shared "Capture plan" renderer (SHERLO-1919).
  *
  * This is the ONE formatter both the live run and the --dry-run preview print
  * through, so the assertions here are the load-bearing ones:
+ *   - every approved output case (1, 2, 2b tiers, 3, 4, 5, 7) renders VERBATIM;
  *   - the inversion pin: a FULL capture with an EMPTY captured-file list renders
- *     as "EVERY story", NEVER "nothing" (Deliverable 3);
- *   - tense parity: the live and dry-run blocks are byte-identical once the tense
- *     words are normalised, asserted DIRECTLY against the formatter rather than by
- *     eyeballing two snapshots (Deliverable 5.5);
- *   - the reused side and the "N of M stories in this bundle" relabel that names
- *     the fraction's universe (Deliverable 4).
+ *     as "all N stories", NEVER "nothing";
+ *   - tense parity: the live and dry-run blocks are byte-identical once the
+ *     capture verb is normalised - asserted DIRECTLY against the formatter;
+ *   - the "N of M stories" fraction is manifest-denominated;
+ *   - the no-manifest degrade drops "of M" and the reuse clause.
+ *
+ * chalk is forced off so the assertions compare against the exact plain text the
+ * e2e suite (which also runs chalk-disabled) parses.
  */
+import chalk from 'chalk';
+chalk.level = 0;
+
 import { describe, expect, it } from 'vitest';
 import {
   formatDiffScopeBlock,
@@ -18,9 +24,7 @@ import {
   type DiffScopePlatformReport,
 } from '../diffScopeReport';
 
-type DecidedBlock = Extract<DiffScopePlatformReport, { kind: 'decided' }>;
-
-function decided(overrides: Partial<DecidedBlock> = {}): DecidedBlock {
+function decided(overrides: Partial<DiffScopePlatformReport> = {}): DiffScopePlatformReport {
   return {
     kind: 'decided',
     platform: 'ios',
@@ -33,40 +37,200 @@ function decided(overrides: Partial<DecidedBlock> = {}): DecidedBlock {
 }
 
 // ---------------------------------------------------------------------------
+// The approved output cases, rendered VERBATIM (SHERLO-1919 spec)
+// ---------------------------------------------------------------------------
+
+describe('approved output (verbatim)', () => {
+  it('Case 1: partial capture - one story', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: ['src/components/Sanity/Hello.stories.tsx'],
+        totalStoriesInBundle: 22,
+        reason: 'Sanity/Hello.stories.tsx changed',
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🤖 Android - capturing 1 of 22 stories, reusing 21 from the previous build',
+        '     why: Sanity/Hello.stories.tsx changed',
+        '     stories:',
+        '       • Sanity/Hello',
+      ].join('\n')
+    );
+  });
+
+  it('Case 2: shared file, several stories', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: [
+          'src/components/Storefront/CheckoutScreen.stories.tsx',
+          'src/components/Storefront/PriceTag.stories.tsx',
+          'src/components/Storefront/PriceTagInline.stories.tsx',
+          'src/components/Storefront/ProductCard.stories.tsx',
+          'src/components/Storefront/ProductCardCompact.stories.tsx',
+          'src/components/Storefront/SharedButton.stories.tsx',
+        ],
+        totalStoriesInBundle: 22,
+        reason: 'SharedButton.tsx changed',
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🤖 Android - capturing 6 of 22 stories, reusing 16 from the previous build',
+        '     why: SharedButton.tsx changed',
+        '     stories:',
+        '       • Storefront/CheckoutScreen',
+        '       • Storefront/PriceTag',
+        '       • Storefront/PriceTagInline',
+        '       • Storefront/ProductCard',
+        '       • Storefront/ProductCardCompact',
+        '       • Storefront/SharedButton',
+      ].join('\n')
+    );
+  });
+
+  // Case 2b: the why-line is SERVER-composed and printed VERBATIM after "why: ".
+  // The CLI does not compose the tier wording - it passes whatever it is given
+  // straight through, so both tiers below are a pure pass-through assertion.
+  it.each([
+    ['3-file tier', '3 files changed - SharedButton.tsx, theme.ts, Hello.stories.tsx'],
+    ['many-file tier', '14 files changed'],
+  ])('Case 2b: the why-line is passed through verbatim (%s)', (_name, reason) => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: ['src/components/Storefront/ProductCard.stories.tsx'],
+        totalStoriesInBundle: 22,
+        reason,
+      }),
+    ]);
+
+    expect(out).toContain(`     why: ${reason}`);
+  });
+
+  it('Case 3: nothing to capture', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: 'no change reaches any story',
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🤖 Android - nothing to capture - no change reaches any story',
+        '     ✓ all 22 stories reused from the previous build',
+      ].join('\n')
+    );
+  });
+
+  it('Case 4: full capture, both platforms', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: true,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: 'first build - nothing to compare against yet',
+      }),
+      decided({
+        platform: 'ios',
+        full: true,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: 'native code changed - everything re-shot',
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🤖 Android - capturing all 22 stories',
+        '     why: first build - nothing to compare against yet',
+        '  🍎 iOS - capturing all 22 stories',
+        '     why: native code changed - everything re-shot',
+      ].join('\n')
+    );
+  });
+
+  it('Case 5: platforms disagree (one partial, one nothing)', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'ios',
+        full: false,
+        capturedStoryFilePaths: ['src/components/Storefront/ProductCard.stories.tsx'],
+        totalStoriesInBundle: 22,
+        reason: 'ProductCardPlatformNote.ios.tsx changed',
+      }),
+      decided({
+        platform: 'android',
+        full: false,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: 'the change never reaches the Android app',
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🍎 iOS - capturing 1 of 22 stories, reusing 21 from the previous build',
+        '     why: ProductCardPlatformNote.ios.tsx changed',
+        '     stories:',
+        '       • Storefront/ProductCard',
+        '  🤖 Android - nothing to capture - the change never reaches the Android app',
+        '     ✓ all 22 stories reused from the previous build',
+      ].join('\n')
+    );
+  });
+
+  it('Case 7: decision unavailable - full capture with no reason (degraded / older server)', () => {
+    const out = formatDiffScopeReport('live', [
+      decided({
+        platform: 'android',
+        full: true,
+        capturedStoryFilePaths: [],
+        totalStoriesInBundle: 22,
+        reason: undefined,
+      }),
+    ]);
+
+    expect(out).toBe(
+      [
+        '📸 Capture plan',
+        '  🤖 Android - capturing all 22 stories',
+        "     ! couldn't compute what changed - capturing everything to be safe",
+      ].join('\n')
+    );
+  });
+
+  it('the dry-run header appends " (dry run)"', () => {
+    const out = formatDiffScopeReport('dry-run', [
+      decided({ platform: 'android', full: true, totalStoriesInBundle: 3, reason: 'x' }),
+    ]);
+    expect(out.split('\n')[0]).toBe('📸 Capture plan (dry run)');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // formatDiffScopeBlock - the shared per-platform core
 // ---------------------------------------------------------------------------
 
 describe('formatDiffScopeBlock', () => {
-  it('renders a partial capture with its fraction, reused side, story list, and verbatim reason', () => {
-    const block = decided({
-      platform: 'ios',
-      full: false,
-      capturedStoryFilePaths: [
-        'src/components/Storefront/Storefront.stories.tsx',
-        'src/components/Cart/Cart.stories.tsx',
-      ],
-      totalStoriesInBundle: 22,
-      reason: 'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx',
-    });
-
-    const live = formatDiffScopeBlock(block, 'captured').join('\n');
-
-    // The fraction NAMES ITS UNIVERSE - "in this bundle", not the --include scope.
-    expect(live).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
-    // Reused = M - N = 20, shown as its own line.
-    expect(live).toContain(
-      'Reused the other 20 (already photographed on the base build, not re-shot here).'
-    );
-    expect(live).toContain('Stories captured:');
-    expect(live).toContain('• src/components/Storefront/Storefront.stories.tsx');
-    expect(live).toContain('• src/components/Cart/Cart.stories.tsx');
-    // Reason is byte-for-byte the server string.
-    expect(live).toContain(
-      'Reason: captured 2 - closure changed via src/components/Storefront/SharedButton.tsx'
-    );
-  });
-
-  it('THE INVERSION PIN: a FULL capture with an EMPTY list renders "EVERY story", never "nothing"', () => {
+  it('THE INVERSION PIN: a FULL capture with an EMPTY list renders "all N stories", never "nothing"', () => {
     // full: true is "everything"; the empty capturedStoryFilePaths must never be
     // read as "nothing" - the single worst misread this formatter guards.
     const block = decided({
@@ -77,114 +241,224 @@ describe('formatDiffScopeBlock', () => {
       reason: 'main-branch',
     });
 
-    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
-    expect(out).toContain('Reason: main-branch');
+    expect(out).toBe(['  🍎 iOS - capturing all 12 stories', '     why: main-branch'].join('\n'));
     // None of the "nothing" / partial renderings may leak.
     expect(out).not.toContain('nothing');
-    expect(out).not.toContain('captured 0');
-    expect(out).not.toContain('Stories captured:');
-    expect(out).not.toContain('Reused');
+    expect(out).not.toContain('capturing 0');
+    expect(out).not.toContain('stories:');
+    expect(out).not.toContain('reusing');
   });
 
-  it('renders a PARTIAL zero-capture as "nothing captured" with the whole bundle reused', () => {
+  it('renders a PARTIAL zero-capture as "nothing to capture" with the whole bundle reused', () => {
     const block = decided({
       platform: 'android',
       full: false,
       capturedStoryFilePaths: [],
       totalStoriesInBundle: 22,
-      reason: 'captured 0 - no module changes reach any story',
+      reason: 'no change reaches any story',
     });
 
-    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toContain('🤖 Android - captured 0 of 22 stories in this bundle');
-    expect(out).toContain(
-      'Nothing your changes touch reaches a story, so all 22 were reused from the base build.'
+    expect(out).toBe(
+      [
+        '  🤖 Android - nothing to capture - no change reaches any story',
+        '     ✓ all 22 stories reused from the previous build',
+      ].join('\n')
     );
-    expect(out).toContain('Reason: captured 0 - no module changes reach any story');
-    // A partial-zero is NOT a full capture.
-    expect(out).not.toContain('EVERY story');
-    expect(out).not.toContain('Stories captured:');
+    // A partial-zero is NOT a full capture and never lists stories.
+    expect(out).not.toContain('capturing');
+    expect(out).not.toContain('stories:');
   });
 
-  it('degrades to a bare count (no "of M", no reused line) when the bundle has no manifest', () => {
+  it('degrades to a bare count (no "of M", no reuse clause) when the bundle has no manifest', () => {
     const block = decided({
       platform: 'ios',
       full: false,
-      capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+      capturedStoryFilePaths: ['src/components/A/A.stories.tsx'],
       totalStoriesInBundle: undefined,
-      reason: 'captured 1 - closure changed via src/a/a.ts',
+      reason: 'a.ts changed',
     });
 
-    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toContain('🍎 iOS - captured 1 story');
+    expect(out).toBe(
+      [
+        '  🍎 iOS - capturing 1 story',
+        '     why: a.ts changed',
+        '     stories:',
+        '       • A/A',
+      ].join('\n')
+    );
     expect(out).not.toContain(' of ');
-    expect(out).not.toContain('Reused');
-    expect(out).toContain('• src/a/A.stories.tsx');
+    expect(out).not.toContain('reusing');
   });
 
-  it('omits the reason line entirely when no reason is given (live ladder rung 3)', () => {
+  it('SINGULAR at M === 1: a full capture reads "all 1 story", not "all 1 stories"', () => {
+    const block = decided({
+      platform: 'android',
+      full: true,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 1,
+      reason: 'first build - nothing to compare against yet',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toBe(
+      [
+        '  🤖 Android - capturing all 1 story',
+        '     why: first build - nothing to compare against yet',
+      ].join('\n')
+    );
+    expect(out).not.toContain('all 1 stories');
+  });
+
+  it('SINGULAR at M === 1: a zero-capture reads "all 1 story reused", not "all 1 stories reused"', () => {
+    const block = decided({
+      platform: 'android',
+      full: false,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 1,
+      reason: 'no change reaches any story',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toBe(
+      [
+        '  🤖 Android - nothing to capture - no change reaches any story',
+        '     ✓ all 1 story reused from the previous build',
+      ].join('\n')
+    );
+    expect(out).not.toContain('all 1 stories');
+  });
+
+  it('drops the "reusing 0" clause when nothing is reused (partial 1 of 1)', () => {
+    const block = decided({
+      platform: 'android',
+      full: false,
+      capturedStoryFilePaths: ['src/components/Sanity/Hello.stories.tsx'],
+      totalStoriesInBundle: 1,
+      reason: 'Sanity/Hello.stories.tsx changed',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toBe(
+      [
+        '  🤖 Android - capturing 1 of 1 stories',
+        '     why: Sanity/Hello.stories.tsx changed',
+        '     stories:',
+        '       • Sanity/Hello',
+      ].join('\n')
+    );
+    // The meaningless "nothing happened" clause must not appear.
+    expect(out).not.toContain('reusing');
+    expect(out).not.toContain('reusing 0');
+  });
+
+  it('a full capture with no manifest degrades to "all stories" (no number)', () => {
+    const block = decided({
+      platform: 'ios',
+      full: true,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: undefined,
+      reason: 'native-changed',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toBe(['  🍎 iOS - capturing all stories', '     why: native-changed'].join('\n'));
+  });
+
+  it('omits the why line entirely on a partial when no reason is given', () => {
     const block = decided({
       platform: 'ios',
       full: false,
-      capturedStoryFilePaths: ['src/a/A.stories.tsx'],
+      capturedStoryFilePaths: ['src/components/A/A.stories.tsx'],
       totalStoriesInBundle: 4,
       reason: undefined,
     });
 
-    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toContain('captured 1 of 4 stories in this bundle');
-    expect(out).not.toContain('Reason:');
+    expect(out).toBe(
+      [
+        '  🍎 iOS - capturing 1 of 4 stories, reusing 3 from the previous build',
+        '     stories:',
+        '       • A/A',
+      ].join('\n')
+    );
+    expect(out).not.toContain('why:');
   });
 
-  it('bounds the story list and summarises the remainder', () => {
-    const paths = Array.from({ length: 25 }, (_, i) => `src/s${i}/S${i}.stories.tsx`);
+  it('lists the FULL story set with no "+N more" truncation (MAX_LISTED_STORIES deleted)', () => {
+    const paths = Array.from({ length: 25 }, (_, i) => `src/components/g${i}/S${i}.stories.tsx`);
     const block = decided({
       platform: 'ios',
       full: false,
       capturedStoryFilePaths: paths,
       totalStoriesInBundle: 30,
-      reason: 'captured 25 - many changed',
+      reason: 'many changed',
     });
 
-    const out = formatDiffScopeBlock(block, 'captured').join('\n');
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
 
-    expect(out).toContain('• src/s0/S0.stories.tsx');
-    expect(out).toContain('• src/s19/S19.stories.tsx');
-    // Path 20 (the 21st) is past the cap of 20.
-    expect(out).not.toContain('• src/s20/S20.stories.tsx');
-    expect(out).toContain('• ... and 5 more');
+    // Every path is listed - including the 21st and beyond, which the old
+    // renderer would have summarised as "... and N more".
+    expect(out).toContain('       • g0/S0');
+    expect(out).toContain('       • g20/S20');
+    expect(out).toContain('       • g24/S24');
+    expect(out).not.toContain('more');
+    // 25 bullets present.
+    expect(out.split('\n').filter((l) => l.includes('• g')).length).toBe(25);
+  });
+
+  it('cleans story paths to "group/name", dropping the src/... prefix and .stories.<ext> suffix', () => {
+    const block = decided({
+      platform: 'ios',
+      full: false,
+      capturedStoryFilePaths: [
+        'src/components/Storefront/ProductCard.stories.tsx',
+        'src/features/checkout/components/Cart/Cart.stories.jsx',
+        'packages/ui/src/Sanity/Hello.stories.ts',
+      ],
+      totalStoriesInBundle: 10,
+      reason: 'x changed',
+    });
+
+    const out = formatDiffScopeBlock(block, 'capturing').join('\n');
+
+    expect(out).toContain('       • Storefront/ProductCard');
+    expect(out).toContain('       • Cart/Cart');
+    expect(out).toContain('       • Sanity/Hello');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tense parity - live and dry-run read identically apart from tense
+// Tense parity - live and dry-run read identically apart from the capture verb
 // ---------------------------------------------------------------------------
 
-describe('tense parity (Deliverable 5.5)', () => {
-  /** Rewrite a would-capture block into its captured form using ONLY tense words. */
-  function normaliseTense(wouldLines: string[]): string[] {
-    return wouldLines.map((line) =>
-      line
-        .replace('would capture', 'captured')
-        .replace('Would reuse', 'Reused')
-        .replace('would be reused', 'were reused')
-        .replace('Stories to capture:', 'Stories captured:')
-    );
+describe('tense parity', () => {
+  /** Rewrite a would-capture block into its capturing form using ONLY the verb. */
+  function normaliseVerb(wouldLines: string[]): string[] {
+    return wouldLines.map((line) => line.replace('would capture', 'capturing'));
   }
 
-  const cases: Array<[string, DecidedBlock]> = [
+  const cases: Array<[string, DiffScopePlatformReport]> = [
     [
       'partial with captures',
       decided({
         full: false,
-        capturedStoryFilePaths: ['src/a/A.stories.tsx', 'src/b/B.stories.tsx'],
+        capturedStoryFilePaths: [
+          'src/components/a/A.stories.tsx',
+          'src/components/b/B.stories.tsx',
+        ],
         totalStoriesInBundle: 22,
-        reason: 'captured 2 - closure changed via src/a/a.ts',
+        reason: 'a.ts changed',
       }),
     ],
     [
@@ -193,89 +467,52 @@ describe('tense parity (Deliverable 5.5)', () => {
         full: false,
         capturedStoryFilePaths: [],
         totalStoriesInBundle: 22,
-        reason: 'captured 0',
+        reason: 'no change reaches any story',
       }),
     ],
-    ['full capture', decided({ full: true, capturedStoryFilePaths: [], reason: 'main-branch' })],
+    ['full capture', decided({ full: true, totalStoriesInBundle: 12, reason: 'main-branch' })],
+    ['full capture, no reason', decided({ full: true, totalStoriesInBundle: 12 })],
     [
       'no-manifest degrade',
       decided({
         full: false,
-        capturedStoryFilePaths: ['src/a/A.stories.tsx'],
-        reason: 'captured 1',
+        capturedStoryFilePaths: ['src/components/a/A.stories.tsx'],
+        reason: 'x',
       }),
     ],
   ];
 
-  it.each(cases)('%s reads identically once tense is normalised', (_name, block) => {
+  it.each(cases)('%s reads identically once the verb is normalised', (_name, block) => {
     const would = formatDiffScopeBlock(block, 'would-capture');
-    const captured = formatDiffScopeBlock(block, 'captured');
+    const capturing = formatDiffScopeBlock(block, 'capturing');
 
-    // The ONLY difference between the two tenses is the tense words themselves.
-    expect(normaliseTense(would)).toEqual(captured);
-    // Sanity: the tense genuinely changed the raw text (nothing is a no-op).
-    expect(would.join('\n')).not.toEqual(captured.join('\n'));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// formatDiffScopeReport - headers, footer, mode -> tense
-// ---------------------------------------------------------------------------
-
-describe('formatDiffScopeReport', () => {
-  const partial: DiffScopePlatformReport = decided({
-    platform: 'ios',
-    full: false,
-    capturedStoryFilePaths: ['src/a/A.stories.tsx'],
-    totalStoriesInBundle: 4,
-    reason: 'captured 1 - closure changed via src/a/a.ts',
+    // The ONLY difference between the two tenses is the capture verb.
+    expect(normaliseVerb(would)).toEqual(capturing);
   });
 
-  it('dry-run mode uses the preview header/footer and the "would capture" tense', () => {
-    const out = formatDiffScopeReport('dry-run', [partial]);
-
-    expect(out).toContain('📋 Diff Scope preview - dry run (no build created)');
-    expect(out).toContain('iOS - would capture 1 of 4 stories in this bundle');
-    expect(out).toContain('This is a preview: no build was created and nothing was uploaded.');
+  it('the capture verb genuinely changes a capturing block (nothing is a no-op)', () => {
+    const block = decided({
+      full: false,
+      capturedStoryFilePaths: ['src/components/a/A.stories.tsx'],
+      totalStoriesInBundle: 22,
+      reason: 'a.ts changed',
+    });
+    expect(formatDiffScopeBlock(block, 'would-capture').join('\n')).not.toEqual(
+      formatDiffScopeBlock(block, 'capturing').join('\n')
+    );
   });
 
-  it('live mode uses the live header (no preview footer) and the "captured" tense', () => {
-    const out = formatDiffScopeReport('live', [partial]);
-
-    expect(out).toContain('📋 Diff Scope - what this run photographed');
-    expect(out).toContain('iOS - captured 1 of 4 stories in this bundle');
-    expect(out).not.toContain('This is a preview');
-  });
-
-  it('renders a mix of one full and one partial platform', () => {
-    const out = formatDiffScopeReport('live', [
-      decided({
-        platform: 'ios',
-        full: true,
-        capturedStoryFilePaths: [],
-        reason: 'native-changed',
-      }),
-      decided({
-        platform: 'android',
-        full: false,
-        capturedStoryFilePaths: ['src/x/X.stories.tsx'],
-        totalStoriesInBundle: 8,
-        reason: 'captured 1 - closure changed via src/x.tsx',
-      }),
-    ]);
-
-    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
-    expect(out).toContain('Reason: native-changed');
-    expect(out).toContain('🤖 Android - captured 1 of 8 stories in this bundle');
-    expect(out).toContain('• src/x/X.stories.tsx');
-  });
-
-  it('renders a dry-run bail-open as "a real run would capture EVERY story"', () => {
-    const out = formatDiffScopeReport('dry-run', [
-      { kind: 'bailed-open', platform: 'ios', reason: 'network exploded' },
-    ]);
-
-    expect(out).toContain('🍎 iOS - preview unavailable; a real run would capture EVERY story');
-    expect(out).toContain('Reason: network exploded');
+  // A partial-zero block has NO capture verb, so it is byte-identical in both
+  // modes - the "reusing ... from the previous build" wording stays present tense.
+  it('a partial-zero block is byte-identical across both modes', () => {
+    const block = decided({
+      full: false,
+      capturedStoryFilePaths: [],
+      totalStoriesInBundle: 22,
+      reason: 'no change reaches any story',
+    });
+    expect(formatDiffScopeBlock(block, 'would-capture')).toEqual(
+      formatDiffScopeBlock(block, 'capturing')
+    );
   });
 });

--- a/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
@@ -1,21 +1,24 @@
 /**
- * Tests for the test:bundled --dry-run preview (SHERLO-1895 Diff Scope Phase C).
+ * Tests for the test:bundled --dry-run capture-plan preview (SHERLO-1919, format
+ * replacing SHERLO-1895/1915).
  *
  * Covers the two contract-INDEPENDENT halves of the dry run:
  *   - formatDryRunPreview: the plain-text rendering of decided (partial + full)
  *     and bailed-open platforms, including that server reason strings are printed
- *     VERBATIM and that an isFullCapture=true result with an EMPTY
- *     capturedStoryFilePaths list renders as "capture EVERY story", never as
- *     "capture nothing".
- *   - runDryRunPreview: orchestration + bail-open. It issues ONE decision call
- *     for all platforms; a platform the server omits, or a query that throws,
- *     is previewed as "capture EVERY story" and is never dropped; the run never
- *     throws for a decision problem.
+ *     VERBATIM, that an isFullCapture=true result with an EMPTY
+ *     capturedStoryFilePaths list renders as "would capture all N stories" (never
+ *     "nothing"), and that the "◦ Dry run" closer is appended.
+ *   - runDryRunPreview: orchestration + bail-open. It issues ONE decision call for
+ *     all platforms; a platform the server omits, or a query that throws, is
+ *     previewed as "would capture all stories" (bail-open safety) and never
+ *     dropped; the run never throws for a decision problem.
  *
  * The decision query itself (requestDryRunDecision) is the contract seam and is
- * mocked here - this suite asserts everything AROUND it. The seam's own mapping
- * onto the real contract is covered in dryRunDecision.test.ts.
+ * mocked here - this suite asserts everything AROUND it.
  */
+import chalk from 'chalk';
+chalk.level = 0;
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockRequestDryRunDecision } = vi.hoisted(() => ({
@@ -63,56 +66,60 @@ const gitInfo: any = { branchName: 'feature', commitHash: 'abc', commitName: 'ms
 // ---------------------------------------------------------------------------
 
 describe('formatDryRunPreview', () => {
-  it('renders a partial platform with its story-file list, count, and verbatim reason', () => {
+  it('Case 6: renders a partial platform verbatim, closing with the dry-run notice', () => {
     const decision: DryRunPlatformDecision = {
-      platform: 'ios',
+      platform: 'android',
       isFullCapture: false,
       capturedStoryFilePaths: [
-        'src/components/Storefront/Storefront.stories.tsx',
-        'src/components/Cart/Cart.stories.tsx',
+        'src/components/Storefront/CheckoutScreen.stories.tsx',
+        'src/components/Storefront/PriceTag.stories.tsx',
+        'src/components/Storefront/PriceTagInline.stories.tsx',
+        'src/components/Storefront/ProductCard.stories.tsx',
+        'src/components/Storefront/ProductCardCompact.stories.tsx',
+        'src/components/Storefront/SharedButton.stories.tsx',
       ],
-      totalStories: 5,
-      reason: 'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx',
+      totalStories: 22,
+      reason: 'SharedButton.tsx changed',
     };
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('Diff Scope preview - dry run (no build created)');
-    // The fraction NAMES ITS UNIVERSE - "in this bundle", not the --include scope.
-    expect(output).toContain('iOS - would capture 2 of 5 stories in this bundle');
-    // Reused side (M - N = 3) is now shown alongside the captured side.
-    expect(output).toContain('Would reuse the other 3');
-    expect(output).toContain('• src/components/Storefront/Storefront.stories.tsx');
-    expect(output).toContain('• src/components/Cart/Cart.stories.tsx');
-    // Reason printed EXACTLY as the server returned it - no re-rendering.
-    expect(output).toContain(
-      'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx'
+    expect(output).toBe(
+      [
+        '📸 Capture plan (dry run)',
+        '  🤖 Android - would capture 6 of 22 stories, reusing 16 from the previous build',
+        '     why: SharedButton.tsx changed',
+        '     stories:',
+        '       • Storefront/CheckoutScreen',
+        '       • Storefront/PriceTag',
+        '       • Storefront/PriceTagInline',
+        '       • Storefront/ProductCard',
+        '       • Storefront/ProductCardCompact',
+        '       • Storefront/SharedButton',
+        '',
+        '◦ Dry run - no build created, nothing uploaded',
+      ].join('\n')
     );
-    expect(output).toContain('no build was created and nothing was uploaded');
   });
 
-  it('renders a PARTIAL zero-capture as "nothing captured" with its verbatim reason', () => {
+  it('renders a PARTIAL zero-capture as "nothing to capture" with its verbatim reason', () => {
     const decision: DryRunPlatformDecision = {
       platform: 'android',
       isFullCapture: false,
       capturedStoryFilePaths: [],
       totalStories: 5,
-      reason: 'captured 0 - no module changes reach any story',
+      reason: 'no change reaches any story',
     };
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('Android - would capture 0 of 5 stories in this bundle');
-    expect(output).toContain('so all 5 would be reused from the base build');
-    expect(output).toContain('captured 0 - no module changes reach any story');
-    // A partial-zero is NOT a full capture.
-    expect(output).not.toContain('EVERY story');
+    expect(output).toContain('🤖 Android - nothing to capture - no change reaches any story');
+    expect(output).toContain('     ✓ all 5 stories reused from the previous build');
+    // A partial-zero has no capture verb at all.
+    expect(output).not.toContain('would capture');
   });
 
-  it('renders a FULL capture (isFullCapture=true, EMPTY list) as "capture EVERY story", never "nothing"', () => {
-    // Point 4 of the contract: isFullCapture=true means "would capture
-    // EVERYTHING", and capturedStoryFilePaths is empty in that case. The empty
-    // list must NOT be read as "captures nothing".
+  it('renders a FULL capture (isFullCapture=true, EMPTY list) as "would capture all N stories"', () => {
     const decision: DryRunPlatformDecision = {
       platform: 'ios',
       isFullCapture: true,
@@ -123,13 +130,12 @@ describe('formatDryRunPreview', () => {
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('iOS - would capture EVERY story');
-    expect(output).toContain('Reason: main-branch');
-    // The dangerous misreads: never render the empty list as "nothing", and
-    // never leak a "0 stories" / "Story files:" partial rendering.
-    expect(output).not.toContain('capture nothing');
+    expect(output).toContain('🍎 iOS - would capture all 12 stories');
+    expect(output).toContain('     why: main-branch');
+    // The dangerous misreads: never render the empty list as "nothing".
+    expect(output).not.toContain('nothing to capture');
     expect(output).not.toContain('would capture 0');
-    expect(output).not.toContain('Story files:');
+    expect(output).not.toContain('stories:');
   });
 
   it("renders a full capture from the server's in-band bail-open reason verbatim", () => {
@@ -138,21 +144,22 @@ describe('formatDryRunPreview', () => {
       platform: 'android',
       isFullCapture: true,
       capturedStoryFilePaths: [],
+      totalStories: 8,
       reason: 'dry-run-error: base ancestry lookup timed out',
     };
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('Android - would capture EVERY story');
-    expect(output).toContain('Reason: dry-run-error: base ancestry lookup timed out');
+    expect(output).toContain('🤖 Android - would capture all 8 stories');
+    expect(output).toContain('     why: dry-run-error: base ancestry lookup timed out');
   });
 
   it('omits the "of M" total on a partial when the decision does not report one', () => {
     const decision: DryRunPlatformDecision = {
       platform: 'ios',
       isFullCapture: false,
-      capturedStoryFilePaths: ['src/a/A.stories.tsx'],
-      reason: 'captured 1 - closure changed via src/a/a.ts',
+      capturedStoryFilePaths: ['src/components/a/A.stories.tsx'],
+      reason: 'a.ts changed',
     };
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
@@ -161,15 +168,19 @@ describe('formatDryRunPreview', () => {
     expect(output).not.toContain(' of ');
   });
 
-  it('renders a bailed-open platform as "capture EVERY story" with its reason', () => {
+  it('renders a bailed-open platform as "would capture all stories" with the couldn\'t-compute row', () => {
     const previews: DryRunPlatformPreview[] = [
       { status: 'bailed-open', platform: 'ios', reason: 'network exploded' },
     ];
 
     const output = formatDryRunPreview(previews);
 
-    expect(output).toContain('iOS - preview unavailable; a real run would capture EVERY story');
-    expect(output).toContain('Reason: network exploded');
+    expect(output).toContain('🍎 iOS - would capture all stories');
+    expect(output).toContain(
+      "     ! couldn't compute what changed - capturing everything to be safe"
+    );
+    // The raw error stays in telemetry, not on the user's line.
+    expect(output).not.toContain('network exploded');
   });
 });
 
@@ -186,9 +197,9 @@ describe('runDryRunPreview', () => {
       {
         platform: 'ios',
         isFullCapture: false,
-        capturedStoryFilePaths: ['src/App.stories.tsx'],
+        capturedStoryFilePaths: ['src/components/App/App.stories.tsx'],
         totalStories: 3,
-        reason: 'captured 1 - closure changed via src/App.tsx',
+        reason: 'App.tsx changed',
       },
     ] as DryRunPlatformDecision[]);
 
@@ -216,8 +227,11 @@ describe('runDryRunPreview', () => {
     expect(arg.platforms[0].manifest.parsed.version).toBe(1);
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(printed).toContain('iOS - would capture 1 of 3 stories');
-    expect(printed).toContain('captured 1 - closure changed via src/App.tsx');
+    expect(printed).toContain(
+      '🍎 iOS - would capture 1 of 3 stories, reusing 2 from the previous build'
+    );
+    expect(printed).toContain('why: App.tsx changed');
+    expect(printed).toContain('◦ Dry run - no build created, nothing uploaded');
 
     logSpy.mockRestore();
   });
@@ -253,8 +267,9 @@ describe('runDryRunPreview', () => {
     expect(arg.platforms[0].baseReference).toBeUndefined();
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(printed).toContain('Android - would capture EVERY story');
-    expect(printed).toContain('Reason: manifest-missing');
+    // No manifest total -> full capture degrades to "all stories" (no number).
+    expect(printed).toContain('🤖 Android - would capture all stories');
+    expect(printed).toContain('why: manifest-missing');
 
     logSpy.mockRestore();
   });
@@ -275,11 +290,11 @@ describe('runDryRunPreview', () => {
     ).resolves.toBeUndefined();
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(printed).toContain('iOS - preview unavailable; a real run would capture EVERY story');
-    expect(printed).toContain(
-      'Android - preview unavailable; a real run would capture EVERY story'
-    );
-    expect(printed).toContain('network exploded');
+    expect(printed).toContain('🍎 iOS - would capture all stories');
+    expect(printed).toContain('🤖 Android - would capture all stories');
+    expect(printed).toContain("! couldn't compute what changed - capturing everything to be safe");
+    // The raw error is telemetry-only, never on the user's line.
+    expect(printed).not.toContain('network exploded');
 
     logSpy.mockRestore();
   });
@@ -290,8 +305,8 @@ describe('runDryRunPreview', () => {
       {
         platform: 'ios',
         isFullCapture: false,
-        capturedStoryFilePaths: ['src/x/X.stories.tsx'],
-        reason: 'captured 1 - closure changed via src/x.tsx',
+        capturedStoryFilePaths: ['src/components/x/X.stories.tsx'],
+        reason: 'x.tsx changed',
       },
       // android intentionally absent from the server's results.
     ] as DryRunPlatformDecision[]);
@@ -306,11 +321,8 @@ describe('runDryRunPreview', () => {
     });
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(printed).toContain('iOS - would capture 1 story');
-    expect(printed).toContain(
-      'Android - preview unavailable; a real run would capture EVERY story'
-    );
-    expect(printed).toContain('the dry-run decision returned no result for this platform');
+    expect(printed).toContain('🍎 iOS - would capture 1 story');
+    expect(printed).toContain('🤖 Android - would capture all stories');
 
     logSpy.mockRestore();
   });
@@ -321,14 +333,15 @@ describe('runDryRunPreview', () => {
       {
         platform: 'ios',
         isFullCapture: false,
-        capturedStoryFilePaths: ['src/x/X.stories.tsx'],
+        capturedStoryFilePaths: ['src/components/x/X.stories.tsx'],
         totalStories: 4,
-        reason: 'captured 1 - closure changed via src/x.tsx',
+        reason: 'x.tsx changed',
       },
       {
         platform: 'android',
         isFullCapture: true,
         capturedStoryFilePaths: [],
+        totalStories: 4,
         reason: 'native-changed',
       },
     ] as DryRunPlatformDecision[]);
@@ -343,10 +356,12 @@ describe('runDryRunPreview', () => {
     });
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(printed).toContain('iOS - would capture 1 of 4 stories');
-    expect(printed).toContain('• src/x/X.stories.tsx');
-    expect(printed).toContain('Android - would capture EVERY story');
-    expect(printed).toContain('Reason: native-changed');
+    expect(printed).toContain(
+      '🍎 iOS - would capture 1 of 4 stories, reusing 3 from the previous build'
+    );
+    expect(printed).toContain('• x/X');
+    expect(printed).toContain('🤖 Android - would capture all 4 stories');
+    expect(printed).toContain('why: native-changed');
 
     logSpy.mockRestore();
   });

--- a/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/dryRun.test.ts
@@ -87,7 +87,7 @@ describe('formatDryRunPreview', () => {
     expect(output).toBe(
       [
         '📸 Capture plan (dry run)',
-        '  🤖 Android - would capture 6 of 22 stories, reusing 16 from the previous build',
+        '  🤖 Android - would capture 6 of 22 stories in this bundle, reusing 16 from the previous build',
         '     why: SharedButton.tsx changed',
         '     stories:',
         '       • Storefront/CheckoutScreen',
@@ -130,7 +130,7 @@ describe('formatDryRunPreview', () => {
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('🍎 iOS - would capture all 12 stories');
+    expect(output).toContain('🍎 iOS - would capture all 12 stories in this bundle');
     expect(output).toContain('     why: main-branch');
     // The dangerous misreads: never render the empty list as "nothing".
     expect(output).not.toContain('nothing to capture');
@@ -150,7 +150,7 @@ describe('formatDryRunPreview', () => {
 
     const output = formatDryRunPreview([{ status: 'decided', decision }]);
 
-    expect(output).toContain('🤖 Android - would capture all 8 stories');
+    expect(output).toContain('🤖 Android - would capture all 8 stories in this bundle');
     expect(output).toContain('     why: dry-run-error: base ancestry lookup timed out');
   });
 
@@ -228,7 +228,7 @@ describe('runDryRunPreview', () => {
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(printed).toContain(
-      '🍎 iOS - would capture 1 of 3 stories, reusing 2 from the previous build'
+      '🍎 iOS - would capture 1 of 3 stories in this bundle, reusing 2 from the previous build'
     );
     expect(printed).toContain('why: App.tsx changed');
     expect(printed).toContain('◦ Dry run - no build created, nothing uploaded');
@@ -357,10 +357,10 @@ describe('runDryRunPreview', () => {
 
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(printed).toContain(
-      '🍎 iOS - would capture 1 of 4 stories, reusing 3 from the previous build'
+      '🍎 iOS - would capture 1 of 4 stories in this bundle, reusing 3 from the previous build'
     );
     expect(printed).toContain('• x/X');
-    expect(printed).toContain('🤖 Android - would capture all 4 stories');
+    expect(printed).toContain('🤖 Android - would capture all 4 stories in this bundle');
     expect(printed).toContain('why: native-changed');
 
     logSpy.mockRestore();

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -538,7 +538,9 @@ describe('live capture plan', () => {
 
     const out = printed(logSpy);
     expect(out).toContain('📸 Capture plan');
-    expect(out).toContain('🍎 iOS - capturing 2 of 22 stories, reusing 20 from the previous build');
+    expect(out).toContain(
+      '🍎 iOS - capturing 2 of 22 stories in this bundle, reusing 20 from the previous build'
+    );
     expect(out).toContain('     why: SharedButton.tsx changed');
     expect(out).toContain('     stories:');
     expect(out).toContain('       • Storefront/Storefront');
@@ -567,7 +569,7 @@ describe('live capture plan', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - capturing all 22 stories');
+    expect(out).toContain('🍎 iOS - capturing all 22 stories in this bundle');
     expect(out).toContain('     why: native code changed - everything re-shot');
     // Inversion: an empty list on a full capture is "everything", never "nothing".
     expect(out).not.toContain('capturing 0');
@@ -622,7 +624,7 @@ describe('live capture plan', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - capturing all 22 stories');
+    expect(out).toContain('🍎 iOS - capturing all 22 stories in this bundle');
     expect(out).toContain("     ! couldn't compute what changed - capturing everything to be safe");
     expect(out).not.toContain('why:');
 
@@ -654,7 +656,9 @@ describe('live capture plan', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - capturing 1 of 8 stories, reusing 7 from the previous build');
+    expect(out).toContain(
+      '🍎 iOS - capturing 1 of 8 stories in this bundle, reusing 7 from the previous build'
+    );
     expect(out).toContain('       • x/X');
     // The block renders in full; it simply carries no why line.
     expect(out).not.toContain('why:');
@@ -677,8 +681,10 @@ describe('live capture plan', () => {
     // No plan: no header, no per-platform block, no assertion of a decision.
     expect(out).not.toContain('Capture plan');
     expect(out).not.toContain('capturing');
-    // The build still ran on devices, and the link is never withheld.
-    expect(out).toContain('✓ Build created - running on devices');
+    // The closer never promises runner behavior (Decision 5): plain "✓ Build
+    // created", no "- running on devices" suffix. The link is never withheld.
+    expect(out).toContain('✓ Build created');
+    expect(out).not.toContain('running on devices');
     expect(out).toContain('🔗 Review: http://app/build');
 
     logSpy.mockRestore();
@@ -718,15 +724,19 @@ describe('live capture plan', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - capturing 1 of 22 stories, reusing 21 from the previous build');
+    expect(out).toContain(
+      '🍎 iOS - capturing 1 of 22 stories in this bundle, reusing 21 from the previous build'
+    );
     expect(out).toContain('     why: ProductCardPlatformNote.ios.tsx changed');
     expect(out).toContain('       • Storefront/ProductCard');
     expect(out).toContain(
       '🤖 Android - nothing to capture - the change never reaches the Android app'
     );
     expect(out).toContain('     ✓ all 22 stories reused from the previous build');
-    // iOS captured a story -> "- running on devices" on the closer.
-    expect(out).toContain('✓ Build created - running on devices');
+    // The closer is always the plain "✓ Build created" (Decision 5) - even though
+    // iOS captured a story, it carries no "- running on devices" suffix.
+    expect(out).toContain('✓ Build created');
+    expect(out).not.toContain('running on devices');
 
     logSpy.mockRestore();
   });
@@ -795,10 +805,10 @@ describe('live capture plan', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - capturing all 10 stories');
+    expect(out).toContain('🍎 iOS - capturing all 10 stories in this bundle');
     expect(out).toContain('     why: native-changed');
     expect(out).toContain(
-      '🤖 Android - capturing 1 of 10 stories, reusing 9 from the previous build'
+      '🤖 Android - capturing 1 of 10 stories in this bundle, reusing 9 from the previous build'
     );
     expect(out).toContain('       • x/X');
     expect(out).toContain('     why: x.tsx changed');
@@ -840,7 +850,9 @@ describe('live capture plan', () => {
 
     const out = printed(logSpy);
     // The exact fraction is pinned so the invariant is stated, not inferred.
-    expect(out).toContain('🍎 iOS - capturing 2 of 22 stories, reusing 20 from the previous build');
+    expect(out).toContain(
+      '🍎 iOS - capturing 2 of 22 stories in this bundle, reusing 20 from the previous build'
+    );
 
     logSpy.mockRestore();
   });

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -15,6 +15,9 @@
  * those are covered by buildBundle.test.ts. The STAGED_GATE_REFUSAL wire format
  * is covered by stagedGateRefusal.test.ts.
  */
+import chalk from 'chalk';
+chalk.level = 0;
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ASYNC_UPLOAD_S3_KEY_PLACEHOLDER } from '@sherlo/shared';
 
@@ -435,10 +438,11 @@ describe('--dry-run', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Live Diff Scope report (SHERLO-1915): the command EXPLAINS its own decision.
+// Live capture plan (SHERLO-1919): the command EXPLAINS its own decision, then
+// closes with "✓ Build created" and the Review URL LAST.
 // ---------------------------------------------------------------------------
 
-describe('live Diff Scope report', () => {
+describe('live capture plan', () => {
   const ANDROID_DEVICE = { ...IOS_DEVICE, id: 'test-pixel' };
 
   /** A module manifest whose story-closure count is `storyCount` (the "M"). */
@@ -495,14 +499,13 @@ describe('live Diff Scope report', () => {
     mockGetGitInfo.mockResolvedValue({ commitHash: 'c', branchName: 'b', commitName: 'm' } as any);
     mockOpenBuild.mockResolvedValue(openBuildReturn);
     mockGetAppBuildUrl.mockReturnValue('http://app/build');
-    mockPrintResultsUrl.mockImplementation(() => {});
   }
 
   function printed(logSpy: ReturnType<typeof vi.spyOn>): string {
     return logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
   }
 
-  it('renders a partial capture WITH a per-platform reason: fraction, reused side, list, reason', async () => {
+  it('Case 2: partial capture WITH a per-platform reason - fraction, reuse clause, list, why', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       storyCount: 22,
@@ -511,12 +514,7 @@ describe('live Diff Scope report', () => {
           index: 7,
           diffScopeInfo: {
             isFullCapture: false,
-            platforms: {
-              ios: {
-                reason:
-                  'captured 2 - closure changed via src/components/Storefront/SharedButton.tsx',
-              },
-            },
+            platforms: { ios: { reason: 'SharedButton.tsx changed' } },
           },
         },
         buildRun: {
@@ -539,28 +537,26 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('📋 Diff Scope - what this run photographed');
-    expect(out).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
-    expect(out).toContain(
-      'Reused the other 20 (already photographed on the base build, not re-shot here).'
-    );
-    expect(out).toContain('Stories captured:');
-    expect(out).toContain('• src/components/Storefront/Storefront.stories.tsx');
-    expect(out).toContain('• src/components/Cart/Cart.stories.tsx');
-    expect(out).toContain(
-      'Reason: captured 2 - closure changed via src/components/Storefront/SharedButton.tsx'
-    );
+    expect(out).toContain('📸 Capture plan');
+    expect(out).toContain('🍎 iOS - capturing 2 of 22 stories, reusing 20 from the previous build');
+    expect(out).toContain('     why: SharedButton.tsx changed');
+    expect(out).toContain('     stories:');
+    expect(out).toContain('       • Storefront/Storefront');
+    expect(out).toContain('       • Cart/Cart');
 
     logSpy.mockRestore();
   });
 
-  it('renders a full capture, taking the reason from fullCaptureTriggerReason (ladder rung 2)', async () => {
+  it('Case 4: full capture, taking the reason from fullCaptureTriggerReason (ladder rung 2)', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       openBuildReturn: {
         build: {
           index: 7,
-          diffScopeInfo: { isFullCapture: true, fullCaptureTriggerReason: 'native-changed' },
+          diffScopeInfo: {
+            isFullCapture: true,
+            fullCaptureTriggerReason: 'native code changed - everything re-shot',
+          },
         },
         buildRun: {
           config: { ios: { devices: [], captureScope: { full: true, storyFilePaths: [] } } },
@@ -571,28 +567,84 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
-    expect(out).toContain('Reason: native-changed');
+    expect(out).toContain('🍎 iOS - capturing all 22 stories');
+    expect(out).toContain('     why: native code changed - everything re-shot');
     // Inversion: an empty list on a full capture is "everything", never "nothing".
-    expect(out).not.toContain('captured 0');
+    expect(out).not.toContain('capturing 0');
     expect(out).not.toContain('nothing');
 
     logSpy.mockRestore();
   });
 
-  it('renders a partial WITHOUT a reason (forward-compat degrade): counts + list, no reason line', async () => {
+  it('Case 3: nothing to capture - the whole bundle reused, plain "✓ Build created" closer', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      storyCount: 22,
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: {
+            isFullCapture: false,
+            platforms: { ios: { reason: 'no change reaches any story' } },
+          },
+        },
+        buildRun: {
+          config: { ios: { devices: [], captureScope: { full: false, storyFilePaths: [] } } },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - nothing to capture - no change reaches any story');
+    expect(out).toContain('     ✓ all 22 stories reused from the previous build');
+    // Nothing captured on any platform -> the plain closer, NOT "- running on devices".
+    expect(out).toContain('✓ Build created');
+    expect(out).not.toContain('running on devices');
+
+    logSpy.mockRestore();
+  });
+
+  it('Case 7: full capture with NO reason degrades to the "couldn\'t compute" safety row', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      storyCount: 22,
+      openBuildReturn: {
+        // Full capture recorded, but no reason available (older server / degraded).
+        build: { index: 7, diffScopeInfo: { isFullCapture: true } },
+        buildRun: {
+          config: { ios: { devices: [], captureScope: { full: true, storyFilePaths: [] } } },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - capturing all 22 stories');
+    expect(out).toContain("     ! couldn't compute what changed - capturing everything to be safe");
+    expect(out).not.toContain('why:');
+
+    logSpy.mockRestore();
+  });
+
+  it('renders a partial WITHOUT a reason (forward-compat degrade): counts + list, no why line', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       storyCount: 8,
       openBuildReturn: {
         // diffScopeInfo has NO per-platform reason yet (api PR not landed), and this
-        // is not a full capture, so the reason line is omitted entirely.
+        // is not a full capture, so the why line is omitted entirely.
         build: { index: 7, diffScopeInfo: { isFullCapture: false } },
         buildRun: {
           config: {
             ios: {
               devices: [],
-              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+              captureScope: {
+                full: false,
+                storyFilePaths: ['src/components/x/X.stories.tsx'],
+              },
             },
           },
         },
@@ -602,15 +654,15 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - captured 1 of 8 stories in this bundle');
-    expect(out).toContain('• src/x/X.stories.tsx');
-    // The block renders in full; it simply carries no reason line.
-    expect(out).not.toContain('Reason:');
+    expect(out).toContain('🍎 iOS - capturing 1 of 8 stories, reusing 7 from the previous build');
+    expect(out).toContain('       • x/X');
+    // The block renders in full; it simply carries no why line.
+    expect(out).not.toContain('why:');
 
     logSpy.mockRestore();
   });
 
-  it('prints NOTHING about diff scope when captureScope is absent (Diff Scope off / older API)', async () => {
+  it('prints NO plan block when captureScope is absent, but still closes with the build + URL', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       openBuildReturn: {
@@ -622,9 +674,94 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    // Silence is correct: no header, no per-platform block, no assertion of a decision.
-    expect(out).not.toContain('Diff Scope');
-    expect(out).not.toContain('captured');
+    // No plan: no header, no per-platform block, no assertion of a decision.
+    expect(out).not.toContain('Capture plan');
+    expect(out).not.toContain('capturing');
+    // The build still ran on devices, and the link is never withheld.
+    expect(out).toContain('✓ Build created - running on devices');
+    expect(out).toContain('🔗 Review: http://app/build');
+
+    logSpy.mockRestore();
+  });
+
+  it('Case 5: platforms disagree - one partial captures, one reuses everything', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      platforms: ['ios', 'android'],
+      storyCount: 22,
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: {
+            isFullCapture: false,
+            platforms: {
+              ios: { reason: 'ProductCardPlatformNote.ios.tsx changed' },
+              android: { reason: 'the change never reaches the Android app' },
+            },
+          },
+        },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: {
+                full: false,
+                storyFilePaths: ['src/components/Storefront/ProductCard.stories.tsx'],
+              },
+            },
+            android: { devices: [], captureScope: { full: false, storyFilePaths: [] } },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🍎 iOS - capturing 1 of 22 stories, reusing 21 from the previous build');
+    expect(out).toContain('     why: ProductCardPlatformNote.ios.tsx changed');
+    expect(out).toContain('       • Storefront/ProductCard');
+    expect(out).toContain(
+      '🤖 Android - nothing to capture - the change never reaches the Android app'
+    );
+    expect(out).toContain('     ✓ all 22 stories reused from the previous build');
+    // iOS captured a story -> "- running on devices" on the closer.
+    expect(out).toContain('✓ Build created - running on devices');
+
+    logSpy.mockRestore();
+  });
+
+  // ORDERING: the Review URL prints LAST - after the capture plan and the
+  // build-created closer, never before them (SHERLO-1919 ordering change).
+  it('prints the Review URL LAST, after the capture plan and the build-created line', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({
+      storyCount: 22,
+      openBuildReturn: {
+        build: {
+          index: 7,
+          diffScopeInfo: { isFullCapture: false, platforms: { ios: { reason: 'x changed' } } },
+        },
+        buildRun: {
+          config: {
+            ios: {
+              devices: [],
+              captureScope: { full: false, storyFilePaths: ['src/components/x/X.stories.tsx'] },
+            },
+          },
+        },
+      },
+    });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    const planIdx = out.indexOf('📸 Capture plan');
+    const builtIdx = out.indexOf('✓ Build created');
+    const urlIdx = out.indexOf('🔗 Review:');
+    expect(planIdx).toBeGreaterThanOrEqual(0);
+    expect(builtIdx).toBeGreaterThan(planIdx);
+    expect(urlIdx).toBeGreaterThan(builtIdx);
 
     logSpy.mockRestore();
   });
@@ -640,7 +777,7 @@ describe('live Diff Scope report', () => {
           diffScopeInfo: {
             isFullCapture: false,
             fullCaptureTriggerReason: 'native-changed',
-            platforms: { android: { reason: 'captured 1 - closure changed via src/x.tsx' } },
+            platforms: { android: { reason: 'x.tsx changed' } },
           },
         },
         buildRun: {
@@ -648,7 +785,7 @@ describe('live Diff Scope report', () => {
             ios: { devices: [], captureScope: { full: true, storyFilePaths: [] } },
             android: {
               devices: [],
-              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+              captureScope: { full: false, storyFilePaths: ['src/components/x/X.stories.tsx'] },
             },
           },
         },
@@ -658,23 +795,24 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    expect(out).toContain('🍎 iOS - captured EVERY story in this bundle');
-    expect(out).toContain('Reason: native-changed');
-    expect(out).toContain('🤖 Android - captured 1 of 10 stories in this bundle');
-    expect(out).toContain('• src/x/X.stories.tsx');
-    expect(out).toContain('Reason: captured 1 - closure changed via src/x.tsx');
+    expect(out).toContain('🍎 iOS - capturing all 10 stories');
+    expect(out).toContain('     why: native-changed');
+    expect(out).toContain(
+      '🤖 Android - capturing 1 of 10 stories, reusing 9 from the previous build'
+    );
+    expect(out).toContain('       • x/X');
+    expect(out).toContain('     why: x.tsx changed');
 
     logSpy.mockRestore();
   });
 
-  // Deliverable 5.1: the fraction is MANIFEST-denominated, so --include never moves
-  // it. Same M, same "2 of 22 in this bundle" label, whether include is unset,
-  // matches a subset, or matches nothing.
+  // The fraction is MANIFEST-denominated, so --include never moves it. Same M,
+  // same "2 of 22" label, whether include is unset, matches a subset, or nothing.
   it.each([
     ['no --include', undefined],
     ['--include matching a subset', ['Sanity', 'Storefront']],
     ['--include matching nothing', ['DoesNotExist']],
-  ])('the fraction is unchanged by %s (tier-1 relabel invariant)', async (_name, include) => {
+  ])('the fraction is unchanged by %s (--include invariant)', async (_name, include) => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       include: include as string[] | undefined,
@@ -687,7 +825,10 @@ describe('live Diff Scope report', () => {
               devices: [],
               captureScope: {
                 full: false,
-                storyFilePaths: ['src/a/A.stories.tsx', 'src/b/B.stories.tsx'],
+                storyFilePaths: [
+                  'src/components/a/A.stories.tsx',
+                  'src/components/b/B.stories.tsx',
+                ],
               },
             },
           },
@@ -698,27 +839,27 @@ describe('live Diff Scope report', () => {
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    // The exact label is pinned so the invariant is stated, not inferred.
-    expect(out).toContain('🍎 iOS - captured 2 of 22 stories in this bundle');
+    // The exact fraction is pinned so the invariant is stated, not inferred.
+    expect(out).toContain('🍎 iOS - capturing 2 of 22 stories, reusing 20 from the previous build');
 
     logSpy.mockRestore();
   });
 
-  // Deliverable 5.2: this task is DISPLAY ONLY. The openBuild request (the decision
-  // inputs) must not move because the response now carries a diff-scope decision.
-  it('does NOT alter the openBuild request or the buildRunConfig when printing the report', async () => {
+  // DISPLAY ONLY. The openBuild request (the decision inputs) must not move
+  // because the response now carries a diff-scope decision.
+  it('does NOT alter the openBuild request or the buildRunConfig when printing the plan', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({
       openBuildReturn: {
         build: {
           index: 7,
-          diffScopeInfo: { isFullCapture: false, platforms: { ios: { reason: 'captured 1 - x' } } },
+          diffScopeInfo: { isFullCapture: false, platforms: { ios: { reason: 'x changed' } } },
         },
         buildRun: {
           config: {
             ios: {
               devices: [],
-              captureScope: { full: false, storyFilePaths: ['src/x/X.stories.tsx'] },
+              captureScope: { full: false, storyFilePaths: ['src/components/x/X.stories.tsx'] },
             },
           },
         },

--- a/packages/cli/src/commands/testBundled/diffScopeReport.ts
+++ b/packages/cli/src/commands/testBundled/diffScopeReport.ts
@@ -1,33 +1,37 @@
 /**
- * The ONE Diff Scope report renderer, shared by BOTH the live test:bundled run
- * and its --dry-run preview (SHERLO-1915).
+ * The ONE "Capture plan" renderer, shared by BOTH the live test:bundled run and
+ * its --dry-run preview (SHERLO-1919, format replacing SHERLO-1915).
  *
- * A Diff Scope decision photographs only the stories a change can affect and
- * reuses the base build's photos for the rest. Before this module, the live run
- * printed NOTHING about that decision and the dry run had its own formatter, so a
- * developer learned the outcome only from the dashboard. This module renders a
- * per-platform block that reads IDENTICALLY in both modes except for TENSE: the
- * dry run says "would capture", the live run says "captured". Tense is a
- * parameter ({@link CaptureTense}), never a second implementation - two
- * formatters that can drift is the exact failure this module exists to prevent.
+ * test:bundled photographs only the stories a change can affect and reuses the
+ * previous build's photos for the rest. This module renders a per-platform
+ * "Capture plan" block that reads IDENTICALLY in both modes except for the
+ * capture VERB: the live run says "capturing", the dry run says "would capture".
+ * The verb is a parameter ({@link CaptureTense}), never a second implementation -
+ * two formatters that can drift is the exact failure this module exists to
+ * prevent. Everything else - the "reusing N from the previous build" clause, the
+ * "nothing to capture" line, the story list, the reason - is byte-identical
+ * across the two modes.
  *
  * THE INVERSION HAZARD (read twice): a FULL capture (`full: true`) means EVERY
  * story was in scope, EVEN THOUGH its captured-file list is empty. Empty-list on
  * a full capture is "everything", NOT "nothing". {@link formatDiffScopeBlock}
  * branches on `full` FIRST and never infers "nothing" from an empty list. The
- * ONLY block that renders as "nothing captured" is a PARTIAL capture whose list
+ * ONLY block that renders as "nothing to capture" is a PARTIAL capture whose list
  * is empty (`full: false`, no paths).
  *
- * THE FRACTION NAMES ITS UNIVERSE (tier-1 relabel): "N of M stories in this
- * bundle". M is the WHOLE bundle's story set, NOT the `--include` scope. The
- * scope filter runs on-device against story titles; the CLI cannot honestly
- * scope this count at bundle time, so the wording says "in this bundle" to stop
- * a developer running `--include ...` from reading M as their scope.
+ * THE FRACTION IS MANIFEST-DENOMINATED: "N of M stories". M is the WHOLE
+ * bundle's story set (the manifest story-closure count), NOT the `--include`
+ * scope - the scope filter runs on-device against story titles, so the CLI cannot
+ * honestly scope this count at bundle time. `--include` never moves M.
  *
- * Server reasons are printed VERBATIM. This module never invents, rewords, or
- * re-derives a reason; a reason it is not given is simply omitted.
+ * Reasons are printed VERBATIM. This module never invents, rewords, or re-derives
+ * a reason; the "why:" text is composed SERVER-side (1 file: "X changed" / 2-3:
+ * "3 files changed - a, b, c" / more: "14 files changed") and printed straight
+ * through. A reason it is not given is simply omitted, and a full capture with no
+ * reason degrades to the "couldn't compute" safety row.
  */
 import { Platform } from '@sherlo/api-types';
+import chalk from 'chalk';
 import { PLATFORM_LABEL } from '../../constants';
 
 // ---------------------------------------------------------------------------
@@ -35,217 +39,198 @@ import { PLATFORM_LABEL } from '../../constants';
 // ---------------------------------------------------------------------------
 
 /**
- * The tense the report reads in. The decision is identical in both modes; only
- * the verbs change. `would-capture` = the dry-run preview ("would capture");
- * `captured` = the live run ("captured").
+ * The tense the plan reads in. The decision is identical in both modes; only the
+ * capture verb changes. `would-capture` = the dry-run preview ("would capture");
+ * `capturing` = the live run ("capturing"). Note the "reusing N from the previous
+ * build" clause stays PRESENT tense in BOTH modes - only the capture verb moves.
  */
-export type CaptureTense = 'would-capture' | 'captured';
+export type CaptureTense = 'would-capture' | 'capturing';
 
-/** Which run is printing. Selects the header/footer and the tense. */
+/** Which run is printing. Selects the header suffix and the tense. */
 export type DiffScopeMode = 'dry-run' | 'live';
 
 /**
- * One platform's Diff Scope outcome, as the report consumes it. Both callers map
- * their own data into this shape, so the rendering below is the single source of
- * truth for how a decision reads.
+ * One platform's capture outcome, as the plan consumes it. Both callers map their
+ * own data into this shape, so the rendering below is the single source of truth
+ * for how a decision reads.
  */
-export type DiffScopePlatformReport =
-  | {
-      kind: 'decided';
-      platform: Platform;
-      /**
-       * true = EVERY story was in scope (a full capture). The captured-file list
-       * is empty in that case and MUST render as "every story", never "nothing"
-       * (the inversion hazard). false = the partial closure-diff below.
-       */
-      full: boolean;
-      /**
-       * Story SOURCE FILE paths that were captured. Empty on a full capture
-       * (means "everything"); may also be empty on a partial capture that reaches
-       * no story (means "nothing"). Ignored when `full` is true.
-       */
-      capturedStoryFilePaths: string[];
-      /**
-       * M: the total number of stories in THIS bundle (the manifest's story-file
-       * count). Absent when no manifest was produced - the fraction then degrades
-       * to a bare count with no "of M" and no reuse line.
-       */
-      totalStoriesInBundle?: number;
-      /**
-       * The server's reason, printed VERBATIM. Absent -> no reason line (the live
-       * reason ladder can land here; the dry run always carries one).
-       */
-      reason?: string;
-    }
-  | {
-      // Dry-run only: the decision query could not give a trustworthy answer, so
-      // the safe preview is "a real run would capture everything".
-      kind: 'bailed-open';
-      platform: Platform;
-      reason: string;
-    };
+export type DiffScopePlatformReport = {
+  kind: 'decided';
+  platform: Platform;
+  /**
+   * true = EVERY story was in scope (a full capture). The captured-file list is
+   * empty in that case and MUST render as "all N stories", never "nothing" (the
+   * inversion hazard). false = the partial closure-diff below.
+   */
+  full: boolean;
+  /**
+   * Story SOURCE FILE paths that were captured. Empty on a full capture (means
+   * "everything"); may also be empty on a partial capture that reaches no story
+   * (means "nothing to capture"). Ignored when `full` is true.
+   */
+  capturedStoryFilePaths: string[];
+  /**
+   * M: the total number of stories in THIS bundle (the manifest's story-file
+   * count). Absent when no manifest was produced - the fraction then degrades to
+   * a bare count with no "of M" and no reuse clause.
+   */
+  totalStoriesInBundle?: number;
+  /**
+   * The server's reason, printed VERBATIM after "why: " (partial) or inline after
+   * "nothing to capture - " (partial-zero). Absent -> no reason shown; a full
+   * capture with no reason falls to the "couldn't compute" safety row.
+   */
+  reason?: string;
+};
 
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
-/** The most story-file paths a block lists before it summarises the remainder. */
-const MAX_LISTED_STORIES = 20;
-
 const HEADER: Record<DiffScopeMode, string> = {
-  'dry-run': '📋 Diff Scope preview - dry run (no build created)',
-  live: '📋 Diff Scope - what this run photographed',
+  'dry-run': '📸 Capture plan (dry run)',
+  live: '📸 Capture plan',
 };
 
+/** The capture verb per tense - the ONLY word that differs between the two modes. */
+const CAPTURE_VERB: Record<CaptureTense, string> = {
+  'would-capture': 'would capture',
+  capturing: 'capturing',
+};
+
+// Indentation is significant (SHERLO-1919 spec): platform line = 2 spaces, the
+// why:/stories:/status rows = 5 spaces, bullets = 7 spaces.
+const ROW = '     '; // 5 spaces
+const BULLET = '       •'; // 7 spaces + bullet
 /**
- * One line, printed once under the header, that introduces the idea before the
- * per-platform blocks assume it. Someone who has never heard of Diff Scope can
- * read this and know what will and will not be photographed.
+ * The separator that divides a label from its claim (and a claim from its reason)
+ * throughout the capture plan and its callers' closers. Exported so the closers
+ * (dryRun.ts, testBundled.ts) read the same way as the formatter rather than each
+ * spelling the character inline.
  */
-const EXPLAINER =
-  "Diff Scope photographs only the stories your changes can affect; the rest reuse the base build's photos.";
+export const SEPARATOR = '-';
 
 /**
- * Render the whole report: header, explainer, one block per platform, and (dry
- * run only) a footer stating nothing was created. Returned as a plain string the
- * caller prints as-is and tests assert on directly.
+ * Render the whole "Capture plan": the header and one block per platform. The
+ * closers (live: "✓ Build created" + the Review URL; dry run: the "◦ Dry run"
+ * notice) are printed by the CALLERS, not here - this module owns the plan, not
+ * the run's outcome line.
  */
 export function formatDiffScopeReport(
   mode: DiffScopeMode,
   platforms: DiffScopePlatformReport[]
 ): string {
-  const tense: CaptureTense = mode === 'dry-run' ? 'would-capture' : 'captured';
+  const tense: CaptureTense = mode === 'dry-run' ? 'would-capture' : 'capturing';
 
-  const lines: string[] = [HEADER[mode], EXPLAINER];
-
+  const lines: string[] = [chalk.bold(HEADER[mode])];
   for (const platform of platforms) {
-    lines.push('');
-    lines.push(
-      ...(platform.kind === 'bailed-open'
-        ? formatBailedOpenBlock(platform.platform, platform.reason)
-        : formatDiffScopeBlock(platform, tense))
-    );
-  }
-
-  if (mode === 'dry-run') {
-    lines.push('');
-    lines.push('This is a preview: no build was created and nothing was uploaded.');
+    lines.push(...formatDiffScopeBlock(platform, tense));
   }
 
   return lines.join('\n');
 }
 
 /**
- * Render ONE decided platform block in the given tense. This is the shared core
- * both modes read identically apart from tense - it takes no header, footer, or
- * mode, only the decision and the tense.
+ * Render ONE platform block in the given tense. This is the shared core both
+ * modes read identically apart from the capture verb - it takes no header,
+ * closer, or mode, only the decision and the tense.
  */
 export function formatDiffScopeBlock(
-  block: Extract<DiffScopePlatformReport, { kind: 'decided' }>,
+  block: DiffScopePlatformReport,
   tense: CaptureTense
 ): string[] {
-  const heading = `${platformEmoji(block.platform)} ${PLATFORM_LABEL[block.platform]}`;
-  const verb = VERBS[tense];
+  const verb = CAPTURE_VERB[tense];
+  const M = block.totalStoriesInBundle;
   const lines: string[] = [];
 
-  // INVERSION GUARD: `full` is checked FIRST. A full capture is "every story",
+  // INVERSION GUARD: `full` is checked FIRST. A full capture is "all N stories",
   // even with an empty captured-file list - never let the empty list read as
-  // "nothing". Only the partial branch below can render "nothing captured".
+  // "nothing". Only the partial branch below can render "nothing to capture".
   if (block.full) {
-    lines.push(`${heading} - ${verb.capture} EVERY story in this bundle`);
-    pushReason(lines, block.reason);
+    // "all N story/stories" agrees in number with M (M === 1 -> "story"); with no
+    // manifest it degrades to a bare "all stories".
+    const allStories =
+      M !== undefined ? `all ${M} ${M === 1 ? 'story' : 'stories'}` : 'all stories';
+    lines.push(headingLine(block.platform, `${verb} ${allStories}`));
+    if (block.reason) {
+      lines.push(whyRow(block.reason));
+    } else {
+      // No reason for a full capture -> the honest degrade: we could not work out
+      // what changed, so everything is re-shot to be safe.
+      lines.push(
+        chalk.yellow(
+          `${ROW}! couldn't compute what changed ${SEPARATOR} capturing everything to be safe`
+        )
+      );
+    }
     return lines;
   }
 
   const captured = block.capturedStoryFilePaths.length;
-  const total = block.totalStoriesInBundle;
 
-  if (total === undefined) {
-    // No manifest -> no denominator and no honest reuse count. Degrade to a bare
-    // captured count; still list the captured stories and the reason below.
-    lines.push(`${heading} - ${verb.capture} ${captured} ${captured === 1 ? 'story' : 'stories'}`);
+  // PARTIAL zero: nothing your changes touch reaches a story.
+  if (captured === 0) {
+    const tail = block.reason ? ` ${SEPARATOR} ${block.reason}` : '';
+    lines.push(headingLine(block.platform, `nothing to capture${tail}`));
+    if (M !== undefined) {
+      const noun = M === 1 ? 'story' : 'stories';
+      lines.push(
+        chalk.green(`${ROW}✓`) + chalk.dim(` all ${M} ${noun} reused from the previous build`)
+      );
+    }
+    return lines;
+  }
+
+  // PARTIAL with captures.
+  if (M !== undefined) {
+    const reused = M - captured;
+    // "reusing 0 from the previous build" only states that nothing happened - drop
+    // the clause entirely when nothing is reused and print just the fraction.
+    const reuseClause = reused === 0 ? '' : `, reusing ${reused} from the previous build`;
+    lines.push(headingLine(block.platform, `${verb} ${captured} of ${M} stories${reuseClause}`));
   } else {
-    // The fraction names its universe ("in this bundle") so M is never misread as
-    // the --include scope.
-    lines.push(`${heading} - ${verb.capture} ${captured} of ${total} stories in this bundle`);
-    const reused = total - captured;
-    if (captured === 0) {
-      lines.push(
-        `   Nothing your changes touch reaches a story, so all ${total} ${verb.reusedAll} from the base build.`
-      );
-    } else if (reused > 0) {
-      lines.push(
-        `   ${verb.reuseOther} the other ${reused} (already photographed on the base build, not re-shot here).`
-      );
-    }
+    // No manifest -> no honest denominator and no reuse count. Degrade to a bare
+    // captured count; still list the captured stories and the reason below.
+    lines.push(
+      headingLine(block.platform, `${verb} ${captured} ${captured === 1 ? 'story' : 'stories'}`)
+    );
   }
 
-  if (captured > 0) {
-    lines.push(`   ${verb.listLabel}`);
-    for (const line of listStoryFiles(block.capturedStoryFilePaths)) {
-      lines.push(line);
-    }
+  if (block.reason) lines.push(whyRow(block.reason));
+
+  lines.push(chalk.dim(`${ROW}stories:`));
+  for (const filePath of block.capturedStoryFilePaths) {
+    lines.push(chalk.dim(`${BULLET} ${cleanStoryPath(filePath)}`));
   }
 
-  pushReason(lines, block.reason);
   return lines;
 }
 
 /* ========================================================================== */
 
-/**
- * Verb forms per tense. This is the ONLY place the two modes diverge - every
- * other character a block prints is identical.
- */
-const VERBS: Record<
-  CaptureTense,
-  {
-    capture: string;
-    reuseOther: string;
-    reusedAll: string;
-    listLabel: string;
-  }
-> = {
-  'would-capture': {
-    capture: 'would capture',
-    reuseOther: 'Would reuse',
-    reusedAll: 'would be reused',
-    listLabel: 'Stories to capture:',
-  },
-  captured: {
-    capture: 'captured',
-    reuseOther: 'Reused',
-    reusedAll: 'were reused',
-    listLabel: 'Stories captured:',
-  },
-};
-
 function platformEmoji(platform: Platform): string {
   return platform === 'android' ? '🤖' : '🍎';
 }
 
-function pushReason(lines: string[], reason: string | undefined): void {
-  // Printed VERBATIM; absent -> no reason line at all.
-  if (reason) lines.push(`   Reason: ${reason}`);
+/** The 2-space platform line: cyan heading, separator, bold claim. */
+function headingLine(platform: Platform, claim: string): string {
+  const heading = chalk.cyan(`${platformEmoji(platform)} ${PLATFORM_LABEL[platform]}`);
+  return `  ${heading} ${SEPARATOR} ${chalk.bold(claim)}`;
 }
 
-/** The bounded bullet list of captured story files, with an overflow summary. */
-function listStoryFiles(paths: string[]): string[] {
-  const shown = paths.slice(0, MAX_LISTED_STORIES).map((p) => `     • ${p}`);
-  const hidden = paths.length - shown.length;
-  if (hidden > 0) shown.push(`     • ... and ${hidden} more`);
-  return shown;
+/** The 5-space "why:" row - the server's reason, printed VERBATIM. */
+function whyRow(reason: string): string {
+  return chalk.dim(`${ROW}why: ${reason}`);
 }
 
 /**
- * Dry-run only: the preview could not get a trustworthy answer for this
- * platform, so it states the safe outcome - a real run would capture everything.
- * Always future tense; a live run never bails open.
+ * Turn a story SOURCE FILE path into its display name: keep the last two path
+ * segments (the story's group folder + its name) and drop the `.stories.<ext>`
+ * suffix, so `src/components/Storefront/ProductCard.stories.tsx` reads
+ * `Storefront/ProductCard`. This is pure path cleanup - NOT a story-title map.
  */
-function formatBailedOpenBlock(platform: Platform, reason: string): string[] {
-  const heading = `${platformEmoji(platform)} ${PLATFORM_LABEL[platform]}`;
-  return [
-    `${heading} - preview unavailable; a real run would capture EVERY story`,
-    `   Reason: ${reason}`,
-  ];
+function cleanStoryPath(filePath: string): string {
+  const withoutSuffix = filePath.replace(/\.stories\.[jt]sx?$/, '');
+  const segments = withoutSuffix.split('/').filter(Boolean);
+  return segments.slice(-2).join('/');
 }

--- a/packages/cli/src/commands/testBundled/diffScopeReport.ts
+++ b/packages/cli/src/commands/testBundled/diffScopeReport.ts
@@ -147,10 +147,12 @@ export function formatDiffScopeBlock(
   // even with an empty captured-file list - never let the empty list read as
   // "nothing". Only the partial branch below can render "nothing to capture".
   if (block.full) {
-    // "all N story/stories" agrees in number with M (M === 1 -> "story"); with no
-    // manifest it degrades to a bare "all stories".
+    // "all N story/stories in this bundle" agrees in number with M (M === 1 ->
+    // "story") and names the fraction's universe so M cannot be misread as the
+    // --include scope; with no manifest it degrades to a bare "all stories" (no M,
+    // so nothing to name).
     const allStories =
-      M !== undefined ? `all ${M} ${M === 1 ? 'story' : 'stories'}` : 'all stories';
+      M !== undefined ? `all ${M} ${M === 1 ? 'story' : 'stories'} in this bundle` : 'all stories';
     lines.push(headingLine(block.platform, `${verb} ${allStories}`));
     if (block.reason) {
       lines.push(whyRow(block.reason));
@@ -187,7 +189,15 @@ export function formatDiffScopeBlock(
     // "reusing 0 from the previous build" only states that nothing happened - drop
     // the clause entirely when nothing is reused and print just the fraction.
     const reuseClause = reused === 0 ? '' : `, reusing ${reused} from the previous build`;
-    lines.push(headingLine(block.platform, `${verb} ${captured} of ${M} stories${reuseClause}`));
+    // "in this bundle" names the fraction's universe (M is the whole bundle's
+    // story set, NOT the --include scope) and sits between the fraction and the
+    // reuse clause: "N of M stories in this bundle, reusing K ...".
+    lines.push(
+      headingLine(
+        block.platform,
+        `${verb} ${captured} of ${M} stories in this bundle${reuseClause}`
+      )
+    );
   } else {
     // No manifest -> no honest denominator and no reuse count. Degrade to a bare
     // captured count; still list the captured stories and the reason below.

--- a/packages/cli/src/commands/testBundled/dryRun.ts
+++ b/packages/cli/src/commands/testBundled/dryRun.ts
@@ -25,6 +25,7 @@
  * and are printed VERBATIM - never re-rendered into module numbers.
  */
 import { Platform } from '@sherlo/api-types';
+import chalk from 'chalk';
 import reporting from '../../helpers/reporting';
 import type { GitInfo } from '../../helpers/getGitInfo';
 import type { BundleResult } from './buildBundle';
@@ -34,7 +35,7 @@ import {
   type DryRunPlatformDecision,
   type DryRunPlatformRequest,
 } from './dryRunDecision';
-import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
+import { SEPARATOR, formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -143,19 +144,36 @@ export default runDryRunPreview;
 // ---------------------------------------------------------------------------
 
 /**
+ * The dry-run closer, printed after the plan instead of the live "✓ Build
+ * created" + Review URL. A dry run creates nothing, so it says exactly that.
+ */
+const DRY_RUN_CLOSER = chalk.yellow(`◦ Dry run ${SEPARATOR} no build created, nothing uploaded`);
+
+/**
  * Render the whole dry-run preview by mapping each platform's preview onto the
- * shared {@link formatDiffScopeReport}. The dry run and the live run print the
- * SAME per-platform block; only the tense (here: "would capture") and the
- * preview header/footer differ, and both live in that one shared module.
+ * shared {@link formatDiffScopeReport}, then appending the dry-run closer. The
+ * dry run and the live run print the SAME per-platform block; only the capture
+ * verb ("would capture") differs, and it lives in that one shared module.
+ *
+ * A bail-open (the decision query gave no trustworthy answer for a platform)
+ * maps onto a FULL capture with no reason - the shared formatter renders that as
+ * "would capture all stories" plus the "couldn't compute" safety row, the same
+ * honest degrade the live run shows. The raw error stays in telemetry, not on the
+ * user's line.
  */
 export function formatDryRunPreview(previews: DryRunPlatformPreview[]): string {
   const platforms: DiffScopePlatformReport[] = previews.map((preview) =>
     preview.status === 'bailed-open'
-      ? { kind: 'bailed-open', platform: preview.platform, reason: preview.reason }
+      ? {
+          kind: 'decided',
+          platform: preview.platform,
+          full: true,
+          capturedStoryFilePaths: [],
+        }
       : decisionToReport(preview.decision)
   );
 
-  return formatDiffScopeReport('dry-run', platforms);
+  return `${formatDiffScopeReport('dry-run', platforms)}\n\n${DRY_RUN_CLOSER}`;
 }
 
 /* ========================================================================== */

--- a/packages/cli/src/commands/testBundled/readModuleManifest.ts
+++ b/packages/cli/src/commands/testBundled/readModuleManifest.ts
@@ -131,16 +131,16 @@ export function readValidatedModuleManifest(projectRoot: string): ValidatedModul
 }
 
 /**
- * The number of stories THIS build's manifest carries - the "M" in every Diff
- * Scope "N of M" fraction. It is the count of story closures the serializer
- * recorded, keyed by story SOURCE FILE. This is the ONE definition of M; both
- * the live and dry-run Diff Scope reports (SHERLO-1915) count it through here so
- * the two modes can never disagree on the denominator.
+ * The number of stories THIS build's manifest carries - the "M" in every capture
+ * plan "N of M stories" fraction. It is the count of story closures the
+ * serializer recorded, keyed by story SOURCE FILE. This is the ONE definition of
+ * M; both the live and dry-run capture plans (SHERLO-1919) count it through here
+ * so the two modes can never disagree on the denominator.
  *
  * Note this counts the WHOLE bundle's story set, NOT the `--include` / `--exclude`
  * scope: the scope filter runs on-device against story TITLES, while the manifest
  * is keyed by file paths, so the CLI has no honest way to scope this number at
- * bundle time. The report wording names the number "in this bundle" to say so.
+ * bundle time. `--include` therefore never moves M.
  */
 export function countBundleStories(manifest: ValidatedModuleManifest): number {
   return Object.keys(manifest.parsed.storyClosures).length;

--- a/packages/cli/src/commands/testBundled/readModuleManifest.ts
+++ b/packages/cli/src/commands/testBundled/readModuleManifest.ts
@@ -140,7 +140,8 @@ export function readValidatedModuleManifest(projectRoot: string): ValidatedModul
  * Note this counts the WHOLE bundle's story set, NOT the `--include` / `--exclude`
  * scope: the scope filter runs on-device against story TITLES, while the manifest
  * is keyed by file paths, so the CLI has no honest way to scope this number at
- * bundle time. `--include` therefore never moves M.
+ * bundle time. `--include` therefore never moves M. The report wording names the
+ * number "in this bundle" to say so.
  */
 export function countBundleStories(manifest: ValidatedModuleManifest): number {
   return Object.keys(manifest.parsed.storyClosures).length;

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -47,7 +47,7 @@ import { getOnStaleMode, handleStaleBase } from './onStale';
 import uploadStagedArtifacts, { type StagedUploadKeys } from './uploadStagedArtifacts';
 import { runDryRunPreview } from './dryRun';
 import { countBundleStories } from './readModuleManifest';
-import { SEPARATOR, formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
+import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
 /**
  * The per-platform staged build config plus the SHERLO-1894 `manifestS3Key` the api
@@ -378,8 +378,9 @@ export default testBundled;
  * response (SHERLO-1919). No extra API call: `captureScope` carries the captured
  * set and `diffScopeInfo` carries the reason. Renders through the SAME shared
  * formatter the dry run uses, so the two modes read identically apart from the
- * capture verb. Then closes with "✓ Build created" (dim " - running on devices"
- * when at least one platform captured a story) and the Review URL LAST.
+ * capture verb. Then closes with a plain "✓ Build created" and the Review URL
+ * LAST - the closer never promises runner behavior (Decision 5), so it carries no
+ * "- running on devices" suffix regardless of what was captured.
  *
  * A platform the server made no decision for (no `captureScope`) is skipped
  * entirely - silence, never an invented "captured everything". If NO platform has
@@ -430,19 +431,11 @@ function printCapturePlanAndCloser({
     console.log('\n' + formatDiffScopeReport('live', platforms));
   }
 
-  // The closer, LAST (SHERLO-1919 ordering). "- running on devices" is shown when
-  // at least one platform is capturing a story; a run that reuses everything on
-  // every platform gets the plain "✓ Build created". With no plan at all (Diff
-  // Scope off) the build still runs on devices, so keep the suffix.
-  const somethingCaptured = platforms.length === 0 || platforms.some(platformCapturesAStory);
-  const runningSuffix = somethingCaptured ? chalk.dim(` ${SEPARATOR} running on devices`) : '';
-  console.log('\n' + chalk.green('✓') + chalk.bold(' Build created') + runningSuffix);
+  // The closer, LAST (SHERLO-1919 ordering). Always the plain "✓ Build created":
+  // the closer never promises runner behavior (Decision 5), so it carries no
+  // "- running on devices" suffix regardless of what was captured.
+  console.log('\n' + chalk.green('✓') + chalk.bold(' Build created'));
   console.log(`🔗 Review: ${printLink(url)}`);
-}
-
-/** True when this platform is capturing at least one story (full, or a partial > 0). */
-function platformCapturesAStory(block: DiffScopePlatformReport): boolean {
-  return block.full || block.capturedStoryFilePaths.length > 0;
 }
 
 /**

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -34,11 +34,11 @@ import {
   getValidatedCommandParams,
   handleClientError,
   logWarning,
-  printResultsUrl,
   printSherloIntro,
   reporting,
   waitForBuildResult,
 } from '../../helpers';
+import printLink from '../../helpers/printLink';
 import { computeBaseFingerprint, type GateMetadataInput } from '../../helpers/fingerprint';
 import { THIS_COMMAND } from './constants';
 import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from './buildBundle';
@@ -47,7 +47,7 @@ import { getOnStaleMode, handleStaleBase } from './onStale';
 import uploadStagedArtifacts, { type StagedUploadKeys } from './uploadStagedArtifacts';
 import { runDryRunPreview } from './dryRun';
 import { countBundleStories } from './readModuleManifest';
-import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
+import { SEPARATOR, formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
 /**
  * The per-platform staged build config plus the SHERLO-1894 `manifestS3Key` the api
@@ -343,13 +343,13 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
 
   const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
 
-  printResultsUrl(url);
-
-  // The command now EXPLAINS its own Diff Scope decision (SHERLO-1915): which
-  // stories this run captured, which it reused from the base, and why - read
-  // straight off the openBuild response, no extra API call. Prints nothing for a
-  // platform the server made no decision for (Diff Scope off, or older API).
-  printLiveDiffScopeReport({ openBuildReturn, bundles, platformsToTest });
+  // The command EXPLAINS its own capture plan (SHERLO-1919): which stories this
+  // run is capturing, which it is reusing from the previous build, and why - read
+  // straight off the openBuild response, no extra API call - then closes with
+  // "✓ Build created" and the Review URL LAST. Prints no plan block for a platform
+  // the server made no decision for (Diff Scope off, or older API), but always
+  // closes with the build-created line + URL so the link never disappears.
+  printCapturePlanAndCloser({ openBuildReturn, bundles, platformsToTest, url });
 
   if (commandParams.wait) {
     const exitCode = await waitForBuildResult({
@@ -374,23 +374,28 @@ export default testBundled;
 /* ========================================================================== */
 
 /**
- * Print this run's Diff Scope decision, per platform, straight off the openBuild
- * response (SHERLO-1915). No extra API call: `captureScope` carries the captured
+ * Print this run's capture plan, per platform, straight off the openBuild
+ * response (SHERLO-1919). No extra API call: `captureScope` carries the captured
  * set and `diffScopeInfo` carries the reason. Renders through the SAME shared
- * formatter the dry run uses, so the two modes read identically apart from tense.
+ * formatter the dry run uses, so the two modes read identically apart from the
+ * capture verb. Then closes with "✓ Build created" (dim " - running on devices"
+ * when at least one platform captured a story) and the Review URL LAST.
  *
  * A platform the server made no decision for (no `captureScope`) is skipped
- * entirely - silence, never an invented "captured everything". If NO platform
- * has a decision, nothing is printed at all.
+ * entirely - silence, never an invented "captured everything". If NO platform has
+ * a decision, no plan block prints, but the build-created line + URL still do so
+ * the developer always gets their link.
  */
-function printLiveDiffScopeReport({
+function printCapturePlanAndCloser({
   openBuildReturn,
   bundles,
   platformsToTest,
+  url,
 }: {
   openBuildReturn: Awaited<ReturnType<ReturnType<typeof sdkClient>['openBuild']>>;
   bundles: Partial<Record<Platform, BundleResult>>;
   platformsToTest: Platform[];
+  url: string;
 }): void {
   const diffScopeInfo = openBuildReturn.build.diffScopeInfo as
     | DiffScopeInfoWithPlatformReasons
@@ -421,9 +426,23 @@ function printLiveDiffScopeReport({
     });
   }
 
-  if (platforms.length === 0) return;
+  if (platforms.length > 0) {
+    console.log('\n' + formatDiffScopeReport('live', platforms));
+  }
 
-  console.log('\n' + formatDiffScopeReport('live', platforms));
+  // The closer, LAST (SHERLO-1919 ordering). "- running on devices" is shown when
+  // at least one platform is capturing a story; a run that reuses everything on
+  // every platform gets the plain "✓ Build created". With no plan at all (Diff
+  // Scope off) the build still runs on devices, so keep the suffix.
+  const somethingCaptured = platforms.length === 0 || platforms.some(platformCapturesAStory);
+  const runningSuffix = somethingCaptured ? chalk.dim(` ${SEPARATOR} running on devices`) : '';
+  console.log('\n' + chalk.green('✓') + chalk.bold(' Build created') + runningSuffix);
+  console.log(`🔗 Review: ${printLink(url)}`);
+}
+
+/** True when this platform is capturing at least one story (full, or a partial > 0). */
+function platformCapturesAStory(block: DiffScopePlatformReport): boolean {
+  return block.full || block.capturedStoryFilePaths.length > 0;
 }
 
 /**


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1919

https://sherlo-io.atlassian.net/browse/SHERLO-1919

## What this does

`test:bundled` replaces the SHERLO-1915 Diff Scope block with the operator-approved **Capture plan** format. The story list leads on partials, the explainer sentence is gone, and the formatting joins the same visual family as the bundling output around it.

Four repos move together: `sherlo` owns the layout, `sherlo-api` owns the words in the `why:` line (PR #298), `sherlo-tester` teaches the e2e parser the new format (PR #184), `sherlo-content` carries the copy deliverables (PR #21).

The operator/Director copy rulings (2026-07-23) are all applied. The output below is the final state, rendered by calling the merged formatter.

## The output, every case

```
📸 Capture plan
  🤖 Android - capturing 1 of 22 stories in this bundle, reusing 21 from the previous build
     why: Hello.stories.tsx changed
     stories:
       • Sanity/Hello
```

```
📸 Capture plan
  🤖 Android - capturing 6 of 22 stories in this bundle, reusing 16 from the previous build
     why: SharedButton.tsx changed
     stories:
       • Storefront/CheckoutScreen
       • Storefront/PriceTag
       • Storefront/PriceTagInline
       • Storefront/ProductCard
       • Storefront/ProductCardCompact
       • Storefront/SharedButton
```

The `why:` line's three tiers, server-composed and printed verbatim:

```
     why: SharedButton.tsx changed
     why: 3 files changed - SharedButton.tsx, theme.ts, Hello.stories.tsx
     why: 14 files changed
```

Nothing to capture:

```
📸 Capture plan
  🤖 Android - nothing to capture - no change reaches any story
     ✓ all 22 stories reused from the previous build
```

Full capture:

```
📸 Capture plan
  🤖 Android - capturing all 22 stories in this bundle
     why: first build - nothing to compare against yet
  🍎 iOS - capturing all 22 stories in this bundle
     why: native code changed - everything re-shot
```

Platforms disagree:

```
📸 Capture plan
  🍎 iOS - capturing 1 of 22 stories in this bundle, reusing 21 from the previous build
     why: ProductCardPlatformNote.ios.tsx changed
     stories:
       • Storefront/ProductCard
  🤖 Android - nothing to capture - no change reaches any story
     ✓ all 22 stories reused from the previous build
```

Dry run:

```
📸 Capture plan (dry run)
  🤖 Android - would capture 6 of 22 stories in this bundle, reusing 16 from the previous build
     why: SharedButton.tsx changed
     stories:
       • Storefront/CheckoutScreen
       • Storefront/PriceTag
       • Storefront/PriceTagInline
       • Storefront/ProductCard
       • Storefront/ProductCardCompact
       • Storefront/SharedButton

◦ Dry run - no build created, nothing uploaded
```

Decision unavailable (degraded / older server):

```
📸 Capture plan
  🤖 Android - capturing all 22 stories in this bundle
     ! couldn't compute what changed - capturing everything to be safe
```

Closer, always the plain form (Decision 5: the closer never promises runner behavior):

```
✓ Build created
🔗 Review: https://app.sherlo.io/build?t=mur_Yu_u&p=1&b=3
```

Degraded shapes with no mocked case:

```
  🤖 Android - capturing 1 story                          (no manifest, so no denominator - no "in this bundle")
  🤖 Android - capturing all 1 story in this bundle       (M is 1, singular agrees)
     ✓ all 1 story reused from the previous build         (M is 1, singular agrees)
  🤖 Android - capturing 1 of 1 stories in this bundle    (nothing reused, clause dropped)
  🤖 Android - capturing all 0 stories in this bundle     (empty manifest - reachable, pinned)
```

## Copy rulings applied

Every open copy item was ruled by the operator/Director and is applied here:

- **em dash → hyphen** - accepted; the ban is an org-wide operator rule and the hook enforces it. No em dash ships.
- **"in this bundle" restored** - the operator's original SHERLO-1915 wording naming the fraction's universe (so M is not misread as the `--include` scope) is back on the count line.
- **closer** - Decision 5 wins over the mocks: the `- running on devices` suffix is dropped everywhere; the closer is always plain `✓ Build created`.
- **why-line names basenames** - accepted; mock case 1's `Sanity/Hello.stories.tsx` renders `Hello.stories.tsx changed`.
- **duplicate basenames** - disambiguated only on collision: `2 files changed - api/index.ts, utils/index.ts`; non-colliding names stay bare (server-side).
- **zero-capture** - collapsed to `no change reaches any story` always; the phantom `the change never reaches the <platform> app` variant and its cross-platform coupling are deleted (server-side).
- **brand string** - `standard upload - only bundled builds can be narrowed`, brand-free (server-side).
- **dry-run tense** - kept as shipped (`would capture X, reusing Y` reads as a conditional participle).

## How the pieces fit

**The server owns the words, the CLI owns the layout.** Decision 3 keeps one copy owner, so `sherlo-api` composes the `why:` text and the CLI prints it verbatim. `describeCapturedStories` lost the `captured N -` prefix, the word `closure`, and the `(+N more)` overflow.

**No new wire fields.** Full-capture prose goes into the existing per-platform `platforms.<p>.reason`; the machine rung code stays on the build-wide `fullCaptureTriggerReason`. Nothing reading the code as an enum breaks, and the CLI's reason ladder never reaches its second rung.

**The dashboard needs no change.** `sherlo-frontend` has zero references to `diffScopeInfo`, `captureScope`, or `diffScope` - the reason is not rendered in the web app today, so the cross-surface byte-consistency criterion is met because there is no second surface.

**Ordering.** The Review URL moved last, behind the `✓ Build created` closer local to `test:bundled`. The shared `printResultsUrl` is untouched, so `easBuildOnComplete`, `testEasCloudBuild` and `uploadOrReuseBuildsAndRunTests` are unchanged. One deliberate consequence: a run with Diff Scope off now prints the closer and URL where it printed a bare URL, so the link never disappears.

**Simplifications.** `MAX_LISTED_STORIES` truncation is gone (full list, always). The `bailed-open` block type is gone - a dry-run bail-open maps onto "full capture, no reason", which the formatter renders as the `! couldn't compute` row. The closer's suffix-selection logic is gone with the ruling. The underlying dry-run error text stays in telemetry.

## E2E: a third vintage, not a replacement

The suite runs the PUBLISHED `@test` dist-tag CLI, and this format is not published - republishing is a manual `release_to_prod` `workflow_dispatch`, not a merge side effect. Replacing the post-1915 vintage would red the suite on merge against a CLI still printing the old strings. The parser reads all three and stays green whichever is installed. The cleanup rider is a `TODO(SHERLO-1919)` at the vintage table.

The hyphen rewrite had a consequence worth recording: the parser originally identified this format BY its em-dash separator. Once V3 used a hyphen like V1 and V2, that gate could no longer distinguish anything - and the suite stayed green, because the same pass rewrote the fixtures too. `isV3` now keys off the `📸 Capture plan` header, which is genuinely V3-only.

**Reason wording is orthogonal to format vintage.** The CLI prints whatever the deployed server composes, so the new reason strings reach the OLD published CLI too. That is why `01-cold-start.spec.ts` changed here despite no CLI republish: it asserted `platforms.<p>.reason === 'no-ancestor-manifest'`, now prose. It pins both halves of the split, which makes that one spec the proof the separation holds.

## Known edges

`M === 0` renders `capturing all 0 stories in this bundle`. It is reachable: `readValidatedModuleManifest` accepts any plain object for `storyClosures`, and an empty one passes, so a project with a manifest and no stories hits it. Pinned with a unit test so the edge is deliberate.

## Testing

Numbers from running the suites directly, not from the pre-push gate.

- `sherlo`: `npx vitest run` in packages/cli, testBundled subset = 155 passed. Full package = 483 passed, 2 skipped, 1 failed - the failure is `getGitInfo.test.ts` timing out at 30s building a 205-commit fixture (machine-speed flake), plus a second FILE failing at collection with zero failed tests (the known pre-existing `packagedFingerprint` ncc build failure). Neither is in testBundled.
- `sherlo-api`: `yarn test:unit` = 1409 passed, 3 skipped, 140 files. `tsc --noEmit` = 0 errors. `eslint ./src` = 0 errors, 582 pre-existing warnings.
- `sherlo-tester`: `yarn test` = 1127 passed, 59 files.

Gate notes, recorded rather than glossed:

- The pre-push gate cannot run tests in the `sherlo` repo - it fails with `spawn /bin/sh ENOENT`, a harness error rather than a result (same on SHERLO-1915).
- `yarn test` / `yarn lint` at the sherlo-api ROOT are `run-s ... test:*` / `lint:*` scripts whose glob an interactive shell eats, so both exit 0 in under a second having executed NOTHING. They are not evidence. The gate's own shell expanded them and caught a real `TS2677` error in `assembleDiffScope.ts`, fixed here. Use `yarn test:unit`, `npx tsc --noEmit`, `yarn lint:js`.
- The public-content-guard failed OPEN on the earlier `sherlo` pushes (`claude -p timed out after 25s`). It did not block and did not verify; content's deliverables cover these strings, but that coverage is unconfirmed by the guard itself.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
