### PR TITLE
fix: SHERLO-2030 - tolerate missing sherlo.json in iOS .app builds

### DIFF
--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/__tests__/accessFileInDirectory.test.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/__tests__/accessFileInDirectory.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import accessFileInDirectory from '../accessFileInDirectory';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-access-file-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('accessFileInDirectory - operation: read', () => {
+  it('returns file content when the file exists', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'sherlo.json'), '{"version":"1.2.3"}');
+
+    const content = await accessFileInDirectory({
+      operation: 'read',
+      directory: tmpDir,
+      file: 'sherlo.json',
+    });
+
+    expect(content).toBe('{"version":"1.2.3"}');
+  });
+
+  it('returns undefined when the file does not exist (ENOENT)', async () => {
+    const content = await accessFileInDirectory({
+      operation: 'read',
+      directory: tmpDir,
+      file: 'sherlo.json',
+    });
+
+    expect(content).toBeUndefined();
+  });
+
+  it('throws for non-ENOENT errors (e.g. EISDIR)', async () => {
+    // A directory where a file is expected triggers EISDIR, not ENOENT
+    fs.mkdirSync(path.join(tmpDir, 'sherlo.json'));
+
+    await expect(
+      accessFileInDirectory({ operation: 'read', directory: tmpDir, file: 'sherlo.json' })
+    ).rejects.toThrow(/EISDIR/);
+  });
+});
+
+describe('accessFileInDirectory - operation: exists', () => {
+  it('returns true when the file exists', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'sherlo.json'), '{}');
+
+    const exists = await accessFileInDirectory({
+      operation: 'exists',
+      directory: tmpDir,
+      file: 'sherlo.json',
+    });
+
+    expect(exists).toBe(true);
+  });
+
+  it('returns false when the file does not exist', async () => {
+    const exists = await accessFileInDirectory({
+      operation: 'exists',
+      directory: tmpDir,
+      file: 'sherlo.json',
+    });
+
+    expect(exists).toBe(false);
+  });
+});

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/__tests__/getLocalBinariesInfo.test.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/__tests__/getLocalBinariesInfo.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { TEST_STANDARD_COMMAND } from '../../../../../constants';
+import getLocalBinariesInfo from '../getLocalBinariesInfo';
+
+const tmpRoots: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The .app directory must itself be named "*.app" - getLocalBinariesInfo branches on that suffix
+function makeAppDir(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sherlo-app-'));
+  tmpRoots.push(root);
+
+  const appDir = path.join(root, 'MyApp.app');
+  fs.mkdirSync(appDir);
+  return appDir;
+}
+
+describe('getLocalBinariesInfo - iOS .app directory', () => {
+  it('resolves sdkVersion: undefined when assets/sherlo.json is missing, instead of throwing', async () => {
+    const appDir = makeAppDir();
+
+    const result = await getLocalBinariesInfo({
+      paths: { ios: appDir },
+      platforms: ['ios'],
+      projectRoot: appDir,
+      command: TEST_STANDARD_COMMAND,
+    });
+
+    expect(result.ios?.sdkVersion).toBeUndefined();
+  });
+
+  it('resolves sdkVersion from a valid assets/sherlo.json', async () => {
+    const appDir = makeAppDir();
+    fs.mkdirSync(path.join(appDir, 'assets'));
+    fs.writeFileSync(path.join(appDir, 'assets', 'sherlo.json'), JSON.stringify({ version: '1.2.3' }));
+
+    const result = await getLocalBinariesInfo({
+      paths: { ios: appDir },
+      platforms: ['ios'],
+      projectRoot: appDir,
+      command: TEST_STANDARD_COMMAND,
+    });
+
+    expect(result.ios?.sdkVersion).toBe('1.2.3');
+  });
+
+  it('rejects with the existing invalid-JSON error when assets/sherlo.json is malformed', async () => {
+    const appDir = makeAppDir();
+    fs.mkdirSync(path.join(appDir, 'assets'));
+    fs.writeFileSync(path.join(appDir, 'assets', 'sherlo.json'), '{not valid json');
+
+    await expect(
+      getLocalBinariesInfo({
+        paths: { ios: appDir },
+        platforms: ['ios'],
+        projectRoot: appDir,
+        command: TEST_STANDARD_COMMAND,
+      })
+    ).rejects.toThrow('Invalid assets/sherlo.json in iOS build');
+  });
+});

