### PR TITLE
feat: Zero-capture bundled builds: API bypasses the runner entirely (server-known zero + config-scope intersection); runner's noStories error stays for genuine scope/bundle inconsistency

### DIFF
--- a/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
+++ b/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`waitForBuildResult > server-bypassed build closing message > prints the "nothing needed capturing" closing line and pins its wording 1`] = `
+"⏳ Waiting for build results (timeout: 45min)...
+   🟢 Finished
+
+✅ Nothing needed capturing - every screenshot was reused from the previous build.
+   Sanity/Hello.stories.tsx changed
+   https://app.sherlo.io/build?t=BBBBBBBB&p=42&b=1
+"
+`;

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -7,6 +7,7 @@
  */
 
 import fetch from 'node-fetch';
+import chalk from 'chalk';
 import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
 import waitForBuildResult, {
   EXIT_BLOCK,
@@ -14,6 +15,8 @@ import waitForBuildResult, {
   EXIT_GREEN,
   EXIT_TIMEOUT,
 } from '../waitForBuildResult';
+
+chalk.level = 0;
 
 // The token format used throughout: 32-char apiToken + 8-char teamId + projectIndex
 const API_TOKEN = 'A'.repeat(32);
@@ -32,13 +35,19 @@ const mockFetch = fetch as unknown as Mock;
 function buildResponse(
   runStatus: string,
   viewStatusesCount?: { approved: number; noChanges: number; reported: number; unreviewed: number },
-  runError?: unknown
+  runError?: unknown,
+  diffScopeInfo?: {
+    capturedSnapshotCount?: number;
+    inheritedSnapshotCount?: number;
+    fullCaptureTriggerReason?: string;
+  }
 ): { getBuildStatus: Record<string, unknown> } {
   return {
     getBuildStatus: {
       runStatus,
       viewStatusesCount: viewStatusesCount ?? null,
       runError: runError ?? null,
+      diffScopeInfo: diffScopeInfo ?? null,
       startedAt: null,
       queuedAt: null,
       finishedAt: null,
@@ -122,6 +131,136 @@ describe('waitForBuildResult', () => {
     const result = await promise;
 
     expect(result).toBe(EXIT_GREEN);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* EXIT 0 - GREEN, server-bypassed build (SHERLO-1959/1962)             */
+  /* the API closed the build without ever running it: zero captures,    */
+  /* every snapshot inherited, diffScopeInfo reason preserved             */
+  /* ------------------------------------------------------------------ */
+
+  describe('server-bypassed build closing message', () => {
+    function printedOutput(spy: ReturnType<typeof vi.spyOn>): string {
+      return spy.mock.calls.map((call: unknown[]) => call[0] ?? '').join('\n');
+    }
+
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    it('prints the "nothing needed capturing" closing line and pins its wording', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 },
+          undefined,
+          {
+            capturedSnapshotCount: 0,
+            inheritedSnapshotCount: 15,
+            fullCaptureTriggerReason: 'Sanity/Hello.stories.tsx changed',
+          }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_GREEN);
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toMatchSnapshot();
+    });
+
+    it('falls back to the generic green message when diffScopeInfo is absent', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse('finished', { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 })
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('All stories passed');
+      expect(printed).not.toContain('Nothing needed capturing');
+    });
+
+    it('falls back to the generic green message when capturedSnapshotCount is not 0', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 },
+          undefined,
+          {
+            capturedSnapshotCount: 2,
+            inheritedSnapshotCount: 13,
+            fullCaptureTriggerReason: 'reason',
+          }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('All stories passed');
+      expect(printed).not.toContain('Nothing needed capturing');
+    });
+
+    it('falls back to the generic green message when no reason is present', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 },
+          undefined,
+          { capturedSnapshotCount: 0, inheritedSnapshotCount: 15 }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('All stories passed');
+      expect(printed).not.toContain('Nothing needed capturing');
+    });
   });
 
   /* ------------------------------------------------------------------ */

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -44,6 +44,21 @@ type BuildStatusResponse = {
       unreviewed: number;
     };
     runError?: unknown;
+    /**
+     * Build-wide Diff Scope capture accounting, mirrored off Build.diffScopeInfo
+     * (same shape already used by BuildFragment/CloseBuildFragment elsewhere in
+     * the API). Absent on older API responses -> the closing message degrades to
+     * the generic "All stories passed" line (SHERLO-1962). A server-bypassed
+     * build (SHERLO-1959: the runner never ran because the server already knew
+     * every story's screenshot could be inherited) reports capturedSnapshotCount
+     * 0, inheritedSnapshotCount equal to the whole suite, and
+     * fullCaptureTriggerReason carrying the server's explanation.
+     */
+    diffScopeInfo?: {
+      capturedSnapshotCount?: number;
+      inheritedSnapshotCount?: number;
+      fullCaptureTriggerReason?: string;
+    };
   } | null;
 };
 
@@ -187,6 +202,11 @@ async function fetchBuildStatus(
               unreviewed
             }
             runError
+            diffScopeInfo {
+              capturedSnapshotCount
+              inheritedSnapshotCount
+              fullCaptureTriggerReason
+            }
           }
         }
       `,
@@ -220,7 +240,7 @@ function evaluateTerminalState(
   build: NonNullable<BuildStatusResponse['getBuildStatus']>,
   url: string
 ): number | null {
-  const { runStatus, viewStatusesCount } = build;
+  const { runStatus, viewStatusesCount, diffScopeInfo } = build;
 
   switch (runStatus) {
     case 'finished': {
@@ -229,7 +249,16 @@ function evaluateTerminalState(
 
       if (unreviewed === 0 && reported === 0) {
         console.log();
-        console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
+        if (isServerBypassed(diffScopeInfo)) {
+          console.log(
+            chalk.green(
+              '✅ Nothing needed capturing - every screenshot was reused from the previous build.'
+            )
+          );
+          console.log(chalk.dim(`   ${diffScopeInfo!.fullCaptureTriggerReason}`));
+        } else {
+          console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
+        }
         console.log(chalk.blue(`   ${url}`));
         console.log();
         return EXIT_GREEN;
@@ -264,6 +293,25 @@ function evaluateTerminalState(
       // queued, waiting, inProgress - still running
       return null;
   }
+}
+
+/**
+ * A server-bypassed build (SHERLO-1959): the API already knew every story's
+ * screenshot could be inherited from the previous build, so it closed the
+ * build without ever handing it to the runner. Recognized off the SAME shape
+ * closeBuild fills for the GitHub check summary - zero captures, at least one
+ * inherited snapshot, and the server's reason for the decision - never
+ * inferred from the absence of a runner error, which also covers other
+ * "nothing changed" cases the generic message already handles correctly.
+ */
+function isServerBypassed(
+  diffScopeInfo: NonNullable<BuildStatusResponse['getBuildStatus']>['diffScopeInfo']
+): boolean {
+  return (
+    diffScopeInfo?.capturedSnapshotCount === 0 &&
+    (diffScopeInfo?.inheritedSnapshotCount ?? 0) > 0 &&
+    Boolean(diffScopeInfo?.fullCaptureTriggerReason)
+  );
 }
 
 function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStatus']>): string {


### PR DESCRIPTION
🔁 **Loop channel PR for SHERLO-1959**

This draft PR is the single communication channel for this loop task (SHERLO-1728).
All `[loop:*]` dialogue lives here; the task branch is the cross-repo join key.
It starts as a draft on an empty bootstrap commit and is promoted to ready on the first real push.

https://sherlo-io.atlassian.net/browse/SHERLO-1959