### PR TITLE
fix: remove feature/sherlo-3 from release_to_dev push trigger

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/sherlo-3
 
 jobs:
   checks:

--- a/.github/workflows/release_to_dev.yml
+++ b/.github/workflows/release_to_dev.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - dev
+      - feature/sherlo-3
 
 jobs:
   release-to-dev:

--- a/.github/workflows/release_to_dev.yml
+++ b/.github/workflows/release_to_dev.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - dev
-      - feature/sherlo-3
 
 jobs:
   release-to-dev:


### PR DESCRIPTION
## Director Ruling (nudge-ms54ygpz)

Push-triggered package publishes must NOT fire on feature/sherlo-3 pushes. GitHub Packages dev tag is shared; campaign publishes are dispatch-only.

### Change
- `release_to_dev.yml`: Remove `feature/sherlo-3` from `push.branches` (was `[dev, feature/sherlo-3]`, now `[dev]`)

### What Stays
PR-check fix on `pr_checks.yml` remains intact — `feature/sherlo-3` stays in `pull_request.branches` (was `[main]` only, now `[main, feature/sherlo-3]`).

### Audit Reference
Full audit tables in local-campaign-workflowtrigger task evidence.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)