### PR TITLE
feat: Un-skip S1 (config-scope) now SHERLO-1959 shipped - remove t…

### DIFF
--- a/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
+++ b/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
@@ -5,7 +5,7 @@ exports[`waitForBuildResult > server-bypassed build closing message > prints the
    🟢 Finished
 
 ✅ Nothing needed capturing - every screenshot was reused from the previous build.
-   Sanity/Hello.stories.tsx changed
+   no change reaches any story
    https://app.sherlo.io/build?t=BBBBBBBB&p=42&b=1
 "
 `;

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -39,7 +39,10 @@ function buildResponse(
   diffScopeInfo?: {
     capturedSnapshotCount?: number;
     inheritedSnapshotCount?: number;
-    fullCaptureTriggerReason?: string;
+    platforms?: {
+      android?: { reason?: string };
+      ios?: { reason?: string };
+    };
   }
 ): { getBuildStatus: Record<string, unknown> } {
   return {
@@ -134,9 +137,15 @@ describe('waitForBuildResult', () => {
   });
 
   /* ------------------------------------------------------------------ */
-  /* EXIT 0 - GREEN, server-bypassed build (SHERLO-1959/1962)             */
+  /* EXIT 0 - GREEN, server-bypassed build (SHERLO-1959/1962/1963)        */
   /* the API closed the build without ever running it: zero captures,    */
-  /* every snapshot inherited, diffScopeInfo reason preserved             */
+  /* every snapshot inherited, per-platform prose reason preserved.       */
+  /*                                                                      */
+  /* Fixtures mirror the REAL persisted shape pinned by the API's own     */
+  /* closeAsZeroCaptureNoOp.unit.test.ts: the reason lives in             */
+  /* diffScopeInfo.platforms.<platform>.reason (plain prose), and there   */
+  /* is NO fullCaptureTriggerReason (a machine enum code only ever set on */
+  /* a FULL capture, never on a bypassed partial-capture build).          */
   /* ------------------------------------------------------------------ */
 
   describe('server-bypassed build closing message', () => {
@@ -164,7 +173,7 @@ describe('waitForBuildResult', () => {
           {
             capturedSnapshotCount: 0,
             inheritedSnapshotCount: 15,
-            fullCaptureTriggerReason: 'Sanity/Hello.stories.tsx changed',
+            platforms: { android: { reason: 'no change reaches any story' } },
           }
         )
       );
@@ -183,6 +192,111 @@ describe('waitForBuildResult', () => {
 
       const printed = printedOutput(logSpy);
       expect(printed).toMatchSnapshot();
+    });
+
+    it('prints the bypassed closer off the real API shape even with no fullCaptureTriggerReason (regression, SHERLO-1963)', async () => {
+      // Exactly what the deployed API persists for a server-bypassed build:
+      // zero captured, some inherited, a per-platform prose reason, and NO
+      // fullCaptureTriggerReason. Under the pre-fix gate (which required
+      // fullCaptureTriggerReason) this case wrongly printed the generic line.
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 0, noChanges: 2, reported: 0, unreviewed: 0 },
+          undefined,
+          {
+            capturedSnapshotCount: 0,
+            inheritedSnapshotCount: 2,
+            platforms: { android: { reason: 'no change reaches any story' } },
+          }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_GREEN);
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('Nothing needed capturing');
+      // The platform reason is printed verbatim as the closer's reason line.
+      expect(printed).toContain('no change reaches any story');
+      expect(printed).not.toContain('All stories passed');
+    });
+
+    it('picks the android reason when both platforms carry prose (deterministic tie-break)', async () => {
+      // Both platforms present with distinct prose: the fixed
+      // PLATFORM_REASON_ORDER (android, then ios) makes the chosen line
+      // deterministic regardless of JSON key order.
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 0, noChanges: 4, reported: 0, unreviewed: 0 },
+          undefined,
+          {
+            capturedSnapshotCount: 0,
+            inheritedSnapshotCount: 4,
+            platforms: {
+              android: { reason: 'no change reaches any story' },
+              ios: { reason: 'ios: nothing to capture' },
+            },
+          }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('Nothing needed capturing');
+      expect(printed).toContain('no change reaches any story');
+      expect(printed).not.toContain('ios: nothing to capture');
+    });
+
+    it('falls back to the ios reason when only ios carries prose', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse(
+          'finished',
+          { approved: 0, noChanges: 3, reported: 0, unreviewed: 0 },
+          undefined,
+          {
+            capturedSnapshotCount: 0,
+            inheritedSnapshotCount: 3,
+            platforms: { ios: { reason: 'no change reaches any story' } },
+          }
+        )
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const printed = printedOutput(logSpy);
+      expect(printed).toContain('Nothing needed capturing');
+      expect(printed).toContain('no change reaches any story');
     });
 
     it('falls back to the generic green message when diffScopeInfo is absent', async () => {
@@ -216,7 +330,7 @@ describe('waitForBuildResult', () => {
           {
             capturedSnapshotCount: 2,
             inheritedSnapshotCount: 13,
-            fullCaptureTriggerReason: 'reason',
+            platforms: { android: { reason: 'no change reaches any story' } },
           }
         )
       );
@@ -236,7 +350,7 @@ describe('waitForBuildResult', () => {
       expect(printed).not.toContain('Nothing needed capturing');
     });
 
-    it('falls back to the generic green message when no reason is present', async () => {
+    it('falls back to the generic green message when no platform reason is present', async () => {
       mockGraphqlResponse(
         200,
         buildResponse(

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -51,13 +51,23 @@ type BuildStatusResponse = {
      * the generic "All stories passed" line (SHERLO-1962). A server-bypassed
      * build (SHERLO-1959: the runner never ran because the server already knew
      * every story's screenshot could be inherited) reports capturedSnapshotCount
-     * 0, inheritedSnapshotCount equal to the whole suite, and
-     * fullCaptureTriggerReason carrying the server's explanation.
+     * 0, inheritedSnapshotCount equal to the whole suite, and a per-platform
+     * `platforms.<platform>.reason` carrying the server's plain-prose explanation.
+     *
+     * We read `platforms.<platform>.reason`, NOT `fullCaptureTriggerReason`.
+     * Per the API schema (build.graphql) `reason` is the operator-approved prose
+     * the CLI prints verbatim, while `fullCaptureTriggerReason` is a machine enum
+     * code that (a) is only set for FULL captures and so is always absent on a
+     * bypassed build - which is a partial capture by definition - and (b) would
+     * print a raw machine code if it ever were surfaced (SHERLO-1919/1963).
      */
     diffScopeInfo?: {
       capturedSnapshotCount?: number;
       inheritedSnapshotCount?: number;
-      fullCaptureTriggerReason?: string;
+      platforms?: {
+        android?: { reason?: string };
+        ios?: { reason?: string };
+      };
     };
   } | null;
 };
@@ -205,7 +215,14 @@ async function fetchBuildStatus(
             diffScopeInfo {
               capturedSnapshotCount
               inheritedSnapshotCount
-              fullCaptureTriggerReason
+              platforms {
+                android {
+                  reason
+                }
+                ios {
+                  reason
+                }
+              }
             }
           }
         }
@@ -249,13 +266,14 @@ function evaluateTerminalState(
 
       if (unreviewed === 0 && reported === 0) {
         console.log();
-        if (isServerBypassed(diffScopeInfo)) {
+        const serverBypassReason = getServerBypassReason(diffScopeInfo);
+        if (serverBypassReason) {
           console.log(
             chalk.green(
               '✅ Nothing needed capturing - every screenshot was reused from the previous build.'
             )
           );
-          console.log(chalk.dim(`   ${diffScopeInfo!.fullCaptureTriggerReason}`));
+          console.log(chalk.dim(`   ${serverBypassReason}`));
         } else {
           console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
         }
@@ -296,22 +314,50 @@ function evaluateTerminalState(
 }
 
 /**
- * A server-bypassed build (SHERLO-1959): the API already knew every story's
- * screenshot could be inherited from the previous build, so it closed the
- * build without ever handing it to the runner. Recognized off the SAME shape
- * closeBuild fills for the GitHub check summary - zero captures, at least one
- * inherited snapshot, and the server's reason for the decision - never
- * inferred from the absence of a runner error, which also covers other
- * "nothing changed" cases the generic message already handles correctly.
+ * Platforms consulted in this fixed order when picking the reason line for a
+ * server-bypassed build. The order is explicit (not JSON key order) so the
+ * output is deterministic; android is first only to match the field-declaration
+ * order of DiffScopePlatformsInfo in the API schema. A server-bypassed build is
+ * bypassed for the suite as a whole, so every present platform's reason
+ * describes the same "nothing changed" verdict - we surface the first one that
+ * carries prose and never merge or reformat it.
  */
-function isServerBypassed(
+const PLATFORM_REASON_ORDER = ['android', 'ios'] as const;
+
+/**
+ * When the API server-bypassed the build (SHERLO-1959) - it already knew every
+ * story's screenshot could be inherited from the previous build, so it closed
+ * the build without ever handing it to the runner - return the plain-prose
+ * reason line to print beneath the closing message; otherwise return undefined
+ * so the caller falls back to the generic "All stories passed" line.
+ *
+ * Recognized off the SAME shape closeBuild persists (see the API unit test
+ * closeAsZeroCaptureNoOp.unit.test.ts): zero captures, at least one inherited
+ * snapshot, and a per-platform prose `reason`. The reason is taken from
+ * `platforms.<platform>.reason` - the operator-approved prose the CLI prints
+ * verbatim - never from `fullCaptureTriggerReason`, which is a machine enum
+ * code and is always absent on a bypassed (partial-capture) build anyway
+ * (SHERLO-1963). An older API response with no `diffScopeInfo` (or no
+ * `platforms.<platform>.reason`) yields undefined and degrades gracefully.
+ */
+function getServerBypassReason(
   diffScopeInfo: NonNullable<BuildStatusResponse['getBuildStatus']>['diffScopeInfo']
-): boolean {
-  return (
-    diffScopeInfo?.capturedSnapshotCount === 0 &&
-    (diffScopeInfo?.inheritedSnapshotCount ?? 0) > 0 &&
-    Boolean(diffScopeInfo?.fullCaptureTriggerReason)
-  );
+): string | undefined {
+  const bypassed =
+    diffScopeInfo?.capturedSnapshotCount === 0 && (diffScopeInfo?.inheritedSnapshotCount ?? 0) > 0;
+
+  if (!bypassed) {
+    return undefined;
+  }
+
+  for (const platform of PLATFORM_REASON_ORDER) {
+    const reason = diffScopeInfo?.platforms?.[platform]?.reason;
+    if (reason) {
+      return reason;
+    }
+  }
+
+  return undefined;
 }
 
 function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStatus']>): string {


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1963

## TL;DR

SHERLO-1959 merged (api#307 fc9667f: openBuild zero-capture bypass + config-scope intersection; sherlo#215 0fc3dbf: bypassed-build CLI closer; runner#123 9980a05: noStories pin) but was closed BEFORE its e2e acceptance ran - S1 in the Test Bundled suite is still test.skip'd and registered in the sanctioned-skip registry (both added by SHERLO-1948 when S1 exposed the defect). TASK: (1) remove S1's test.skip in e2e/suites/snapshots/test-bundled/02-config-scope.spec.ts AND its entry in the skip-verdict sanctioned-skip registry (cli/commands/skip-verdict.ts) - the gate must again treat an S1 skip as unaccounted; (2) UPDATE S1's assertions to the POST-1959 expected shape: the benign out-of-scope edit now produces a SERVER-BYPASSED build - no runner dispatch, CLI prints the bypassed closer ('Nothing needed capturing - every screenshot was reused from the previous build' + server reason line) - snapshot-pin that output (new baseline via one update_baselines cycle, then no-flag verify); (3) convergent Test Bundled run on published packages fully green with S1 PASSING - record run link + report URL on SHERLO-1959 (pipeline comment) AND this ticket as the completed acceptance evidence. PREREQ: the api test deploy + CLI @test publish fired by the Director at ~19:42 UTC must be green first; verify the published CLI version carries the #215 closer before minting baselines.

## Acceptance Criteria

- S1's test.skip and its sanctioned-skip registry entry are both removed; skip-hygiene gate integrity verified (an S1 skip would again red the run)
- S1 asserts the post-1959 server-bypass shape: no runner dispatch (build closes with runError null, 0 captured, all inherited) and the CLI bypassed-build closer, snapshot-pinned
- Convergent Test Bundled run on published packages fully green including S1 - run link + report URL recorded on SHERLO-1959 and here
- Unit/lint green

## Additional Context

## Origin

SHERLO-1959 was closed Done before its release tail + S1 convergent AC completed (Director correction recorded on the ticket). This micro-task completes the outstanding acceptance evidence.

## Sequencing

sherlo-tester only. Requires the 1959 test deploys/publishes green (Director fired both tails ~19:42 UTC 2026-07-24). Small: one spec + registry entry + baselines + one convergent run.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
