### PR TITLE
feat: CLI corrections batch A: config include/exclude become supported (kill the false warning) + server-bypassed builds print the compact closer with NO review URL and NO wait theater

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -114,3 +114,17 @@ npx sherlo eas-build-on-complete [--profile <profile>]
 **Options:**
 
 - `--profile <profile>` - EAS Build profile (must match profile used in `test:eas-cloud-build`)
+
+<br />
+
+## Configuration file
+
+Test settings live in `sherlo.config.json` (or the file passed to `--config`). Supported properties:
+
+- `token` - Authentication token for the project
+- `android` - Path to the Android build (.apk)
+- `ios` - Path to the iOS build (.app, .tar.gz, .tar)
+- `devices` - Devices to test on, each with its OS version, theme, locale, and font scale
+- `staged` - Staged fast-path settings for `test:bundled` (e.g. the commands that rebuild a stale base)
+- `include` - Story names to test; every other story is skipped
+- `exclude` - Story names to skip; every other story is tested

--- a/packages/cli/src/commands/testBundled/__tests__/__snapshots__/testBundled.test.ts.snap
+++ b/packages/cli/src/commands/testBundled/__tests__/__snapshots__/testBundled.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`server-bypassed build (SHERLO-1952) > NON-wait bypassed output is pinned 1`] = `
+"
+📦 Bundling for staged upload...
+
+
+🍎 Building ios bundle...
+  ✓ Bundle: bundle.ios.js (1.5 MB, plain-js, expo)
+
+⬆️  Uploading ios bundle...
+
+✅ Nothing needed capturing - no change reaches any story
+   closed by the server - no device run was needed"
+`;
+
 exports[`server-bypassed build (SHERLO-1952) > non-bypassed output is byte-identical with and without --wait 1`] = `
 "
 📦 Bundling for staged upload...

--- a/packages/cli/src/commands/testBundled/__tests__/__snapshots__/testBundled.test.ts.snap
+++ b/packages/cli/src/commands/testBundled/__tests__/__snapshots__/testBundled.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`server-bypassed build (SHERLO-1952) > non-bypassed output is byte-identical with and without --wait 1`] = `
+"
+📦 Bundling for staged upload...
+
+
+🍎 Building ios bundle...
+  ✓ Bundle: bundle.ios.js (1.5 MB, plain-js, expo)
+
+⬆️  Uploading ios bundle...
+
+🔗 Review: http://app/build"
+`;

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -94,6 +94,7 @@ import {
   getValidatedCommandParams as _getValidatedCommandParams,
   printResultsUrl as _printResultsUrl,
   printSherloIntro as _printSherloIntro,
+  waitForBuildResult as _waitForBuildResult,
 } from '../../../helpers';
 import { computeBaseFingerprint as _computeBaseFingerprint } from '../../../helpers/fingerprint';
 import {
@@ -116,6 +117,7 @@ const mockBuildBundleForPlatform = vi.mocked(_buildBundleForPlatform);
 const mockBuildGateMetadata = vi.mocked(_buildGateMetadata);
 const mockUploadStagedArtifacts = vi.mocked(_uploadStagedArtifacts);
 const mockRunDryRunPreview = vi.mocked(_runDryRunPreview);
+const mockWaitForBuildResult = vi.mocked(_waitForBuildResult);
 
 // ---------------------------------------------------------------------------
 // Subject under test
@@ -889,5 +891,139 @@ describe('live capture plan', () => {
     expect(openBuildArg.buildRunConfig.ios.jsBundleS3Key).toBe('js-key');
 
     logSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server-bypassed build (SHERLO-1952): the API closed the build itself without a
+// device run (0 captured, >0 inherited). The CLI must stop pointing at the
+// review page (SHERLO-1974) and stop implying device work happened - but ONLY
+// when --wait will print the compact bypassed closer in its place. Non-wait keeps
+// the link (the verbatim reason is unavailable without a poll). Detection is off
+// the openBuild COUNTS; the fact is threaded into waitForBuildResult.
+// ---------------------------------------------------------------------------
+
+describe('server-bypassed build (SHERLO-1952)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  /**
+   * Wire a run whose openBuild response reports the given diffScopeInfo counts.
+   * `wait` toggles --wait; `bypassed` picks the count shape (0/>0 vs a normal
+   * partial capture).
+   */
+  function setup({ wait, bypassed }: { wait: boolean; bypassed: boolean }): void {
+    mockGetValidatedCommandParams.mockReturnValue({
+      projectRoot: '/proj',
+      token: 'token-value',
+      devices: [IOS_DEVICE],
+      wait,
+      waitTimeout: undefined,
+    } as any);
+    mockGetPlatformsToTest.mockReturnValue(['ios'] as any);
+    mockComputeBaseFingerprint.mockResolvedValue({ hash: 'BASE_FP' } as any);
+    mockCheckStagedGate.mockResolvedValue({ outcome: 'fast', diff: [] });
+    mockBuildBundleForPlatform.mockResolvedValue(bundleResult());
+    mockBuildGateMetadata.mockResolvedValue({ engineClass: 'hermes' } as any);
+    mockGetTokenParts.mockReturnValue({ apiToken: 'api', projectIndex: 3, teamId: 'team' });
+    mockGetStagedUploadUrls.mockResolvedValue({
+      stagedPresignedUploadUrls: { ios: { jsBundle: { s3Key: 'js', url: 'http://s3/js' } } },
+    });
+    mockUploadStagedArtifacts.mockResolvedValue({ jsBundleS3Key: 'js' });
+    mockGetBuildRunConfig.mockReturnValue({ ios: { devices: [], s3Key: 'unset' } } as any);
+    mockGetGitInfo.mockResolvedValue({ commitHash: 'c', branchName: 'b', commitName: 'm' } as any);
+    mockGetAppBuildUrl.mockReturnValue('http://app/build');
+    mockWaitForBuildResult.mockResolvedValue(0);
+
+    const diffScopeInfo = bypassed
+      ? { capturedSnapshotCount: 0, inheritedSnapshotCount: 12 }
+      : { capturedSnapshotCount: 3, inheritedSnapshotCount: 9 };
+
+    mockOpenBuild.mockResolvedValue({
+      build: { index: 7, diffScopeInfo },
+      // No captureScope -> no plan block; keeps these tests focused on the closer.
+      buildRun: { config: { ios: { devices: [] } } },
+    });
+  }
+
+  function printed(logSpy: ReturnType<typeof vi.spyOn>): string {
+    return logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+  }
+
+  beforeEach(() => {
+    // --wait exits the process with the code; make that inert so the test can
+    // inspect what was printed and how waitForBuildResult was called.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it('--wait: withholds the Review URL and flags the bypass to waitForBuildResult', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: true, bypassed: true });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    // No review URL here - the --wait closer speaks for the build instead.
+    expect(out).not.toContain('🔗 Review');
+    expect(out).not.toContain('http://app/build');
+
+    expect(mockWaitForBuildResult).toHaveBeenCalledTimes(1);
+    expect(mockWaitForBuildResult.mock.calls[0][0]).toMatchObject({ serverBypassed: true });
+
+    logSpy.mockRestore();
+  });
+
+  it('NON-wait: keeps the Review URL (the verbatim reason needs a poll that never runs)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: false, bypassed: true });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    // A working link beats silence - non-wait cannot print the verbatim closer.
+    expect(out).toContain('🔗 Review: http://app/build');
+    expect(mockWaitForBuildResult).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it('non-bypassed --wait: Review URL prints and waitForBuildResult is told serverBypassed=false', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: true, bypassed: false });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🔗 Review: http://app/build');
+
+    expect(mockWaitForBuildResult).toHaveBeenCalledTimes(1);
+    expect(mockWaitForBuildResult.mock.calls[0][0]).toMatchObject({ serverBypassed: false });
+
+    logSpy.mockRestore();
+  });
+
+  // BYTE-IDENTICAL guarantee (explicit acceptance criterion): a non-bypassed
+  // build's own printed output is unchanged, and identical whether or not --wait
+  // is set (the wait poll adds nothing to testBundled's own output here).
+  it('non-bypassed output is byte-identical with and without --wait', async () => {
+    const logA = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: false, bypassed: false });
+    await testBundled(mockOptions());
+    const withoutWait = printed(logA);
+    logA.mockRestore();
+
+    vi.clearAllMocks();
+
+    const logB = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: true, bypassed: false });
+    await testBundled(mockOptions());
+    const withWait = printed(logB);
+    logB.mockRestore();
+
+    expect(withWait).toBe(withoutWait);
+    expect(withoutWait).toMatchSnapshot();
   });
 });

--- a/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/testBundled.test.ts
@@ -81,6 +81,16 @@ vi.mock('../dryRun', () => ({
   runDryRunPreview: vi.fn(),
 }));
 
+// testBundled imports isServerBypassed / printServerBypassCloser / the network
+// fetchServerBypassReason directly from the waitForBuildResult module. Keep the
+// pure helpers real (so bypass detection + the closer text are exercised for
+// real) and mock ONLY the network read, so tests control the reason without
+// hitting the API.
+vi.mock('../../../helpers/waitForBuildResult', async (importActual) => {
+  const actual = await importActual<typeof import('../../../helpers/waitForBuildResult')>();
+  return { ...actual, fetchServerBypassReason: vi.fn() };
+});
+
 // ---------------------------------------------------------------------------
 // Mocked dependency accessors
 // ---------------------------------------------------------------------------
@@ -103,6 +113,7 @@ import {
 } from '../buildBundle';
 import _uploadStagedArtifacts from '../uploadStagedArtifacts';
 import { runDryRunPreview as _runDryRunPreview } from '../dryRun';
+import { fetchServerBypassReason as _fetchServerBypassReason } from '../../../helpers/waitForBuildResult';
 
 const mockGetAppBuildUrl = vi.mocked(_getAppBuildUrl);
 const mockGetBuildRunConfig = vi.mocked(_getBuildRunConfig);
@@ -118,6 +129,7 @@ const mockBuildGateMetadata = vi.mocked(_buildGateMetadata);
 const mockUploadStagedArtifacts = vi.mocked(_uploadStagedArtifacts);
 const mockRunDryRunPreview = vi.mocked(_runDryRunPreview);
 const mockWaitForBuildResult = vi.mocked(_waitForBuildResult);
+const mockFetchServerBypassReason = vi.mocked(_fetchServerBypassReason);
 
 // ---------------------------------------------------------------------------
 // Subject under test
@@ -897,10 +909,12 @@ describe('live capture plan', () => {
 // ---------------------------------------------------------------------------
 // Server-bypassed build (SHERLO-1952): the API closed the build itself without a
 // device run (0 captured, >0 inherited). The CLI must stop pointing at the
-// review page (SHERLO-1974) and stop implying device work happened - but ONLY
-// when --wait will print the compact bypassed closer in its place. Non-wait keeps
-// the link (the verbatim reason is unavailable without a poll). Detection is off
-// the openBuild COUNTS; the fact is threaded into waitForBuildResult.
+// review page (SHERLO-1974) and stop implying device work happened, in BOTH
+// modes. Detection is off the openBuild COUNTS. In --wait mode the compact closer
+// comes from the poll (waitForBuildResult, mocked here). In non-wait mode it
+// comes from a single guarded getBuildStatus read (fetchServerBypassReason,
+// mocked here); if that read yields no reason the CLI falls back to today's
+// Review URL - a working link beats silence.
 // ---------------------------------------------------------------------------
 
 describe('server-bypassed build (SHERLO-1952)', () => {
@@ -959,38 +973,69 @@ describe('server-bypassed build (SHERLO-1952)', () => {
     exitSpy.mockRestore();
   });
 
-  it('--wait: withholds the Review URL and flags the bypass to waitForBuildResult', async () => {
+  it('--wait: withholds the Review URL, makes NO non-wait read, flags the bypass to the poll', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({ wait: true, bypassed: true });
 
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    // No review URL here - the --wait closer speaks for the build instead.
+    // No review URL here - the --wait poll's closer speaks for the build instead.
     expect(out).not.toContain('🔗 Review');
     expect(out).not.toContain('http://app/build');
 
     expect(mockWaitForBuildResult).toHaveBeenCalledTimes(1);
     expect(mockWaitForBuildResult.mock.calls[0][0]).toMatchObject({ serverBypassed: true });
+    // The non-wait single read is exclusive to the non-wait path.
+    expect(mockFetchServerBypassReason).not.toHaveBeenCalled();
 
     logSpy.mockRestore();
   });
 
-  it('NON-wait: keeps the Review URL (the verbatim reason needs a poll that never runs)', async () => {
+  it('NON-wait: prints the compact closer with the verbatim reason and NO Review URL', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({ wait: false, bypassed: true });
+    mockFetchServerBypassReason.mockResolvedValue('no change reaches any story');
 
     await testBundled(mockOptions());
 
     const out = printed(logSpy);
-    // A working link beats silence - non-wait cannot print the verbatim closer.
-    expect(out).toContain('🔗 Review: http://app/build');
+    expect(out).toContain('✅ Nothing needed capturing - no change reaches any story');
+    expect(out).toContain('closed by the server - no device run was needed');
+    // The whole point: no URL of any kind on the bypassed path.
+    expect(out).not.toContain('🔗 Review');
+    expect(out).not.toContain('http://app/build');
+
+    // One getBuildStatus read against the already-closed build; no polling.
     expect(mockWaitForBuildResult).not.toHaveBeenCalled();
+    expect(mockFetchServerBypassReason).toHaveBeenCalledTimes(1);
+    expect(mockFetchServerBypassReason.mock.calls[0][0]).toMatchObject({
+      token: 'token-value',
+      buildIndex: 7,
+      projectIndex: 3,
+      teamId: 'team',
+    });
 
     logSpy.mockRestore();
   });
 
-  it('non-bypassed --wait: Review URL prints and waitForBuildResult is told serverBypassed=false', async () => {
+  it('NON-wait fallback: reason unavailable -> keeps the Review URL, never a bare closer', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: false, bypassed: true });
+    // The read degraded (network / older API / no per-platform prose).
+    mockFetchServerBypassReason.mockResolvedValue(undefined);
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    // A working link beats silence; a closer never prints with nothing after the dash.
+    expect(out).toContain('🔗 Review: http://app/build');
+    expect(out).not.toContain('Nothing needed capturing');
+
+    logSpy.mockRestore();
+  });
+
+  it('non-bypassed --wait: Review URL prints, serverBypassed=false, ZERO extra reads', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     setup({ wait: true, bypassed: false });
 
@@ -1001,6 +1046,33 @@ describe('server-bypassed build (SHERLO-1952)', () => {
 
     expect(mockWaitForBuildResult).toHaveBeenCalledTimes(1);
     expect(mockWaitForBuildResult.mock.calls[0][0]).toMatchObject({ serverBypassed: false });
+    // Guard rail 1: a normal build makes NO extra call.
+    expect(mockFetchServerBypassReason).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it('non-bypassed NON-wait: Review URL prints and makes ZERO extra reads', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: false, bypassed: false });
+
+    await testBundled(mockOptions());
+
+    const out = printed(logSpy);
+    expect(out).toContain('🔗 Review: http://app/build');
+    expect(mockFetchServerBypassReason).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it('NON-wait bypassed output is pinned', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    setup({ wait: false, bypassed: true });
+    mockFetchServerBypassReason.mockResolvedValue('no change reaches any story');
+
+    await testBundled(mockOptions());
+
+    expect(printed(logSpy)).toMatchSnapshot();
 
     logSpy.mockRestore();
   });

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -39,6 +39,7 @@ import {
   waitForBuildResult,
 } from '../../helpers';
 import printLink from '../../helpers/printLink';
+import { isServerBypassed } from '../../helpers/waitForBuildResult';
 import { computeBaseFingerprint, type GateMetadataInput } from '../../helpers/fingerprint';
 import { THIS_COMMAND } from './constants';
 import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from './buildBundle';
@@ -343,14 +344,31 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
 
   const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
 
+  // The API may close the build itself, without ever running it on a device
+  // (SHERLO-1959), when every story's screenshot can be inherited from the
+  // previous build. Detected off the openBuild COUNTS (the per-platform prose
+  // reason is not selected by BuildFragment, so it is unavailable here - it comes
+  // from the --wait poll where it IS selected). A bypassed build has nothing to
+  // review, so we suppress the review/build URL and the --wait "device work"
+  // theatre (SHERLO-1952/1974).
+  const serverBypassed = isServerBypassed(openBuildReturn.build.diffScopeInfo);
+
   // The command EXPLAINS its own capture plan (SHERLO-1919): which stories this
   // run is capturing, which it is reusing from the previous build, and why - read
   // straight off the openBuild response, no extra API call - then closes with the
   // Review URL LAST (SHERLO-1937: no "Build created" line - the URL IS the
   // ending). Prints no plan block for a platform the server made no decision for
   // (Diff Scope off, or older API), but always closes with the URL so the link
-  // never disappears.
-  printCapturePlanAndCloser({ openBuildReturn, bundles, platformsToTest, url });
+  // never disappears - UNLESS the build was server-bypassed and --wait will print
+  // the compact bypassed closer instead (SHERLO-1952).
+  printCapturePlanAndCloser({
+    openBuildReturn,
+    bundles,
+    platformsToTest,
+    url,
+    serverBypassed,
+    wait: commandParams.wait,
+  });
 
   if (commandParams.wait) {
     const exitCode = await waitForBuildResult({
@@ -359,6 +377,7 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
       projectIndex,
       teamId,
       waitTimeoutMinutes: parseWaitTimeout(commandParams.waitTimeout),
+      serverBypassed,
     });
 
     // --wait mode: the exit code IS the contract. Flush telemetry then exit.
@@ -386,17 +405,28 @@ export default testBundled;
  * entirely - silence, never an invented "captured everything". If NO platform has
  * a decision, no plan block prints, but the URL still does so the developer
  * always gets their link.
+ *
+ * The one exception (SHERLO-1952): a server-bypassed build under --wait. There is
+ * nothing to review and the review page cannot render this build shape yet
+ * (SHERLO-1974), so the Review URL is withheld here and the --wait poll prints
+ * the compact bypassed closer (with the server's verbatim reason) instead. In
+ * NON-wait mode there is no poll and hence no verbatim reason, so the link is
+ * kept (a working link beats silence) and the closer prints as usual.
  */
 function printCapturePlanAndCloser({
   openBuildReturn,
   bundles,
   platformsToTest,
   url,
+  serverBypassed,
+  wait,
 }: {
   openBuildReturn: Awaited<ReturnType<ReturnType<typeof sdkClient>['openBuild']>>;
   bundles: Partial<Record<Platform, BundleResult>>;
   platformsToTest: Platform[];
   url: string;
+  serverBypassed: boolean;
+  wait: boolean | undefined;
 }): void {
   const diffScopeInfo = openBuildReturn.build.diffScopeInfo as
     | DiffScopeInfoWithPlatformReasons
@@ -429,6 +459,14 @@ function printCapturePlanAndCloser({
 
   if (platforms.length > 0) {
     console.log('\n' + formatDiffScopeReport('live', platforms));
+  }
+
+  // A server-bypassed build under --wait has its closer printed by the poll (the
+  // compact "Nothing needed capturing" line, no URL); withhold the Review URL
+  // here so it is not pointed at a build the review page cannot render yet
+  // (SHERLO-1952/1974).
+  if (serverBypassed && wait) {
+    return;
   }
 
   // The closer, LAST (SHERLO-1919 ordering). A live run has no "Build created"

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -39,7 +39,11 @@ import {
   waitForBuildResult,
 } from '../../helpers';
 import printLink from '../../helpers/printLink';
-import { isServerBypassed } from '../../helpers/waitForBuildResult';
+import {
+  isServerBypassed,
+  fetchServerBypassReason,
+  printServerBypassCloser,
+} from '../../helpers/waitForBuildResult';
 import { computeBaseFingerprint, type GateMetadataInput } from '../../helpers/fingerprint';
 import { THIS_COMMAND } from './constants';
 import { buildBundleForPlatform, buildGateMetadata, type BundleResult } from './buildBundle';
@@ -347,10 +351,10 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
   // The API may close the build itself, without ever running it on a device
   // (SHERLO-1959), when every story's screenshot can be inherited from the
   // previous build. Detected off the openBuild COUNTS (the per-platform prose
-  // reason is not selected by BuildFragment, so it is unavailable here - it comes
-  // from the --wait poll where it IS selected). A bypassed build has nothing to
-  // review, so we suppress the review/build URL and the --wait "device work"
-  // theatre (SHERLO-1952/1974).
+  // reason is not selected by BuildFragment, so it is unavailable here). Such a
+  // build has nothing to review and the review page cannot render its shape yet
+  // (SHERLO-1974), so - in BOTH modes - we withhold the review/build URL and
+  // print the compact bypassed closer instead (SHERLO-1952).
   const serverBypassed = isServerBypassed(openBuildReturn.build.diffScopeInfo);
 
   // The command EXPLAINS its own capture plan (SHERLO-1919): which stories this
@@ -359,16 +363,9 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
   // Review URL LAST (SHERLO-1937: no "Build created" line - the URL IS the
   // ending). Prints no plan block for a platform the server made no decision for
   // (Diff Scope off, or older API), but always closes with the URL so the link
-  // never disappears - UNLESS the build was server-bypassed and --wait will print
-  // the compact bypassed closer instead (SHERLO-1952).
-  printCapturePlanAndCloser({
-    openBuildReturn,
-    bundles,
-    platformsToTest,
-    url,
-    serverBypassed,
-    wait: commandParams.wait,
-  });
+  // never disappears - UNLESS the build was server-bypassed, whose compact closer
+  // is printed below instead (by the --wait poll, or the non-wait branch).
+  printCapturePlanAndCloser({ openBuildReturn, bundles, platformsToTest, url, serverBypassed });
 
   if (commandParams.wait) {
     const exitCode = await waitForBuildResult({
@@ -383,6 +380,17 @@ async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url:
     // --wait mode: the exit code IS the contract. Flush telemetry then exit.
     await reporting.flush().finally(() => {
       process.exit(exitCode);
+    });
+  } else if (serverBypassed) {
+    // Non-wait bypassed build: --wait is not printing the closer, so fetch the
+    // server's verbatim reason with a single getBuildStatus read and print the
+    // compact closer here (SHERLO-1952). Best-effort - see printBypassedCloser.
+    await printBypassedCloser({
+      token: commandParams.token,
+      buildIndex,
+      projectIndex,
+      teamId,
+      url,
     });
   }
 
@@ -406,12 +414,10 @@ export default testBundled;
  * a decision, no plan block prints, but the URL still does so the developer
  * always gets their link.
  *
- * The one exception (SHERLO-1952): a server-bypassed build under --wait. There is
- * nothing to review and the review page cannot render this build shape yet
- * (SHERLO-1974), so the Review URL is withheld here and the --wait poll prints
- * the compact bypassed closer (with the server's verbatim reason) instead. In
- * NON-wait mode there is no poll and hence no verbatim reason, so the link is
- * kept (a working link beats silence) and the closer prints as usual.
+ * The one exception (SHERLO-1952): a server-bypassed build. There is nothing to
+ * review and the review page cannot render this build shape yet (SHERLO-1974), so
+ * the Review URL is withheld here in BOTH modes; the compact bypassed closer is
+ * printed by the caller instead (the --wait poll, or the non-wait branch).
  */
 function printCapturePlanAndCloser({
   openBuildReturn,
@@ -419,14 +425,12 @@ function printCapturePlanAndCloser({
   platformsToTest,
   url,
   serverBypassed,
-  wait,
 }: {
   openBuildReturn: Awaited<ReturnType<ReturnType<typeof sdkClient>['openBuild']>>;
   bundles: Partial<Record<Platform, BundleResult>>;
   platformsToTest: Platform[];
   url: string;
   serverBypassed: boolean;
-  wait: boolean | undefined;
 }): void {
   const diffScopeInfo = openBuildReturn.build.diffScopeInfo as
     | DiffScopeInfoWithPlatformReasons
@@ -461,17 +465,51 @@ function printCapturePlanAndCloser({
     console.log('\n' + formatDiffScopeReport('live', platforms));
   }
 
-  // A server-bypassed build under --wait has its closer printed by the poll (the
-  // compact "Nothing needed capturing" line, no URL); withhold the Review URL
-  // here so it is not pointed at a build the review page cannot render yet
-  // (SHERLO-1952/1974).
-  if (serverBypassed && wait) {
+  // A server-bypassed build has its compact closer printed by the caller (the
+  // --wait poll, or the non-wait branch), never a Review URL - the review page
+  // cannot render this build shape yet (SHERLO-1952/1974). Withhold the URL here
+  // in both modes.
+  if (serverBypassed) {
     return;
   }
 
   // The closer, LAST (SHERLO-1919 ordering). A live run has no "Build created"
   // line (SHERLO-1937 operator ruling) - the Review URL IS the ending.
   console.log(`\n🔗 Review: ${printLink(url)}`);
+}
+
+/**
+ * Non-wait closer for a server-bypassed build (SHERLO-1952). Sources the server's
+ * verbatim reason with a single getBuildStatus read (the build is already closed,
+ * so it returns immediately - a read, not a wait) and prints the compact closer.
+ *
+ * Best-effort by ruling: if the reason cannot be fetched (network, auth, timeout,
+ * older API with no per-platform prose), fall back to TODAY's full output - the
+ * Review URL - rather than a closer with nothing after the dash. A working link
+ * beats silence, and a build that succeeded is never reported failed over this
+ * cosmetic query (fetchServerBypassReason swallows every error).
+ */
+async function printBypassedCloser({
+  token,
+  buildIndex,
+  projectIndex,
+  teamId,
+  url,
+}: {
+  token: string;
+  buildIndex: number;
+  projectIndex: number;
+  teamId: string;
+  url: string;
+}): Promise<void> {
+  const reason = await fetchServerBypassReason({ token, buildIndex, projectIndex, teamId });
+
+  if (reason) {
+    console.log();
+    printServerBypassCloser(reason);
+  } else {
+    console.log(`\n🔗 Review: ${printLink(url)}`);
+  }
 }
 
 /**

--- a/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
+++ b/packages/cli/src/helpers/__tests__/__snapshots__/waitForBuildResult.test.ts.snap
@@ -1,11 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`waitForBuildResult > server-bypassed build closing message > prints the "nothing needed capturing" closing line and pins its wording 1`] = `
-"⏳ Waiting for build results (timeout: 45min)...
-   🟢 Finished
-
-✅ Nothing needed capturing - every screenshot was reused from the previous build.
-   no change reaches any story
-   https://app.sherlo.io/build?t=BBBBBBBB&p=42&b=1
+exports[`waitForBuildResult > server-bypassed build closing message > pins the compact bypassed closer and the absence of all device-run output 1`] = `
+"
+✅ Nothing needed capturing - no change reaches any story
+   closed by the server - no device run was needed
 "
 `;

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -153,6 +153,20 @@ describe('waitForBuildResult', () => {
       return spy.mock.calls.map((call: unknown[]) => call[0] ?? '').join('\n');
     }
 
+    // A build the caller already flagged as server-bypassed off the openBuild
+    // counts (SHERLO-1952) passes `serverBypassed: true` - that is how testBundled
+    // invokes it in the real flow. The poll response is set up per test via
+    // mockGraphqlResponse before this is called.
+    function bypassedBuild() {
+      return waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+        serverBypassed: true,
+      });
+    }
+
     let logSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
