### PR TITLE
fix: remove feature/sherlo-3 from release_to_dev push trigger

### DIFF
--- a/.github/workflows/release_to_dev.yml
+++ b/.github/workflows/release_to_dev.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - dev
-      - feature/sherlo-3
 
 jobs:
   release-to-dev:


### PR DESCRIPTION
Removes  from the  push-trigger branch filter.

**Why**:  publishes to GitHub Packages — a shared channel. Campaign deploys are dispatch-only.

**pr_checks.yml** keeps  — it has zero deploy side-effects.