### PR TITLE
feat: test:standard emits the module manifest at registration - so the FIRST test:bundled build can already take a partial (kills the per-project cold-start full)

### DIFF
--- a/packages/cli/src/commands/testBundled/__tests__/moduleManifestProducerParity.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/moduleManifestProducerParity.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Producer-header-parity test (SHERLO-1943, PRODUCER HEADER PARITY AC).
+ *
+ * test:standard does NOT implement a second module-manifest producer: it
+ * calls the EXACT same buildBundleForPlatform test:bundled uses. This is the
+ * structural half of the comparability proof - it drives BOTH paths against
+ * the same mocked bundler output on the same working tree and asserts the
+ * resulting manifest.header (metroVersion, babelConfigDigest, envDigest,
+ * envKeys) is byte-identical, because there is only one producer to route
+ * through.
+ *
+ * The bundler itself is mocked (same technique as buildBundle.test.ts) - no
+ * real Metro/expo process runs - but buildBundleForPlatform is NOT mocked:
+ * both the "test:bundled" call and the "test:standard" call below execute
+ * the real function.
+ */
+import chalk from 'chalk';
+chalk.level = 0;
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import zlib from 'zlib';
+import { execSync } from 'child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Platform } from '@sherlo/api-types';
+
+// ---------------------------------------------------------------------------
+// Mocks - bundler + surrounding project-detection only. buildBundleForPlatform
+// and emitAndUploadModuleManifests are REAL (not mocked).
+// ---------------------------------------------------------------------------
+
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+
+vi.mock('../../showError/detectBundler', () => ({
+  default: vi.fn(),
+  detectEntryFile: vi.fn(),
+}));
+
+vi.mock('../../init/requirements/getPackageVersion', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../readBundledSdkProtocolVersion', () => ({
+  readBundledSdkProtocolVersion: vi.fn(),
+}));
+
+const mocks = vi.hoisted(() => ({ putBuffer: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('../uploadStagedArtifacts', () => ({ putBuffer: mocks.putBuffer }));
+
+import detectBundlerDefault from '../../showError/detectBundler';
+import { detectEntryFile as detectEntryFileNamed } from '../../showError/detectBundler';
+import getPackageVersionDefault from '../../init/requirements/getPackageVersion';
+import { buildBundleForPlatform } from '../buildBundle';
+import { emitAndUploadModuleManifests } from '../../../helpers/emitAndUploadModuleManifests';
+
+const mockExecSync = vi.mocked(execSync);
+const mockDetectBundler = vi.mocked(detectBundlerDefault);
+const mockDetectEntryFile = vi.mocked(detectEntryFileNamed);
+const mockGetPackageVersion = vi.mocked(getPackageVersionDefault);
+
+// ---------------------------------------------------------------------------
+// Fixture: a fixed manifest sidecar the mocked bundler "emits" on every run.
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+const MANIFEST_REL = ['node_modules', '.cache', 'sherlo', 'module-manifest.json'];
+
+function manifestSidecarPath(): string {
+  return path.join(tempDir, ...MANIFEST_REL);
+}
+
+function manifestSidecarJson(): string {
+  return JSON.stringify({
+    version: 1,
+    header: {
+      metroVersion: '0.81.3',
+      babelConfigDigest: 'digest-abc123',
+      envDigest: 'env-digest-xyz789',
+      envKeys: ['NODE_ENV'],
+      absolutePathLeaks: [],
+    },
+    moduleHashes: { './src/App.tsx': 'a'.repeat(64) },
+    storyClosures: { './src/App.stories.tsx': ['./src/App.tsx'] },
+  });
+}
+
+/** Models a single platform's bundler + Metro serializer run, deterministically. */
+function mockBundlerRun() {
+  mockGetPackageVersion.mockReturnValue('0.76.0');
+  mockDetectBundler.mockReturnValue('rn');
+  mockDetectEntryFile.mockReturnValue('index.js');
+  mockExecSync.mockImplementation(((cmd: string) => {
+    const bundleMatch = cmd.match(/--bundle-output[= ](\S+)/);
+    if (bundleMatch) {
+      const dir = path.dirname(bundleMatch[1]);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(bundleMatch[1], Buffer.from('(function(global){})();', 'utf8'));
+    }
+    const mp = manifestSidecarPath();
+    fs.mkdirSync(path.dirname(mp), { recursive: true });
+    fs.writeFileSync(mp, manifestSidecarJson(), 'utf8');
+    return Buffer.alloc(0);
+  }) as any);
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-manifest-parity-'));
+  vi.clearAllMocks();
+  mocks.putBuffer.mockResolvedValue(undefined);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('module manifest producer parity (SHERLO-1943)', () => {
+  it('test:standard and test:bundled route through the SAME buildBundleForPlatform and produce byte-identical headers', async () => {
+    // --- "test:bundled" side: call the producer directly, exactly as
+    // testBundled.ts does. ---
+    mockBundlerRun();
+    const bundledResult = await buildBundleForPlatform({
+      projectRoot: tempDir,
+      platform: 'android' as Platform,
+    });
+    expect(bundledResult.moduleManifest).toBeDefined();
+    const bundledHeader = bundledResult.moduleManifest!.parsed.header;
+    const bundledRaw = bundledResult.moduleManifest!.raw;
+
+    // --- "test:standard" side: go through the guarded producer pass. The
+    // bundler mock is reset to model a fresh, independent bundler invocation
+    // on the SAME working tree (same fixed sidecar), then captured via the
+    // exact upload path emitAndUploadModuleManifests uses. ---
+    mockBundlerRun();
+    const client = {
+      getStagedUploadUrls: vi.fn().mockResolvedValue({
+        stagedPresignedUploadUrls: {
+          android: { manifest: { url: 'http://s3/manifest', s3Key: 'manifest-key' } },
+        },
+      }),
+    } as any;
+
+    const keys = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: tempDir,
+      platforms: ['android' as Platform],
+      gitInfo: { commitName: 'c', commitHash: 'h', branchName: 'b', isDirty: false },
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(keys.android).toBe('manifest-key');
+    expect(mocks.putBuffer).toHaveBeenCalledTimes(1);
+    const uploadedGzip: Buffer = mocks.putBuffer.mock.calls[0][0].buffer;
+    const uploadedRaw = zlib.gunzipSync(uploadedGzip);
+    const standardHeader = JSON.parse(uploadedRaw.toString('utf8')).header;
+
+    // The structural proof: both flows produced the manifest through the
+    // identical function, so the header - and the raw bytes wrapping it - are
+    // byte-identical.
+    expect(standardHeader).toEqual(bundledHeader);
+    expect(uploadedRaw.equals(bundledRaw)).toBe(true);
+
+    // Sanity: the bundler was actually invoked twice (once per "flow"), not
+    // stubbed away - this is a real (mocked-bundler) execution, not a fixture
+    // read from disk.
+    expect(mockExecSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cli/src/commands/testBundled/uploadStagedArtifacts.ts
+++ b/packages/cli/src/commands/testBundled/uploadStagedArtifacts.ts
@@ -128,7 +128,13 @@ export default uploadStagedArtifacts;
 
 /* ========================================================================== */
 
-async function putBuffer({
+/**
+ * PUTs a buffer to a presigned S3 URL with protocol-appropriate keep-alive +
+ * retry. Exported so other staged-upload producers (e.g. test:standard's
+ * module-manifest pass, SHERLO-1943) reuse the exact same upload mechanics
+ * instead of re-implementing the retry/agent logic.
+ */
+export async function putBuffer({
   platform,
   label,
   uploadUrl,

--- a/packages/cli/src/helpers/__tests__/emitAndUploadModuleManifests.test.ts
+++ b/packages/cli/src/helpers/__tests__/emitAndUploadModuleManifests.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for test:standard's module-manifest producer pass (SHERLO-1943).
+ *
+ * Covers:
+ *  - assessManifestProvenance: the hard provenance guard (clean tree + known
+ *    commit) that decides emit vs skip.
+ *  - emitAndUploadModuleManifests: REUSES buildBundleForPlatform (the exact
+ *    test:bundled producer) - never a second implementation - gzips + PUTs
+ *    the manifest via the SAME putBuffer testBundled's uploadStagedArtifacts
+ *    uses, and mirrors manifestS3Key per platform.
+ *  - Fail-soft: a bundling error, a missing upload slot, or a PUT failure
+ *    never throws - it degrades to "no manifest for that platform".
+ *  - Cost budget: when provenance is not vouched, buildBundleForPlatform is
+ *    never called at all (no wasted bundling pass).
+ */
+import chalk from 'chalk';
+chalk.level = 0;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitInfo } from '../getGitInfo';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  buildBundleForPlatform: vi.fn(),
+  putBuffer: vi.fn(),
+  logWarning: vi.fn(),
+}));
+
+vi.mock('../../commands/testBundled/buildBundle', () => ({
+  buildBundleForPlatform: mocks.buildBundleForPlatform,
+}));
+
+vi.mock('../../commands/testBundled/uploadStagedArtifacts', () => ({
+  putBuffer: mocks.putBuffer,
+}));
+
+vi.mock('../logWarning', () => ({ default: mocks.logWarning }));
+
+import {
+  assessManifestProvenance,
+  emitAndUploadModuleManifests,
+} from '../emitAndUploadModuleManifests';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function gitInfo(overrides: Partial<GitInfo> = {}): GitInfo {
+  return {
+    commitName: 'feat: my change',
+    commitHash: 'deadbeef',
+    branchName: 'my-branch',
+    isDirty: false,
+    ...overrides,
+  };
+}
+
+function manifest(raw = 'manifest-bytes') {
+  return {
+    raw: Buffer.from(raw, 'utf8'),
+    parsed: {
+      version: 1,
+      header: { metroVersion: '0.81.0' },
+      moduleHashes: {},
+      storyClosures: {},
+    },
+  };
+}
+
+function fakeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    getStagedUploadUrls: vi.fn().mockResolvedValue({
+      stagedPresignedUploadUrls: {
+        android: { manifest: { url: 'http://s3/android-manifest', s3Key: 'android-manifest-key' } },
+        ios: { manifest: { url: 'http://s3/ios-manifest', s3Key: 'ios-manifest-key' } },
+      },
+    }),
+    ...overrides,
+  } as any;
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.putBuffer.mockResolvedValue(undefined);
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// assessManifestProvenance - the hard guard
+// ---------------------------------------------------------------------------
+
+describe('assessManifestProvenance', () => {
+  it('vouches for a clean tree with known commit metadata', () => {
+    expect(assessManifestProvenance(gitInfo())).toEqual({ vouched: true });
+  });
+
+  it('refuses a dirty working tree', () => {
+    const result = assessManifestProvenance(gitInfo({ isDirty: true }));
+    expect(result.vouched).toBe(false);
+    if (!result.vouched) expect(result.reason).toContain('dirty');
+  });
+
+  it('refuses when dirtiness could not be determined (isDirty undefined)', () => {
+    const result = assessManifestProvenance(gitInfo({ isDirty: undefined }));
+    expect(result.vouched).toBe(false);
+    if (!result.vouched) expect(result.reason).toContain('could not be determined');
+  });
+
+  it('refuses the "unknown" commitHash sentinel even on a clean tree', () => {
+    const result = assessManifestProvenance(
+      gitInfo({ commitHash: 'unknown', commitName: 'unknown', isDirty: false })
+    );
+    expect(result.vouched).toBe(false);
+    if (!result.vouched) expect(result.reason).toContain('commit metadata');
+  });
+
+  it('refuses the "unknown" commitName sentinel even on a clean tree', () => {
+    const result = assessManifestProvenance(gitInfo({ commitName: 'unknown' }));
+    expect(result.vouched).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emitAndUploadModuleManifests - provenance-gated cost budget
+// ---------------------------------------------------------------------------
+
+describe('emitAndUploadModuleManifests - provenance skip', () => {
+  it('never calls buildBundleForPlatform when provenance is not vouched (no wasted bundling pass)', async () => {
+    const client = fakeClient();
+
+    const result = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo({ isDirty: true }),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({});
+    expect(mocks.buildBundleForPlatform).not.toHaveBeenCalled();
+    expect(client.getStagedUploadUrls).not.toHaveBeenCalled();
+  });
+
+  it('prints exactly one plain line stating the skip reason', async () => {
+    await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['ios'],
+      gitInfo: gitInfo({ isDirty: true }),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(mocks.logWarning).toHaveBeenCalledTimes(1);
+    const { message } = mocks.logWarning.mock.calls[0][0];
+    expect(message).toContain('Module manifest skipped');
+    expect(message).toContain('dirty');
+  });
+
+  it('returns {} and does nothing when there are no platforms', async () => {
+    const client = fakeClient();
+    const result = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: [],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({});
+    expect(mocks.buildBundleForPlatform).not.toHaveBeenCalled();
+    expect(client.getStagedUploadUrls).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emitAndUploadModuleManifests - vouched emit path
+// ---------------------------------------------------------------------------
+
+describe('emitAndUploadModuleManifests - vouched emit', () => {
+  it('calls buildBundleForPlatform with the EXACT test:bundled signature, per platform', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+
+    await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(mocks.buildBundleForPlatform).toHaveBeenCalledTimes(2);
+    expect(mocks.buildBundleForPlatform).toHaveBeenCalledWith({
+      projectRoot: '/proj',
+      platform: 'android',
+    });
+    expect(mocks.buildBundleForPlatform).toHaveBeenCalledWith({
+      projectRoot: '/proj',
+      platform: 'ios',
+    });
+  });
+
+  it('requests staged upload slots ONLY for platforms that produced a manifest', async () => {
+    mocks.buildBundleForPlatform.mockImplementation(async ({ platform }: { platform: string }) => ({
+      moduleManifest: platform === 'ios' ? manifest() : undefined,
+    }));
+    const client = fakeClient();
+
+    await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(client.getStagedUploadUrls).toHaveBeenCalledWith({
+      platforms: ['ios'],
+      projectIndex: 1,
+      teamId: 'team',
+    });
+  });
+
+  it('gzips the manifest raw bytes and PUTs them via the shared putBuffer', async () => {
+    const m = manifest('exact-raw-bytes');
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: m });
+
+    await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(mocks.putBuffer).toHaveBeenCalledTimes(1);
+    const call = mocks.putBuffer.mock.calls[0][0];
+    expect(call.platform).toBe('ios');
+    expect(call.uploadUrl).toBe('http://s3/ios-manifest');
+    // gzip, not raw bytes verbatim.
+    expect(call.buffer.equals(m.raw)).toBe(false);
+    const zlib = await import('zlib');
+    expect(zlib.gunzipSync(call.buffer).equals(m.raw)).toBe(true);
+  });
+
+  it('prints the house-style step line + a per-platform success checkmark (verbatim, no .snap)', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+
+    await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    const lines = logSpy.mock.calls.map((c: unknown[]) => c.join(' '));
+    expect(lines).toContain('\n📄 Producing the module manifest for Diff Scope...');
+    expect(lines).toContain('  ✓ iOS module manifest uploaded');
+  });
+
+  it('returns the manifestS3Key per platform - mirrors testBundled.ts wiring exactly', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+
+    const result = await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({ android: 'android-manifest-key', ios: 'ios-manifest-key' });
+  });
+
+  it('prints the skip warning as the ONLY console-facing call when nothing is uploaded', async () => {
+    // No manifest at all -> bail-open silently past the provenance line (which
+    // did not fire here, since provenance WAS vouched); no network call either.
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: undefined });
+    const client = fakeClient();
+
+    const result = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: ['android'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({});
+    expect(client.getStagedUploadUrls).not.toHaveBeenCalled();
+    expect(mocks.logWarning).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-soft: never throws, always degrades
+// ---------------------------------------------------------------------------
+
+describe('emitAndUploadModuleManifests - fail-soft', () => {
+  it('swallows a buildBundleForPlatform rejection for one platform, still emits the other', async () => {
+    mocks.buildBundleForPlatform.mockImplementation(async ({ platform }: { platform: string }) => {
+      if (platform === 'android') throw new Error('bundler exploded');
+      return { moduleManifest: manifest() };
+    });
+
+    const result = await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({ ios: 'ios-manifest-key' });
+    expect(mocks.logWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('bundler exploded') })
+    );
+  });
+
+  it('swallows a getStagedUploadUrls rejection and returns {}', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+    const client = fakeClient({
+      getStagedUploadUrls: vi.fn().mockRejectedValue(new Error('network down')),
+    });
+
+    const result = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: ['ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({});
+    expect(mocks.logWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('network down') })
+    );
+  });
+
+  it('swallows a putBuffer rejection for one platform, still emits the other', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+    mocks.putBuffer.mockImplementation(async ({ platform }: { platform: string }) => {
+      if (platform === 'android') throw new Error('S3 PUT failed');
+    });
+
+    const result = await emitAndUploadModuleManifests({
+      client: fakeClient(),
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({ ios: 'ios-manifest-key' });
+    expect(mocks.logWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('S3 PUT failed') })
+    );
+  });
+
+  it('skips a platform whose upload-slot response has no manifest entry (bail-open)', async () => {
+    mocks.buildBundleForPlatform.mockResolvedValue({ moduleManifest: manifest() });
+    const client = fakeClient({
+      getStagedUploadUrls: vi.fn().mockResolvedValue({
+        stagedPresignedUploadUrls: { ios: {} }, // no `.manifest` slot - old API
+      }),
+    });
+
+    const result = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: '/proj',
+      platforms: ['ios'],
+      gitInfo: gitInfo(),
+      projectIndex: 1,
+      teamId: 'team',
+    });
+
+    expect(result).toEqual({});
+    expect(mocks.putBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/helpers/__tests__/openBuildPayload.contract.test.ts
+++ b/packages/cli/src/helpers/__tests__/openBuildPayload.contract.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => {
     registerBase: vi.fn(),
     waitForBuildResult: vi.fn(),
     logWarning: vi.fn(),
+    emitAndUploadModuleManifests: vi.fn(),
   };
 });
 
@@ -61,6 +62,9 @@ vi.mock('../waitForBuildResult', () => ({ default: mocks.waitForBuildResult }));
 vi.mock('../fingerprint', () => ({
   computeBaseFingerprint: mocks.computeBaseFingerprint,
   registerBase: mocks.registerBase,
+}));
+vi.mock('../emitAndUploadModuleManifests', () => ({
+  emitAndUploadModuleManifests: mocks.emitAndUploadModuleManifests,
 }));
 
 import uploadOrReuseBuildsAndRunTests from '../uploadOrReuseBuildsAndRunTests';
@@ -134,6 +138,7 @@ beforeEach(() => {
   // exercised independently of the base-fingerprint spread.
   mocks.computeBaseFingerprint.mockResolvedValue({ hash: null, nativeFingerprint: 'native-fp' });
   mocks.registerBase.mockResolvedValue({ gateMetadata: undefined });
+  mocks.emitAndUploadModuleManifests.mockResolvedValue({});
   mocks.getAppBuildUrl.mockReturnValue('https://app.sherlo.io/team1234/7/build/42');
   mocks.openBuild.mockResolvedValue({ build: { index: 42 } });
   vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -290,6 +295,76 @@ describe('reuse-vs-upload branch selection', () => {
       android: 'android-hash',
       ios: 'ios-hash',
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Module manifest wiring (SHERLO-1943) - reuses the SAME producer as
+// test:bundled via emitAndUploadModuleManifests; only the wiring at the
+// openBuild-payload boundary is exercised here (the producer/guard logic has
+// its own suite in emitAndUploadModuleManifests.test.ts).
+// ---------------------------------------------------------------------------
+
+describe('module manifest wiring (SHERLO-1943)', () => {
+  beforeEach(() => {
+    mocks.computeBaseFingerprint.mockResolvedValue({ hash: 'base-fp-hash' });
+    mocks.registerBase.mockResolvedValue({ gateMetadata: undefined });
+    mocks.getBuildRunConfig.mockReturnValue({ android: {}, ios: {} });
+  });
+
+  it('runs the manifest pass with the platforms being registered + the SAME gitInfo, only when a base fingerprint exists', async () => {
+    await callSubject();
+
+    expect(mocks.emitAndUploadModuleManifests).toHaveBeenCalledTimes(1);
+    expect(mocks.emitAndUploadModuleManifests).toHaveBeenCalledWith({
+      client: expect.anything(),
+      projectRoot: '/proj',
+      platforms: ['android', 'ios'],
+      gitInfo: GIT_INFO,
+      projectIndex: 7,
+      teamId: 'team1234',
+    });
+  });
+
+  it('never runs the manifest pass when there is no base fingerprint (nothing to compare it against)', async () => {
+    mocks.computeBaseFingerprint.mockResolvedValue({ hash: null });
+
+    await callSubject();
+
+    expect(mocks.emitAndUploadModuleManifests).not.toHaveBeenCalled();
+  });
+
+  it('mirrors manifestS3Key onto each platform config when the pass vouched and uploaded (present)', async () => {
+    mocks.emitAndUploadModuleManifests.mockResolvedValue({
+      android: 'android-manifest-key',
+      ios: 'ios-manifest-key',
+    });
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect(payload.buildRunConfig.android.manifestS3Key).toBe('android-manifest-key');
+    expect(payload.buildRunConfig.ios.manifestS3Key).toBe('ios-manifest-key');
+  });
+
+  it('does NOT set manifestS3Key when the pass was skipped/failed (bail-open, absent)', async () => {
+    mocks.emitAndUploadModuleManifests.mockResolvedValue({});
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect('manifestS3Key' in payload.buildRunConfig.android).toBe(false);
+    expect('manifestS3Key' in payload.buildRunConfig.ios).toBe(false);
+  });
+
+  it('sets manifestS3Key only for the platform that got one (partial vouch/upload)', async () => {
+    mocks.emitAndUploadModuleManifests.mockResolvedValue({ ios: 'ios-manifest-key' });
+
+    await callSubject();
+    const payload = lastOpenBuildPayload();
+
+    expect('manifestS3Key' in payload.buildRunConfig.android).toBe(false);
+    expect(payload.buildRunConfig.ios.manifestS3Key).toBe('ios-manifest-key');
   });
 });
 

--- a/packages/cli/src/helpers/emitAndUploadModuleManifests.ts
+++ b/packages/cli/src/helpers/emitAndUploadModuleManifests.ts
@@ -1,0 +1,197 @@
+/**
+ * test:standard's module-manifest producer pass (SHERLO-1943).
+ *
+ * test:standard registers a user-supplied PRE-BUILT binary as the stageable
+ * base; it has no bundling step of its own. To let a later test:bundled run
+ * compare its module manifest against an ancestor, test:standard runs
+ * Sherlo's OWN bundling pass here purely to produce that manifest - the EXACT
+ * same producer test:bundled uses ({@link buildBundleForPlatform} from
+ * commands/testBundled/buildBundle.ts, which sets SHERLO_MODULE_MANIFEST=1 and
+ * reads the sidecar via readValidatedModuleManifest). No second producer is
+ * implemented here: same producer + same env header => guaranteed comparable
+ * with whatever manifest test:bundled would emit on the same tree.
+ *
+ * HARD PROVENANCE GUARD: because test:standard's binary is user-supplied
+ * (requirePlatformPaths: true), the CLI can only vouch that a manifest built
+ * from the CURRENT working tree actually describes that binary's provenance
+ * when the tree is clean and the commit is known. When it can't vouch, this
+ * pass is skipped entirely (no bundling, no upload, no manifestS3Key) and one
+ * plain line states why - degrading to today's cold-start full run, never to
+ * a wrong partial one.
+ *
+ * Fail-soft throughout: any bundling, upload-slot, or upload failure is
+ * logged and swallowed. A module-manifest problem can never fail or slow down
+ * (beyond the one bundling pass) a test:standard run.
+ */
+import zlib from 'zlib';
+import { Platform, StagedPlatformUploadUrls, StagedPresignedUploadUrl } from '@sherlo/api-types';
+import sdkClient from '@sherlo/sdk-client';
+import chalk from 'chalk';
+import { PLATFORM_LABEL } from '../constants';
+import { buildBundleForPlatform } from '../commands/testBundled/buildBundle';
+import { putBuffer } from '../commands/testBundled/uploadStagedArtifacts';
+import type { GitInfo } from './getGitInfo';
+import logWarning from './logWarning';
+
+/**
+ * getStagedUploadUrls with the SHERLO-1894 `manifest` slot. Optional on
+ * purpose - see the identical local extension in uploadStagedArtifacts.ts.
+ */
+type StagedUploadUrlsWithManifest = StagedPlatformUploadUrls & {
+  manifest?: StagedPresignedUploadUrl;
+};
+
+export type ModuleManifestUploadResult = Partial<Record<Platform, string>>;
+
+// ---------------------------------------------------------------------------
+// Provenance guard
+// ---------------------------------------------------------------------------
+
+export type ProvenanceAssessment = { vouched: true } | { vouched: false; reason: string };
+
+/**
+ * Can the CLI vouch that a manifest built from the CURRENT working tree
+ * describes the SAME provenance as the pre-built binary test:standard is
+ * about to register? Only when:
+ *  - the working tree is clean (`isDirty === false`, not merely falsy - an
+ *    UNDETERMINED dirtiness must refuse, not pass), AND
+ *  - commit metadata is present and not the getGitInfo `'unknown'` sentinel.
+ *
+ * A wrong-commit / dirty-tree prebuilt binary must NEVER gain a lying
+ * manifest, so both checks default to refusing when uncertain.
+ */
+export function assessManifestProvenance(gitInfo: GitInfo): ProvenanceAssessment {
+  if (gitInfo.isDirty !== false) {
+    return {
+      vouched: false,
+      reason: 'the git working tree is dirty (or its cleanliness could not be determined)',
+    };
+  }
+
+  if (
+    !gitInfo.commitHash ||
+    gitInfo.commitHash === 'unknown' ||
+    !gitInfo.commitName ||
+    gitInfo.commitName === 'unknown'
+  ) {
+    return { vouched: false, reason: 'commit metadata could not be determined' };
+  }
+
+  return { vouched: true };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces + uploads the per-platform module manifest for a test:standard
+ * registration, guarded by {@link assessManifestProvenance}.
+ *
+ * Returns the per-platform manifest S3 key to mirror onto the openBuild
+ * buildRunConfig (mirrors testBundled.ts's `manifestS3Key` wiring exactly).
+ * Absent entries mean "send nothing extra" - never a fabricated key.
+ */
+export async function emitAndUploadModuleManifests({
+  client,
+  projectRoot,
+  platforms,
+  gitInfo,
+  projectIndex,
+  teamId,
+}: {
+  client: ReturnType<typeof sdkClient>;
+  projectRoot: string;
+  platforms: Platform[];
+  gitInfo: GitInfo;
+  projectIndex: number;
+  teamId: string;
+}): Promise<ModuleManifestUploadResult> {
+  if (platforms.length === 0) return {};
+
+  const provenance = assessManifestProvenance(gitInfo);
+  if (!provenance.vouched) {
+    logWarning({
+      message: `Module manifest skipped - ${provenance.reason}; degrading to a full capture.`,
+    });
+    return {};
+  }
+
+  console.log(chalk.cyan('\n📄 Producing the module manifest for Diff Scope...'));
+
+  // 1. Build the bundle for each platform via the EXACT test:bundled producer,
+  //    purely to obtain the manifest sidecar it emits. Fail-soft per platform:
+  //    a bundling failure here must never block test:standard's real run.
+  const manifests: Partial<Record<Platform, Buffer>> = {};
+
+  for (const platform of platforms) {
+    try {
+      const { moduleManifest } = await buildBundleForPlatform({ projectRoot, platform });
+      if (moduleManifest) {
+        manifests[platform] = moduleManifest.raw;
+      }
+    } catch (error) {
+      logWarning({
+        message:
+          `Could not produce the ${PLATFORM_LABEL[platform]} module manifest ` +
+          `(${error instanceof Error ? error.message : String(error)}); continuing without it.`,
+      });
+    }
+  }
+
+  const platformsWithManifest = platforms.filter(
+    (platform): platform is Platform => manifests[platform] !== undefined
+  );
+  if (platformsWithManifest.length === 0) return {};
+
+  // 2. Request staged manifest upload slots - mirrors testBundled.ts's
+  //    getStagedUploadUrls call exactly (same API, same wire shape).
+  let stagedPresignedUploadUrls: Partial<Record<Platform, StagedUploadUrlsWithManifest>>;
+  try {
+    ({ stagedPresignedUploadUrls } = await client.getStagedUploadUrls({
+      platforms: platformsWithManifest,
+      projectIndex,
+      teamId,
+    }));
+  } catch (error) {
+    logWarning({
+      message:
+        'Could not request module manifest upload slots ' +
+        `(${error instanceof Error ? error.message : String(error)}); continuing without them.`,
+    });
+    return {};
+  }
+
+  // 3. Gzip + PUT each manifest's raw bytes, same as uploadStagedArtifacts.ts's
+  //    manifest branch. Bail-open per platform: an upload-slot miss or a PUT
+  //    failure is warned and skipped, never fatal.
+  const result: ModuleManifestUploadResult = {};
+
+  for (const platform of platformsWithManifest) {
+    const manifestRaw = manifests[platform];
+    const manifestUrl = stagedPresignedUploadUrls[platform]?.manifest;
+    if (!manifestRaw || !manifestUrl) continue;
+
+    try {
+      const gzipped = zlib.gzipSync(manifestRaw);
+      await putBuffer({
+        platform,
+        label: 'module manifest',
+        uploadUrl: manifestUrl.url,
+        buffer: gzipped,
+      });
+      result[platform] = manifestUrl.s3Key;
+      console.log(chalk.green(`  ✓ ${PLATFORM_LABEL[platform]} module manifest uploaded`));
+    } catch (error) {
+      logWarning({
+        message:
+          `Failed to upload the ${PLATFORM_LABEL[platform]} module manifest ` +
+          `(${error instanceof Error ? error.message : String(error)}); continuing without it.`,
+      });
+    }
+  }
+
+  return result;
+}
+
+export default emitAndUploadModuleManifests;

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -1,8 +1,10 @@
 import sdkClient from '@sherlo/sdk-client';
+import { Platform } from '@sherlo/api-types';
 import chalk from 'chalk';
 import logWarning from './logWarning';
 import { TEST_EAS_UPDATE_COMMAND, TEST_STANDARD_COMMAND } from '../constants';
 import { CommandParams, EasUpdateData } from '../types';
+import { emitAndUploadModuleManifests } from './emitAndUploadModuleManifests';
 import getAppBuildUrl from './getAppBuildUrl';
 import getBuildRunConfig from './getBuildRunConfig';
 import getGitInfo from './getGitInfo';
@@ -15,6 +17,15 @@ import reporting from './reporting';
 import { computeBaseFingerprint, registerBase, type GateMetadataInput } from './fingerprint';
 import uploadOrPrintBinaryReuse from './uploadOrPrintBinaryReuse';
 import waitForBuildResult from './waitForBuildResult';
+
+/**
+ * The per-platform `manifestS3Key` the api department is adding to the
+ * openBuild `buildRunConfig` in parallel (SHERLO-1894/1943). Optional and
+ * local for the same reason testBundled.ts's `PlatformConfigWithManifest`
+ * is: the published @sherlo/api-types config type this repo typechecks
+ * against does not carry it yet. Drop once api-types republishes with it.
+ */
+type PlatformConfigWithManifest = { manifestS3Key?: string };
 
 async function uploadOrReuseBuildsAndRunTests({
   commandParams,
@@ -72,12 +83,13 @@ async function uploadOrReuseBuildsAndRunTests({
 
   let baseFingerprint: string | undefined;
   const gateMetadata: { android?: GateMetadataInput; ios?: GateMetadataInput } = {};
+  let manifestS3Keys: Partial<Record<Platform, string>> = {};
 
   if (fpResult.hash) {
     baseFingerprint = fpResult.hash;
 
     // Extract gate metadata per platform (fail-soft per platform).
-    const platforms: ('android' | 'ios')[] = [];
+    const platforms: Platform[] = [];
     if (binariesInfo.android && commandParams.android) platforms.push('android');
     if (binariesInfo.ios && commandParams.ios) platforms.push('ios');
 
@@ -104,12 +116,45 @@ async function uploadOrReuseBuildsAndRunTests({
         // Fail-soft: base registration errors are non-fatal.
       }
     }
+
+    // SHERLO-1943: emit + upload the per-platform module manifest via the SAME
+    // producer test:bundled uses, guarded by provenance (clean tree + known
+    // commit). Runs alongside base registration since the manifest is only
+    // meaningful when compared against the base being registered here.
+    manifestS3Keys = await emitAndUploadModuleManifests({
+      client,
+      projectRoot: commandParams.projectRoot,
+      platforms,
+      gitInfo,
+      projectIndex,
+      teamId,
+    });
   } else {
     logWarning({
       message: `Staged uploads unavailable - ${
         fpResult.debugMessage ?? 'fingerprint computation failed'
       }`,
     });
+  }
+
+  const buildRunConfig = getBuildRunConfig({
+    commandParams,
+    binaryS3Keys: {
+      android: binariesInfo.android?.s3Key,
+      ios: binariesInfo.ios?.s3Key,
+    },
+    easUpdateData,
+  });
+
+  // Mirror the manifest S3 key onto its platform config, exactly like
+  // testBundled.ts's manifestS3Key wiring. Only set when present, so a
+  // skipped/failed manifest sends nothing extra.
+  for (const platform of Object.keys(manifestS3Keys) as Platform[]) {
+    const key = manifestS3Keys[platform];
+    const platformConfig = buildRunConfig[platform];
+    if (platformConfig && key) {
+      (platformConfig as PlatformConfigWithManifest).manifestS3Key = key;
+    }
   }
 
   reporting.addBreadcrumb({
@@ -131,14 +176,7 @@ async function uploadOrReuseBuildsAndRunTests({
         android: binariesInfo.android?.fileName,
         ios: binariesInfo.ios?.fileName,
       },
-      buildRunConfig: getBuildRunConfig({
-        commandParams,
-        binaryS3Keys: {
-          android: binariesInfo.android?.s3Key,
-          ios: binariesInfo.ios?.s3Key,
-        },
-        easUpdateData,
-      }),
+      buildRunConfig,
       gitInfo,
       sdkVersion: binariesInfo.sdkVersion,
       message: commandParams.message,


### PR DESCRIPTION
🔁 **Loop channel PR for SHERLO-1942**

This draft PR is the single communication channel for this loop task (SHERLO-1728).
All `[loop:*]` dialogue lives here; the task branch is the cross-repo join key.
It starts as a draft on an empty bootstrap commit and is promoted to ready on the first real push.

https://sherlo-io.atlassian.net/browse/SHERLO-1942