@@ -163,7 +177,7 @@ describe('waitForBuildResult', () => {
       logSpy.mockRestore();
     });
 
-    it('prints the "nothing needed capturing" closing line and pins its wording', async () => {
+    it('pins the compact bypassed closer and the absence of all device-run output', async () => {
       mockGraphqlResponse(
         200,
         buildResponse(
@@ -178,20 +192,21 @@ describe('waitForBuildResult', () => {
         )
       );
 
-      const promise = waitForBuildResult({
-        token: TOKEN,
-        buildIndex: BUILD_INDEX,
-        projectIndex: PROJECT_INDEX,
-        teamId: TEAM_ID,
-      });
+      const promise = bypassedBuild();
 
       await vi.runAllTimersAsync();
       const result = await promise;
 
+      // The exit-code contract is unchanged: a closed, clean build is GREEN.
       expect(result).toBe(EXIT_GREEN);
 
       const printed = printedOutput(logSpy);
       expect(printed).toMatchSnapshot();
+
+      // Absence assertions are the point of SHERLO-1952: no wait theatre, no URL.
+      expect(printed).not.toContain('Waiting for build results');
+      expect(printed).not.toContain('🟢 Finished');
+      expect(printed).not.toContain('http'); // neither a review nor a build URL
     });
 
     it('prints the bypassed closer off the real API shape even with no fullCaptureTriggerReason (regression, SHERLO-1963)', async () => {
@@ -213,12 +228,7 @@ describe('waitForBuildResult', () => {
         )
       );
 
-      const promise = waitForBuildResult({
-        token: TOKEN,
-        buildIndex: BUILD_INDEX,
-        projectIndex: PROJECT_INDEX,
-        teamId: TEAM_ID,
-      });
+      const promise = bypassedBuild();
 
       await vi.runAllTimersAsync();
       const result = await promise;
@@ -227,8 +237,12 @@ describe('waitForBuildResult', () => {
 
       const printed = printedOutput(logSpy);
       expect(printed).toContain('Nothing needed capturing');
-      // The platform reason is printed verbatim as the closer's reason line.
-      expect(printed).toContain('no change reaches any story');
+      // The platform reason is printed verbatim, INLINE in the headline.
+      expect(printed).toContain('✅ Nothing needed capturing - no change reaches any story');
+      // The fixed dim line replaces the old CLI-invented "every screenshot was
+      // reused" sentence.
+      expect(printed).toContain('closed by the server - no device run was needed');
+      expect(printed).not.toContain('every screenshot was reused');
       expect(printed).not.toContain('All stories passed');
     });
 
@@ -253,12 +267,7 @@ describe('waitForBuildResult', () => {
         )
       );
 
-      const promise = waitForBuildResult({
-        token: TOKEN,
-        buildIndex: BUILD_INDEX,
-        projectIndex: PROJECT_INDEX,
-        teamId: TEAM_ID,
-      });
+      const promise = bypassedBuild();
 
       await vi.runAllTimersAsync();
       await promise;
@@ -284,12 +293,7 @@ describe('waitForBuildResult', () => {
         )
       );
 
-      const promise = waitForBuildResult({
-        token: TOKEN,
-        buildIndex: BUILD_INDEX,
-        projectIndex: PROJECT_INDEX,
-        teamId: TEAM_ID,
-      });
+      const promise = bypassedBuild();
 
       await vi.runAllTimersAsync();
       await promise;
@@ -300,6 +304,8 @@ describe('waitForBuildResult', () => {
     });
 
     it('falls back to the generic green message when diffScopeInfo is absent', async () => {
+      // Not a bypass at openBuild (no counts) -> serverBypassed omitted -> today's
+      // behaviour, waiting line and URL included.
       mockGraphqlResponse(
         200,
         buildResponse('finished', { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 })
@@ -350,7 +356,12 @@ describe('waitForBuildResult', () => {
       expect(printed).not.toContain('Nothing needed capturing');
     });
 
-    it('falls back to the generic green message when no platform reason is present', async () => {
+    it('forward-compat degrade: counts say bypass but the poll carries no reason -> generic green WITH the link', async () => {
+      // The gate condition (SHERLO-1952): 0 captured, >0 inherited, AND a
+      // per-platform reason. Reason absent (older API) -> keep the link. The
+      // caller still flags the bypass off the counts (serverBypassed: true), so
+      // the wait theatre is suppressed, but the closer keeps the URL because a
+      // working link beats silence.
       mockGraphqlResponse(
         200,
         buildResponse(
@@ -361,12 +372,7 @@ describe('waitForBuildResult', () => {
         )
       );
 
-      const promise = waitForBuildResult({
-        token: TOKEN,
-        buildIndex: BUILD_INDEX,
-        projectIndex: PROJECT_INDEX,
-        teamId: TEAM_ID,
-      });
+      const promise = bypassedBuild();
 
       await vi.runAllTimersAsync();
       await promise;
@@ -374,6 +380,8 @@ describe('waitForBuildResult', () => {
       const printed = printedOutput(logSpy);
       expect(printed).toContain('All stories passed');
       expect(printed).not.toContain('Nothing needed capturing');
+      // The link is preserved - silence is never better than a working link.
+      expect(printed).toContain('http');
     });
   });
 

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -14,6 +14,7 @@ import waitForBuildResult, {
   EXIT_ERROR,
   EXIT_GREEN,
   EXIT_TIMEOUT,
+  fetchServerBypassReason,
 } from '../waitForBuildResult';
 
 chalk.level = 0;
@@ -724,5 +725,124 @@ describe('waitForBuildResult', () => {
 
     expect(result).toBe(EXIT_GREEN);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+/* ========================================================================== */
+/* fetchServerBypassReason - the non-wait single-shot reason read (SHERLO-1952) */
+/*                                                                              */
+/* This is the function guard rail 2 rests on: it must degrade EVERY failure    */
+/* (network, auth, timeout, malformed, or simply no per-platform reason) to     */
+/* `undefined` and NEVER throw, so the closing of a build that actually         */
+/* succeeded can never be turned into a failure by a cosmetic display query.    */
+/* Tested directly here (the testBundled tests mock it out and so cannot catch  */
+/* it throwing). Real timers - the mocked fetch resolves synchronously.         */
+/* ========================================================================== */
+
+describe('fetchServerBypassReason', () => {
+  const args = {
+    token: TOKEN,
+    buildIndex: BUILD_INDEX,
+    projectIndex: PROJECT_INDEX,
+    teamId: TEAM_ID,
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns the verbatim per-platform reason for a bypassed poll shape', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse(
+        'finished',
+        { approved: 0, noChanges: 3, reported: 0, unreviewed: 0 },
+        undefined,
+        {
+          capturedSnapshotCount: 0,
+          inheritedSnapshotCount: 15,
+          platforms: { android: { reason: 'no change reaches any story' } },
+        }
+      )
+    );
+
+    await expect(fetchServerBypassReason(args)).resolves.toBe('no change reaches any story');
+  });
+
+  it('resolves undefined (never throws) when the request rejects - network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await expect(fetchServerBypassReason(args)).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined (never throws) on an auth failure - an expired token must not turn a green build red', async () => {
+    // fetchBuildStatus throws AuthError on HTTP 401; fetchServerBypassReason must
+    // convert that into undefined rather than let it escape.
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+    });
+
+    await expect(fetchServerBypassReason(args)).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined for a non-bypassed shape (counts do not match)', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse(
+        'finished',
+        { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 },
+        undefined,
+        {
+          capturedSnapshotCount: 2,
+          inheritedSnapshotCount: 13,
+          platforms: { android: { reason: 'no change reaches any story' } },
+        }
+      )
+    );
+
+    await expect(fetchServerBypassReason(args)).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined for a bypassed shape carrying no per-platform reason', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse(
+        'finished',
+        { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 },
+        undefined,
+        {
+          capturedSnapshotCount: 0,
+          inheritedSnapshotCount: 15,
+        }
+      )
+    );
+
+    await expect(fetchServerBypassReason(args)).resolves.toBeUndefined();
+  });
+
+  it('makes EXACTLY ONE request and passes the 10s timeout to fetch (a read, not a poll)', async () => {
+    mockGraphqlResponse(
+      200,
+      buildResponse(
+        'finished',
+        { approved: 0, noChanges: 1, reported: 0, unreviewed: 0 },
+        undefined,
+        {
+          capturedSnapshotCount: 0,
+          inheritedSnapshotCount: 4,
+          platforms: { ios: { reason: 'nothing changed' } },
+        }
+      )
+    );
+
+    await fetchServerBypassReason(args);
+
+    // One shot - a regression that turned this into a retry loop must fail here.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // The single call is bounded so a wedged API cannot hang a non-wait run.
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({ timeout: 10_000 });
   });
 });

--- a/packages/cli/src/helpers/getValidatedCommandParams/__tests__/getCommandParams.test.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/__tests__/getCommandParams.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for getCommandParams - the config x CLI-options merge.
+ *
+ * Pins the config-vs-flag precedence for `include` and `exclude` (SHERLO-1952).
+ * The merge is `{ ...config, ...options }`, so a passed CLI flag lands AFTER the
+ * config value and REPLACES it wholesale (never merges). `--include` is a real
+ * flag, so it can override the config's `include`; there is no `--exclude` flag,
+ * so `exclude` only ever comes from the config. When a flag is not passed its key
+ * is absent from options (commander omits un-passed options), so the config value
+ * survives.
+ */
+import { describe, expect, it } from 'vitest';
+import getCommandParams from '../getCommandParams';
+
+// Minimal options: only what getCommandParams reads (projectRoot for the
+// android/ios path.resolve). Commander omits keys for flags that were not
+// passed, so an absent flag is modelled as a missing key, not `undefined`.
+function options(overrides: Record<string, unknown> = {}): any {
+  return { projectRoot: '/proj', ...overrides };
+}
+
+describe('getCommandParams include/exclude precedence', () => {
+  describe('include', () => {
+    it('uses the config value when no --include flag is passed', () => {
+      const result = getCommandParams(options(), { include: ['FromConfig'] } as any);
+      expect(result.include).toEqual(['FromConfig']);
+    });
+
+    it('the --include flag REPLACES the config value (no merge)', () => {
+      const result = getCommandParams(options({ include: ['FromFlag'] }), {
+        include: ['FromConfig'],
+      } as any);
+      expect(result.include).toEqual(['FromFlag']);
+    });
+
+    it('uses the --include flag when the config has no include', () => {
+      const result = getCommandParams(options({ include: ['FromFlag'] }), {} as any);
+      expect(result.include).toEqual(['FromFlag']);
+    });
+  });
+
+  describe('exclude', () => {
+    // There is no --exclude CLI flag, so the config is exclude's only source; it
+    // flows through the merge untouched.
+    it('uses the config value (there is no --exclude flag to override it)', () => {
+      const result = getCommandParams(options(), { exclude: ['FromConfig'] } as any);
+      expect(result.exclude).toEqual(['FromConfig']);
+    });
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateConfigProperties.test.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateConfigProperties.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for validateConfigProperties - the config-file property allow-list.
+ *
+ * `include` and `exclude` are supported config properties (SHERLO-1952): both
+ * are honoured end to end (parseConfigFile normalises them, getBuildRunConfig
+ * forwards them), so warning about them was a pure false positive. These tests
+ * pin that they no longer warn, that a genuinely unknown property still does,
+ * and that the warning's supported-list text advertises the two new properties.
+ */
+import chalk from 'chalk';
+chalk.level = 0;
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import validateConfigProperties from '../validateConfigProperties';
+
+describe('validateConfigProperties', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function warnings(): string[] {
+    return logSpy.mock.calls
+      .map((call: unknown[]) => String(call[0] ?? ''))
+      .filter((line: string) => line.includes('WARNING'));
+  }
+
+  // The regression this ticket exists for: a config carrying include/exclude
+  // must NOT warn, because the CLI honours both.
+  it('does NOT warn for a config carrying `include` and `exclude`', () => {
+    validateConfigProperties({
+      token: 'abc',
+      devices: [],
+      include: ['My Story'],
+      exclude: ['Other Story'],
+    } as any);
+
+    expect(warnings()).toEqual([]);
+  });
+
+  it('does NOT warn for any of the supported properties together', () => {
+    validateConfigProperties({
+      token: 'abc',
+      android: 'app.apk',
+      ios: 'app.app',
+      devices: [],
+      staged: {},
+      include: ['a'],
+      exclude: ['b'],
+    } as any);
+
+    expect(warnings()).toEqual([]);
+  });
+
+  it('still warns for a genuinely unknown property', () => {
+    validateConfigProperties({ token: 'abc', bogus: true } as any);
+
+    const warned = warnings();
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain('Unsupported property `bogus` in config file');
+  });
+
+  // The supported-list text the warning prints must now advertise the two new
+  // properties, so a user who mistypes one is pointed at the right names.
+  it("lists `include` and `exclude` in the warning's supported-property text", () => {
+    validateConfigProperties({ bogus: true } as any);
+
+    const warned = warnings();
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain('`include`');
+    expect(warned[0]).toContain('`exclude`');
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateConfigProperties.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateConfigProperties.ts
@@ -2,7 +2,7 @@ import { DOCS_LINK } from '../../../constants';
 import { InvalidatedConfig } from '../../../types';
 import logWarning from '../../logWarning';
 
-const supportedProperties = ['token', 'android', 'ios', 'devices', 'staged'];
+const supportedProperties = ['token', 'android', 'ios', 'devices', 'staged', 'include', 'exclude'];
 
 function validateConfigProperties(config: InvalidatedConfig): void {
   const unsupportedProperties = Object.keys(config).filter(

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -207,10 +207,15 @@ class AuthError extends Error {
 async function fetchBuildStatus(
   endpointUrl: string,
   apiToken: string,
-  variables: { index: number; projectIndex: number; teamId: string }
+  variables: { index: number; projectIndex: number; teamId: string },
+  // Single-shot callers (fetchServerBypassReason) bound the request so a slow API
+  // can never hang a non-wait run. The poll loop omits it - its own outer timeout
+  // governs - so the wait path is unchanged.
+  timeoutMs?: number
 ): Promise<NonNullable<BuildStatusResponse['getBuildStatus']> | null> {
   const response = await fetch(endpointUrl, {
     method: 'POST',
+    ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
     headers: {
       'Content-Type': 'application/json',
       Authorization: JSON.stringify({ authToken: apiToken }),
@@ -286,17 +291,13 @@ function evaluateTerminalState(
           // Server-bypassed build (SHERLO-1952): there is nothing to review (zero
           // new screenshots) and the review page cannot render this build shape
           // yet (SHERLO-1974), so the closer stays compact and points at no URL.
-          // The reason is the server's verbatim prose (SHERLO-1919) - the CLI
-          // never composes it. The caller has already suppressed the review URL
-          // (printCapturePlanAndCloser) when it flagged the bypass, so omitting
-          // the URL here loses no link.
-          console.log(chalk.green(`✅ Nothing needed capturing - ${serverBypassReason}`));
-          console.log(chalk.dim('   closed by the server - no device run was needed'));
+          // The caller (printCapturePlanAndCloser) has already withheld the review
+          // URL for a bypassed build, so omitting it here loses no link.
+          printServerBypassCloser(serverBypassReason);
         } else {
-          // No verbatim reason -> today's behaviour, keeping the link. Covers
-          // both the forward-compat degrade of a counts-bypassed build whose poll
-          // carries no prose (SHERLO-1952 gate: a working link beats silence) and
-          // every ordinary green build.
+          // No verbatim reason -> today's behaviour, keeping the link. Covers the
+          // forward-compat degrade of a counts-bypassed build whose poll carries
+          // no prose (a working link beats silence) and every ordinary green build.
           console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
           console.log(chalk.blue(`   ${url}`));
         }
@@ -352,11 +353,13 @@ const PLATFORM_REASON_ORDER = ['android', 'ios'] as const;
  * the bypass shape - it needs only the two counts, which are present both on the
  * poll response here AND on the openBuild response (BuildFragment selects
  * `capturedSnapshotCount`/`inheritedSnapshotCount` but NOT the per-platform
- * `reason`). testBundled calls this at openBuild time to decide, BEFORE the first
- * poll, whether to suppress the "waiting"/"finished" lines and the review URL for
- * a build that never ran on a device (SHERLO-1952). The prose reason is not
- * needed for that decision and is not available at openBuild anyway; it is read
- * from the poll response by {@link getServerBypassReason}.
+ * `reason`). testBundled calls this at openBuild time to decide whether to
+ * withhold the review URL (both modes) and suppress the "waiting"/"finished"
+ * lines (--wait only) for a build that never ran on a device (SHERLO-1952). The
+ * prose reason is not needed for that decision and is not available at openBuild
+ * anyway; it is read from a getBuildStatus response - the --wait poll's, or the
+ * single non-wait call in {@link fetchServerBypassReason} - by
+ * {@link getServerBypassReason}.
  */
 export function isServerBypassed(
   diffScopeInfo:
@@ -400,6 +403,63 @@ function getServerBypassReason(
   }
 
   return undefined;
+}
+
+/**
+ * The compact closer for a server-bypassed build (SHERLO-1952): the server's
+ * verbatim reason inline in the headline, then the fixed dim line. No URL - the
+ * build has nothing to review and the review page cannot render this shape yet
+ * (SHERLO-1974). One definition, used by BOTH the --wait terminal path here and
+ * the non-wait closer in testBundled, so the two modes print identical text.
+ */
+export function printServerBypassCloser(reason: string): void {
+  console.log(chalk.green(`✅ Nothing needed capturing - ${reason}`));
+  console.log(chalk.dim('   closed by the server - no device run was needed'));
+}
+
+/**
+ * How long the single-shot bypass-reason query may take before it is abandoned.
+ * Generous enough for a healthy API, short enough that a wedged endpoint cannot
+ * stall a non-wait run.
+ */
+const BYPASS_REASON_QUERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetch the server's verbatim bypass reason with ONE getBuildStatus call against
+ * the already-closed build - the non-wait counterpart to the --wait poll, using
+ * the SAME query/wire shape (`fetchBuildStatus`) so there is one place to change
+ * if the shape moves. The build is already terminal server-side, so this returns
+ * immediately; it is a single read, not a wait.
+ *
+ * Best-effort by contract (SHERLO-1952 guard rail): any failure - network, auth,
+ * timeout, malformed response, or simply no per-platform reason - degrades to
+ * `undefined`, and the caller falls back to today's review URL. A build that
+ * succeeded must never be reported failed over this cosmetic closing query, so
+ * nothing here is allowed to throw.
+ */
+export async function fetchServerBypassReason({
+  token,
+  buildIndex,
+  projectIndex,
+  teamId,
+}: {
+  token: string;
+  buildIndex: number;
+  projectIndex: number;
+  teamId: string;
+}): Promise<string | undefined> {
+  try {
+    const { apiToken } = getTokenParts(token);
+    const build = await fetchBuildStatus(
+      getEndpointUrl(),
+      apiToken,
+      { index: buildIndex, projectIndex, teamId },
+      BYPASS_REASON_QUERY_TIMEOUT_MS
+    );
+    return getServerBypassReason(build?.diffScopeInfo);
+  } catch {
+    return undefined;
+  }
 }
 
 function formatProgressLine(build: NonNullable<BuildStatusResponse['getBuildStatus']>): string {

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -78,12 +78,23 @@ async function waitForBuildResult({
   projectIndex,
   teamId,
   waitTimeoutMinutes,
+  serverBypassed = false,
 }: {
   token: string;
   buildIndex: number;
   projectIndex: number;
   teamId: string;
   waitTimeoutMinutes?: number;
+  /**
+   * The build was already closed server-side without ever running on a device
+   * (SHERLO-1959/1952), detected off the openBuild counts by the caller. When
+   * set we keep the poll and the exit-code contract EXACTLY as they are - the
+   * build is already terminal, so the first poll returns immediately - but we
+   * suppress the output that implies device work happened: the "waiting" line
+   * below and the "🟢 Finished" progress line. The compact bypassed closer is
+   * printed by evaluateTerminalState off the poll's verbatim reason.
+   */
+  serverBypassed?: boolean;
 }): Promise<number> {
   const timeoutMs = (waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES) * 60 * 1000;
   const startTime = Date.now();
@@ -92,13 +103,15 @@ async function waitForBuildResult({
   const { apiToken } = getTokenParts(token);
   const endpointUrl = getEndpointUrl();
 
-  console.log(
-    chalk.dim(
-      `⏳ Waiting for build results (timeout: ${
-        waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES
-      }min)...`
-    )
-  );
+  if (!serverBypassed) {
+    console.log(
+      chalk.dim(
+        `⏳ Waiting for build results (timeout: ${
+          waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES
+        }min)...`
+      )
+    );
+  }
 
   let lastStatus = '';
   let pollCount = 0;
@@ -148,9 +161,11 @@ async function waitForBuildResult({
       continue;
     }
 
-    // Print progress when status changes
+    // Print progress when status changes. Suppressed for a server-bypassed build
+    // (SHERLO-1952): its only progress line would be "🟢 Finished", which implies
+    // a device run that never happened.
     const progressLine = formatProgressLine(build);
-    if (progressLine !== lastStatus) {
+    if (!serverBypassed && progressLine !== lastStatus) {
       console.log(progressLine);
       lastStatus = progressLine;
     }
@@ -268,16 +283,23 @@ function evaluateTerminalState(
         console.log();
         const serverBypassReason = getServerBypassReason(diffScopeInfo);
         if (serverBypassReason) {
-          console.log(
-            chalk.green(
-              '✅ Nothing needed capturing - every screenshot was reused from the previous build.'
-            )
-          );
-          console.log(chalk.dim(`   ${serverBypassReason}`));
+          // Server-bypassed build (SHERLO-1952): there is nothing to review (zero
+          // new screenshots) and the review page cannot render this build shape
+          // yet (SHERLO-1974), so the closer stays compact and points at no URL.
+          // The reason is the server's verbatim prose (SHERLO-1919) - the CLI
+          // never composes it. The caller has already suppressed the review URL
+          // (printCapturePlanAndCloser) when it flagged the bypass, so omitting
+          // the URL here loses no link.
+          console.log(chalk.green(`✅ Nothing needed capturing - ${serverBypassReason}`));
+          console.log(chalk.dim('   closed by the server - no device run was needed'));
         } else {
+          // No verbatim reason -> today's behaviour, keeping the link. Covers
+          // both the forward-compat degrade of a counts-bypassed build whose poll
+          // carries no prose (SHERLO-1952 gate: a working link beats silence) and
+          // every ordinary green build.
           console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
+          console.log(chalk.blue(`   ${url}`));
         }
-        console.log(chalk.blue(`   ${url}`));
         console.log();
         return EXIT_GREEN;
       }
@@ -325,15 +347,38 @@ function evaluateTerminalState(
 const PLATFORM_REASON_ORDER = ['android', 'ios'] as const;
 
 /**
+ * The counts-only signature of a server-bypassed build (SHERLO-1959): zero
+ * captures with at least one inherited snapshot. This is the SINGLE detection of
+ * the bypass shape - it needs only the two counts, which are present both on the
+ * poll response here AND on the openBuild response (BuildFragment selects
+ * `capturedSnapshotCount`/`inheritedSnapshotCount` but NOT the per-platform
+ * `reason`). testBundled calls this at openBuild time to decide, BEFORE the first
+ * poll, whether to suppress the "waiting"/"finished" lines and the review URL for
+ * a build that never ran on a device (SHERLO-1952). The prose reason is not
+ * needed for that decision and is not available at openBuild anyway; it is read
+ * from the poll response by {@link getServerBypassReason}.
+ */
+export function isServerBypassed(
+  diffScopeInfo:
+    | { capturedSnapshotCount?: number; inheritedSnapshotCount?: number }
+    | null
+    | undefined
+): boolean {
+  return (
+    diffScopeInfo?.capturedSnapshotCount === 0 && (diffScopeInfo?.inheritedSnapshotCount ?? 0) > 0
+  );
+}
+
+/**
  * When the API server-bypassed the build (SHERLO-1959) - it already knew every
  * story's screenshot could be inherited from the previous build, so it closed
  * the build without ever handing it to the runner - return the plain-prose
- * reason line to print beneath the closing message; otherwise return undefined
- * so the caller falls back to the generic "All stories passed" line.
+ * reason line to print in the closing message; otherwise return undefined so the
+ * caller falls back to the generic "All stories passed" line.
  *
  * Recognized off the SAME shape closeBuild persists (see the API unit test
- * closeAsZeroCaptureNoOp.unit.test.ts): zero captures, at least one inherited
- * snapshot, and a per-platform prose `reason`. The reason is taken from
+ * closeAsZeroCaptureNoOp.unit.test.ts): the {@link isServerBypassed} counts plus
+ * a per-platform prose `reason`. The reason is taken from
  * `platforms.<platform>.reason` - the operator-approved prose the CLI prints
  * verbatim - never from `fullCaptureTriggerReason`, which is a machine enum
  * code and is always absent on a bypassed (partial-capture) build anyway
@@ -343,10 +388,7 @@ const PLATFORM_REASON_ORDER = ['android', 'ios'] as const;
 function getServerBypassReason(
   diffScopeInfo: NonNullable<BuildStatusResponse['getBuildStatus']>['diffScopeInfo']
 ): string | undefined {
-  const bypassed =
-    diffScopeInfo?.capturedSnapshotCount === 0 && (diffScopeInfo?.inheritedSnapshotCount ?? 0) > 0;
-
-  if (!bypassed) {
+  if (!isServerBypassed(diffScopeInfo)) {
     return undefined;
   }
 


### PR DESCRIPTION
🔁 **Loop channel PR for SHERLO-1952**

This draft PR is the single communication channel for this loop task (SHERLO-1728).
All `[loop:*]` dialogue lives here; the task branch is the cross-repo join key.
It starts as a draft on an empty bootstrap commit and is promoted to ready on the first real push.

https://sherlo-io.atlassian.net/browse/SHERLO-1952