### PR TITLE
feat: align npm package messaging to visual regression testing

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,0 +1,41 @@
+name: 'pr_checks'
+
+on:
+  pull_request:
+    branches:
+      - main
+      - feature/sherlo-3
+
+jobs:
+  checks:
+    name: checks (${{ matrix.package.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: cli
+            dir: packages/cli
+          - name: react-native-storybook
+            dir: packages/react-native-storybook
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Download Sherlo packages
+        run: ./scripts/init-env.sh
+        env:
+          CLIENT_STAGE: dev
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Typecheck
+        run: yarn tsc --noEmit -p ${{ matrix.package.dir }}
+
+      - name: Unit tests
+        working-directory: ${{ matrix.package.dir }}
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 # Sherlo
 
-**Visual regression testing for React Native, integrated with Storybook**. Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
+**Sherlo is a visual regression testing tool for React Native.** Capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and review them as a team before release. Integrates with Storybook. Used in production by React Native teams, from fintech to social apps. Free plan, no credit card.
 
 ▶️ [Sherlo in 2 minutes](https://sherlo.io/#video)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # Sherlo CLI: Visual testing for React Native
 
-The `sherlo` CLI orchestrates [visual regression testing for React Native](https://sherlo.io) - capture screenshots on iOS and Android simulators in the cloud, detect visual changes, and ship UI updates with confidence.
+Sherlo is a [visual regression testing tool for React Native](https://sherlo.io). The `sherlo` CLI orchestrates it - capture screenshots on iOS and Android simulators in the cloud, detect visual regressions, and ship UI updates with confidence.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,16 +1,19 @@
 {
   "name": "sherlo",
   "version": "2.0.0-alpha.1",
-  "description": "Sherlo CLI: Visual testing for React Native",
+  "description": "Visual regression testing for React Native - Sherlo CLI",
   "keywords": [
-    "visual testing",
     "react-native",
-    "visual regression testing",
-    "react native visual testing",
     "storybook",
-    "screenshot testing",
     "expo",
-    "eas"
+    "eas",
+    "ios",
+    "android",
+    "cli",
+    "visual testing",
+    "visual regression testing",
+    "screenshot testing",
+    "ui testing"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,10 +10,10 @@
     "ios",
     "android",
     "cli",
-    "visual testing",
-    "visual regression testing",
-    "screenshot testing",
-    "ui testing"
+    "visual-testing",
+    "visual-regression-testing",
+    "screenshot-testing",
+    "ui-testing"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,6 +1,6 @@
-# Sherlo Storybook integration: Visual testing for React Native
+# Sherlo - visual regression testing for React Native (Storybook SDK)
 
-Sherlo is a visual regression testing tool for React Native. The `@sherlo/react-native-storybook` SDK integrates [Sherlo](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
+Sherlo is a [visual regression testing tool for React Native](https://sherlo.io). The `@sherlo/react-native-storybook` SDK integrates it into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch visual regressions before they ship.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 
@@ -21,26 +21,6 @@ This will automatically install `@sherlo/react-native-storybook` and configure y
 ```bash
 npx sherlo test
 ```
-
-<br />
-
-## Metro Config
-
-Add the following to your `metro.config.js`:
-
-```js
-const { getDefaultConfig } = require('@react-native/metro-config');
-const withStorybook = require('@sherlo/react-native-storybook/metro/withStorybook');
-
-const defaultConfig = getDefaultConfig(__dirname);
-
-module.exports = withStorybook(defaultConfig, {
-  enabled: true,
-  configPath: __dirname + '/.rnstorybook',
-});
-```
-
-`withStorybook` is a drop-in replacement for `@storybook/react-native/metro/withStorybook` - it resolves the real one internally via the peer dependency and applies Sherlo's Metro transforms on top.
 
 <br />
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,6 +1,6 @@
 # Sherlo Storybook integration: Visual testing for React Native
 
-Sherlo is a visual regression testing tool for React Native. The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
+Sherlo is a visual regression testing tool for React Native. The `@sherlo/react-native-storybook` SDK integrates [Sherlo](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 
@@ -21,6 +21,26 @@ This will automatically install `@sherlo/react-native-storybook` and configure y
 ```bash
 npx sherlo test
 ```
+
+<br />
+
+## Metro Config
+
+Add the following to your `metro.config.js`:
+
+```js
+const { getDefaultConfig } = require('@react-native/metro-config');
+const withStorybook = require('@sherlo/react-native-storybook/metro/withStorybook');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: true,
+  configPath: __dirname + '/.rnstorybook',
+});
+```
+
+`withStorybook` is a drop-in replacement for `@storybook/react-native/metro/withStorybook` - it resolves the real one internally via the peer dependency and applies Sherlo's Metro transforms on top.
 
 <br />
 

--- a/packages/react-native-storybook/README.md
+++ b/packages/react-native-storybook/README.md
@@ -1,6 +1,6 @@
 # Sherlo Storybook integration: Visual testing for React Native
 
-The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
+Sherlo is a visual regression testing tool for React Native. The `@sherlo/react-native-storybook` SDK integrates [visual regression testing for React Native](https://sherlo.io) into your app via Storybook - capture stories on iOS and Android simulators in the cloud, catch UI regressions before they ship.
 
 > **📚 For full documentation, visit [sherlo.io/docs](https://sherlo.io/docs)**
 

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -9,10 +9,10 @@
     "eas",
     "ios",
     "android",
-    "visual testing",
-    "visual regression testing",
-    "screenshot testing",
-    "ui testing"
+    "visual-testing",
+    "visual-regression-testing",
+    "screenshot-testing",
+    "ui-testing"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -5,10 +5,14 @@
   "keywords": [
     "react-native",
     "storybook",
+    "expo",
+    "eas",
+    "visual-testing",
     "visual-regression-testing",
     "screenshot-testing",
     "ui-testing",
-    "visual-testing"
+    "ios",
+    "android"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -7,12 +7,12 @@
     "storybook",
     "expo",
     "eas",
-    "visual-testing",
-    "visual-regression-testing",
-    "screenshot-testing",
-    "ui-testing",
     "ios",
-    "android"
+    "android",
+    "visual testing",
+    "visual regression testing",
+    "screenshot testing",
+    "ui testing"
   ],
   "license": "MIT",
   "author": "Sherlo",

--- a/packages/react-native-storybook/package.json
+++ b/packages/react-native-storybook/package.json
@@ -1,16 +1,14 @@
 {
   "name": "@sherlo/react-native-storybook",
   "version": "2.0.0-alpha.1",
-  "description": "Sherlo Storybook integration: Visual testing for React Native",
+  "description": "Visual regression testing for React Native - Sherlo Storybook integration SDK",
   "keywords": [
-    "visual testing",
     "react-native",
     "storybook",
-    "visual regression testing",
-    "react native visual testing",
-    "screenshot testing",
-    "expo",
-    "eas"
+    "visual-regression-testing",
+    "screenshot-testing",
+    "ui-testing",
+    "visual-testing"
   ],
   "license": "MIT",
   "author": "Sherlo",


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-1393

Aligns @sherlo/react-native-storybook to admin/messaging.md: description leads with the category not Storybook, keywords hyphenated + screenshot-testing/ui-testing added, README para 1 opens with the canonical fact-sentence. Live at next npm publish.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