--- a/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInDirectory.ts
+++ b/packages/cli/src/helpers/getValidatedBinariesInfoAndNextBuildIndex/getBinariesInfoAndNextBuildIndex/getLocalBinariesInfo/accessFileInDirectory.ts
@@ -11,13 +11,13 @@ type BaseOptions = {
   file: string;
 };
 
-function accessFileInDirectory(options: ReadOptions): Promise<string>;
+function accessFileInDirectory(options: ReadOptions): Promise<string | undefined>;
 function accessFileInDirectory(options: ExistsOptions): Promise<boolean>;
 async function accessFileInDirectory({
   directory,
   file,
   operation,
-}: Options): Promise<string | boolean> {
+}: Options): Promise<string | undefined | boolean> {
   const filePath = path.join(directory, file);
 
   try {
@@ -30,6 +30,8 @@ async function accessFileInDirectory({
     return content;
   } catch (error) {
     if (operation === 'exists') return false;
+
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
 
     throwError({ type: 'unexpected', error });
   }


### PR DESCRIPTION
https://sherlo-io.atlassian.net/browse/SHERLO-2030

Fixes the Sentry issue SHERLO-CLI-3Q, hit by a new free-tier user on their first
real build attempt.

## The problem

When the CLI validated a local iOS `.app` bundle, `accessFileInDirectory` read
`assets/sherlo.json` with no ENOENT tolerance. A build missing that file threw
`UNEXPECTED ERROR: ENOENT: no such file or directory` and reported to Sentry,
instead of reaching the actionable `Invalid iOS build - Sherlo Native Module is
missing` message, with its `pod install` guidance, that already exists for
exactly this case.

The sibling archive accessor used by `.apk`/`.tar` already returns `undefined` on
a failed read, so the *same* user mistake produced a helpful message on Android
and a crash-looking unexpected error on iOS. Both accessors are assigned to the
same variable, declared `let readSherloFile: () => Promise<string | undefined>`,
a contract the directory implementation could not honour.

Not a regression: the unguarded code has been byte-identical since `15f0ebb`
(Dec 2024) and ships in every release from 1.1.0 through 2.0.1.

## The fix

Four lines in `accessFileInDirectory.ts`: the `read` overload is now
`Promise<string | undefined>`, and an ENOENT returns `undefined` rather than
falling through to `throwError`. Because `throwError` is never reached, the run
also produces no Sentry event.

Deliberately narrow - `ENOENT` only. Every other filesystem error (`EACCES`,
`EISDIR`, ...) still throws exactly as before, and the `exists` operation is
untouched. This mirrors the precedent nine lines below in `getLocalBinariesInfo.ts`,
where `readExpoAppConfig` already returns `undefined` for the absent case.

## Tests

Seven new vitest cases across two files, all driving real filesystem fixtures.

`__tests__/accessFileInDirectory.test.ts` covers the accessor directly:
- `read` returns content when the file exists
- `read` returns `undefined` on ENOENT
- `read` still throws on a non-ENOENT error (EISDIR, via a directory where a file is expected)
- `exists` returns true / false

`__tests__/getLocalBinariesInfo.test.ts` covers the user-visible path, through the real `getLocalBinariesInfo`:
- `.app` without `assets/sherlo.json` resolves `sdkVersion: undefined` instead of throwing (this is the bug)
- `.app` with a valid `assets/sherlo.json` still resolves the version
- `.app` with malformed JSON still fails with the existing `Invalid assets/sherlo.json in iOS build` error

The two missing-file tests were confirmed to fail against the unguarded
implementation, throwing the original ENOENT from `accessFileInDirectory.ts:34`.

Android `.apk` behaviour is unchanged. `accessFileInArchive` is not touched.

## Note for the reviewer

SHERLO-2030 also asks for this fix on `feature/sherlo-3`, which is where the
published 2.0.1 ships from. This PR targets `main` only. `accessFileInDirectory.ts`
is byte-identical on both branches and the `.app` branch of `readSherloFile` is
too, so this commit cherry-picks cleanly, but it needs its own branch and PR,
which a single brain task cannot emit. That half is still outstanding.

---
*Generated by [Sherlo Brain](https://github.com/sherlo-io/sherlo-brain)*
