### PR TITLE
feat: land epic sherlo-cli-wait - sherlo CLI --wait flag

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -94,6 +94,7 @@ export const TOKEN_OPTION = 'token';
 export const INCLUDE_OPTION = 'include';
 export const WAIT_FOR_EAS_BUILD_OPTION = 'waitForEasBuild';
 export const WAIT_OPTION = 'wait';
+export const MAX_WAIT_TIME_OPTION = 'maxWaitTime';
 
 export const COLOR = {
   reported: 'FFB36C',

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -93,6 +93,7 @@ export const PROJECT_ROOT_OPTION = 'projectRoot';
 export const TOKEN_OPTION = 'token';
 export const INCLUDE_OPTION = 'include';
 export const WAIT_FOR_EAS_BUILD_OPTION = 'waitForEasBuild';
+export const WAIT_OPTION = 'wait';
 
 export const COLOR = {
   reported: 'FFB36C',

--- a/packages/cli/src/helpers/__tests__/parseMaxWaitTime.test.ts
+++ b/packages/cli/src/helpers/__tests__/parseMaxWaitTime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import parseMaxWaitTime from '../parseMaxWaitTime';
+
+describe('parseMaxWaitTime', () => {
+  it('returns undefined when no value is passed (falls back to the default wait timeout)', () => {
+    expect(parseMaxWaitTime(undefined)).toBeUndefined();
+  });
+
+  it('parses a valid minutes string into a number', () => {
+    expect(parseMaxWaitTime('45')).toBe(45);
+  });
+
+  it('parses a single-digit minutes string into a number', () => {
+    expect(parseMaxWaitTime('1')).toBe(1);
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateMaxWaitTime.test.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateMaxWaitTime.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import validateMaxWaitTime from '../validateMaxWaitTime';
+
+describe('validateMaxWaitTime', () => {
+  it('does nothing when maxWaitTime is not provided', () => {
+    expect(() => validateMaxWaitTime({})).not.toThrow();
+  });
+
+  it.each(['1', '30', '999'])('accepts a valid positive integer string (%s)', (maxWaitTime) => {
+    expect(() => validateMaxWaitTime({ maxWaitTime })).not.toThrow();
+  });
+
+  it.each([
+    ['0', 'zero'],
+    ['-5', 'negative'],
+    ['1.5', 'decimal'],
+    ['abc', 'non-numeric'],
+    ['', 'empty string'],
+    ['  ', 'whitespace'],
+  ])('rejects %s (%s) with a range-naming error', (maxWaitTime) => {
+    expect(() => validateMaxWaitTime({ maxWaitTime })).toThrow(
+      /--maxWaitTime.*integer of at least 1/
+    );
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateCommandParams.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateCommandParams.ts
@@ -8,6 +8,7 @@ import { validatePlatformPaths } from '../../shared';
 import getPlatformsToTest from '../../getPlatformsToTest';
 import validateConfigProperties from './validateConfigProperties';
 import validateDevices from './validateDevices';
+import validateMaxWaitTime from './validateMaxWaitTime';
 import validateToken from './validateToken';
 
 function validateCommandParams<C extends Command>(
@@ -19,6 +20,8 @@ function validateCommandParams<C extends Command>(
   validateToken(commandParams);
 
   validateDevices(commandParams);
+
+  validateMaxWaitTime(commandParams);
 
   if (requirePlatformPaths) {
     const platformsToValidate = getPlatformsToTest(

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateMaxWaitTime.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateMaxWaitTime.ts
@@ -1,0 +1,20 @@
+import { MAX_WAIT_TIME_OPTION } from '../../../constants';
+import throwError from '../../throwError';
+
+function validateMaxWaitTime(commandParams: { [MAX_WAIT_TIME_OPTION]?: string }): void {
+  const { maxWaitTime } = commandParams;
+
+  if (maxWaitTime === undefined) return;
+
+  const parsed = Number(maxWaitTime);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throwError({
+      message:
+        `Invalid \`--${MAX_WAIT_TIME_OPTION}\` value \`${maxWaitTime}\`. ` +
+        'Must be an integer of at least 1 (minutes)',
+    });
+  }
+}
+
+export default validateMaxWaitTime;

--- a/packages/cli/src/helpers/handleClientError.ts
+++ b/packages/cli/src/helpers/handleClientError.ts
@@ -2,7 +2,7 @@ import { APP_DOMAIN } from '../constants';
 import { printLink } from '../helpers';
 import throwError from './throwError';
 
-function handleClientError(error: any) {
+function handleClientError(error: any): never {
   if (error.networkError?.statusCode === 401) {
     throwError({
       type: 'auth',

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -29,5 +29,6 @@ export { default as stripAnsi } from './stripAnsi';
 export { default as throwError } from './throwError';
 export { default as uploadOrReuseBuildsAndRunTests } from './uploadOrReuseBuildsAndRunTests';
 export { default as validateLocalBinaries } from './validateLocalBinaries';
+export { default as waitForBuildResult } from './waitForBuildResult';
 export { default as withCommandTimeout } from './withCommandTimeout';
 export { default as wrapInBox } from './wrapInBox';

--- a/packages/cli/src/helpers/parseMaxWaitTime.ts
+++ b/packages/cli/src/helpers/parseMaxWaitTime.ts
@@ -1,0 +1,10 @@
+/**
+ * Converts the validated `--maxWaitTime` string option into the number
+ * `runWaitLoop` expects. Validation (integer >= 1) already happened in
+ * `validateMaxWaitTime` - this is a pure format conversion.
+ */
+function parseMaxWaitTime(maxWaitTime?: string): number | undefined {
+  return maxWaitTime !== undefined ? Number(maxWaitTime) : undefined;
+}
+
+export default parseMaxWaitTime;

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -8,6 +8,7 @@ import getGitInfo from './getGitInfo';
 import getTokenParts from './getTokenParts';
 import getValidatedBinariesInfoAndNextBuildIndex from './getValidatedBinariesInfoAndNextBuildIndex';
 import handleClientError from './handleClientError';
+import parseMaxWaitTime from './parseMaxWaitTime';
 import printBuildIntroMessage from './printBuildIntroMessage';
 import printResultsUrl from './printResultsUrl';
 import reporting from './reporting';
@@ -114,7 +115,9 @@ async function uploadOrReuseBuildsAndRunTests({
   printResultsUrl(url);
 
   if (commandParams.wait) {
-    await waitForBuildResult({ client, teamId, projectIndex, buildIndex, url });
+    const maxWaitTime = parseMaxWaitTime(commandParams.maxWaitTime);
+
+    await waitForBuildResult({ client, teamId, projectIndex, buildIndex, url, maxWaitTime });
   }
 
   return { url };

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -13,6 +13,7 @@ import printResultsUrl from './printResultsUrl';
 import reporting from './reporting';
 import { computeChangedFiles, computeNativeFingerprint } from './turbosnap';
 import uploadOrPrintBinaryReuse from './uploadOrPrintBinaryReuse';
+import waitForBuildResult from './waitForBuildResult';
 
 async function uploadOrReuseBuildsAndRunTests({
   commandParams,
@@ -111,6 +112,10 @@ async function uploadOrReuseBuildsAndRunTests({
   const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
 
   printResultsUrl(url);
+
+  if (commandParams.wait) {
+    await waitForBuildResult({ client, teamId, projectIndex, buildIndex, url });
+  }
 
   return { url };
 }

--- a/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import runWaitLoop from '../runWaitLoop';
+import { WAIT_TIMEOUT_MINUTES } from '../constants';
+import { BuildStatusSource } from '../types';
+
+const neverPolls: BuildStatusSource = {
+  poll: () => new Promise(() => {}), // must never resolve - the deadline check runs before any poll
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe('runWaitLoop - deadline honors --maxWaitTime override', () => {
+  it('times out after WAIT_TIMEOUT_MINUTES when no override is passed', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
+    now.mockReturnValueOnce(WAIT_TIMEOUT_MINUTES * 60_000); // Date.now() >= deadline
+
+    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com' });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('honors a non-default maxWaitTimeMinutes for the deadline', async () => {
+    const customMinutes = 2;
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + customMinutes * 60_000
+    now.mockReturnValueOnce(customMinutes * 60_000); // Date.now() >= deadline
+
+    await runWaitLoop({
+      statusSource: neverPolls,
+      url: 'https://example.com',
+      maxWaitTimeMinutes: customMinutes,
+    });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('does NOT time out at the custom-minutes mark when it is still under the default deadline', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default)
+    now.mockReturnValueOnce(2 * 60_000); // well before the default deadline
+
+    const statusSource: BuildStatusSource = {
+      poll: () => Promise.resolve({ terminal: true, hasChangesToReview: false }),
+    };
+
+    await runWaitLoop({ statusSource, url: 'https://example.com' });
+
+    // Reached the poll (and resolved terminal) instead of timing out.
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import runWaitLoop from '../runWaitLoop';
 import { WAIT_TIMEOUT_MINUTES } from '../constants';
 import { BuildStatusSource } from '../types';
@@ -8,46 +8,51 @@ const neverPolls: BuildStatusSource = {
 };
 
 afterEach(() => {
-  vi.restoreAllMocks();
   process.exitCode = undefined;
 });
 
+/**
+ * Call-counted clock stub: first call is the deadline computation, every
+ * later call is the loop's deadline check. Passed in directly instead of
+ * spying on the global `Date.now`, so no other `Date.now` caller in the
+ * process (e.g. a test reporter timestamping console output) can perturb it.
+ */
+function makeClockStub(firstCallMs: number, laterCallsMs: number): () => number {
+  let callCount = 0;
+  return () => (callCount++ === 0 ? firstCallMs : laterCallsMs);
+}
+
 describe('runWaitLoop - deadline honors --maxWaitTime override', () => {
   it('times out after WAIT_TIMEOUT_MINUTES when no override is passed', async () => {
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
-    now.mockReturnValueOnce(WAIT_TIMEOUT_MINUTES * 60_000); // Date.now() >= deadline
+    const now = makeClockStub(0, WAIT_TIMEOUT_MINUTES * 60_000); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
 
-    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com' });
+    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com', now });
 
     expect(process.exitCode).toBe(3);
   });
 
   it('honors a non-default maxWaitTimeMinutes for the deadline', async () => {
     const customMinutes = 2;
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + customMinutes * 60_000
-    now.mockReturnValueOnce(customMinutes * 60_000); // Date.now() >= deadline
+    const now = makeClockStub(0, customMinutes * 60_000); // deadline = 0 + customMinutes * 60_000
 
     await runWaitLoop({
       statusSource: neverPolls,
       url: 'https://example.com',
       maxWaitTimeMinutes: customMinutes,
+      now,
     });
 
     expect(process.exitCode).toBe(3);
   });
 
   it('does NOT time out at the custom-minutes mark when it is still under the default deadline', async () => {
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default)
-    now.mockReturnValueOnce(2 * 60_000); // well before the default deadline
+    const now = makeClockStub(0, 2 * 60_000); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default), well before it
 
     const statusSource: BuildStatusSource = {
       poll: () => Promise.resolve({ terminal: true, hasChangesToReview: false }),
     };
 
-    await runWaitLoop({ statusSource, url: 'https://example.com' });
+    await runWaitLoop({ statusSource, url: 'https://example.com', now });
 
     // Reached the poll (and resolved terminal) instead of timing out.
     expect(process.exitCode).toBe(0);

--- a/packages/cli/src/helpers/waitForBuildResult/constants.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/constants.ts
@@ -1,0 +1,4 @@
+// Fixed by contract - not user-configurable.
+export const POLL_INTERVAL_MS = 15_000;
+export const WAIT_TIMEOUT_MINUTES = 30;
+export const WAIT_TIMEOUT_MS = WAIT_TIMEOUT_MINUTES * 60 * 1000;

--- a/packages/cli/src/helpers/waitForBuildResult/constants.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/constants.ts
@@ -1,4 +1,5 @@
 // Fixed by contract - not user-configurable.
 export const POLL_INTERVAL_MS = 15_000;
+
+// Default wait timeout; overridable per-run via the `--maxWaitTime` CLI option.
 export const WAIT_TIMEOUT_MINUTES = 30;
-export const WAIT_TIMEOUT_MS = WAIT_TIMEOUT_MINUTES * 60 * 1000;

--- a/packages/cli/src/helpers/waitForBuildResult/createPollingBuildStatusSource.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/createPollingBuildStatusSource.ts
@@ -2,12 +2,9 @@ import sdkClient from '@sherlo/sdk-client';
 import handleClientError from '../handleClientError';
 import { BuildStatusPoll, BuildStatusSource } from './types';
 
-// The `getBuildStatus` field isn't visible on the sdk-client type from this
-// workspace (it's generated in the sibling sherlo-lib repo) - narrowed here
-// to the fields this source actually reads. There is no single overall
-// status string: `runStatus` says where the run is, and `viewStatusesCount`
-// (only meaningful once `runStatus` is `finished`) says whether there's
-// anything to review.
+// There is no single overall status string: `runStatus` says where the run
+// is, and `viewStatusesCount` (only meaningful once `runStatus` is
+// `finished`) says whether there's anything to review.
 type RunStatus = 'canceled' | 'error' | 'finished' | 'inProgress' | 'queued' | 'waiting';
 
 type ViewStatusesCount = {
@@ -15,14 +12,6 @@ type ViewStatusesCount = {
   noChanges: number;
   reported: number;
   unreviewed: number;
-};
-
-type BuildStatusClient = {
-  getBuildStatus: (params: {
-    teamId: string;
-    projectIndex: number;
-    buildIndex: number;
-  }) => Promise<{ runStatus: RunStatus; viewStatusesCount: ViewStatusesCount | null | undefined }>;
 };
 
 function createPollingBuildStatusSource({
@@ -36,12 +25,10 @@ function createPollingBuildStatusSource({
   projectIndex: number;
   buildIndex: number;
 }): BuildStatusSource {
-  const statusClient = client as unknown as BuildStatusClient;
-
   return {
     poll: async (): Promise<BuildStatusPoll> => {
-      const { runStatus, viewStatusesCount } = await statusClient
-        .getBuildStatus({ teamId, projectIndex, buildIndex })
+      const { runStatus, viewStatusesCount } = await client
+        .getBuildStatus({ teamId, projectIndex, index: buildIndex })
         .catch(handleClientError);
 
       return toBuildStatusPoll(runStatus, viewStatusesCount);

--- a/packages/cli/src/helpers/waitForBuildResult/createPollingBuildStatusSource.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/createPollingBuildStatusSource.ts
@@ -1,0 +1,86 @@
+import sdkClient from '@sherlo/sdk-client';
+import handleClientError from '../handleClientError';
+import { BuildStatusPoll, BuildStatusSource } from './types';
+
+// The `getBuildStatus` field isn't visible on the sdk-client type from this
+// workspace (it's generated in the sibling sherlo-lib repo) - narrowed here
+// to the fields this source actually reads. There is no single overall
+// status string: `runStatus` says where the run is, and `viewStatusesCount`
+// (only meaningful once `runStatus` is `finished`) says whether there's
+// anything to review.
+type RunStatus = 'canceled' | 'error' | 'finished' | 'inProgress' | 'queued' | 'waiting';
+
+type ViewStatusesCount = {
+  approved: number;
+  noChanges: number;
+  reported: number;
+  unreviewed: number;
+};
+
+type BuildStatusClient = {
+  getBuildStatus: (params: {
+    teamId: string;
+    projectIndex: number;
+    buildIndex: number;
+  }) => Promise<{ runStatus: RunStatus; viewStatusesCount: ViewStatusesCount | null | undefined }>;
+};
+
+function createPollingBuildStatusSource({
+  client,
+  teamId,
+  projectIndex,
+  buildIndex,
+}: {
+  client: ReturnType<typeof sdkClient>;
+  teamId: string;
+  projectIndex: number;
+  buildIndex: number;
+}): BuildStatusSource {
+  const statusClient = client as unknown as BuildStatusClient;
+
+  return {
+    poll: async (): Promise<BuildStatusPoll> => {
+      const { runStatus, viewStatusesCount } = await statusClient
+        .getBuildStatus({ teamId, projectIndex, buildIndex })
+        .catch(handleClientError);
+
+      return toBuildStatusPoll(runStatus, viewStatusesCount);
+    },
+  };
+}
+
+export default createPollingBuildStatusSource;
+
+/* ========================================================================== */
+
+// `error`/`canceled` is a run that ended without a usable result - surfaced
+// as a poll error (same path as a network/client error) rather than a
+// terminal outcome. `queued`/`waiting`/`inProgress` keep polling. `finished`
+// is terminal; whether there's anything to review comes from
+// `viewStatusesCount.unreviewed`/`reported` (diffs nobody has judged yet,
+// or ones already flagged), since there's no single overall status string
+// in this response. `viewStatusesCount` can arrive null/undefined on a
+// just-finished poll (a race with the count not being written yet) - treat
+// that as not-yet-terminal so the next poll picks it up.
+function toBuildStatusPoll(
+  runStatus: RunStatus,
+  viewStatusesCount: ViewStatusesCount | null | undefined
+): BuildStatusPoll {
+  switch (runStatus) {
+    case 'finished':
+      if (!viewStatusesCount) {
+        return { terminal: false };
+      }
+      return {
+        terminal: true,
+        hasChangesToReview: viewStatusesCount.unreviewed > 0 || viewStatusesCount.reported > 0,
+      };
+    case 'error':
+    case 'canceled':
+      throw new Error(`Test run ended with status "${runStatus}"`);
+    case 'queued':
+    case 'waiting':
+    case 'inProgress':
+      return { terminal: false };
+  }
+}

--- a/packages/cli/src/helpers/waitForBuildResult/index.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/index.ts
@@ -1,0 +1,2 @@
+export { default } from './waitForBuildResult';
+export type { BuildStatusPoll, BuildStatusSource } from './types';

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -1,0 +1,104 @@
+import printResultsUrl from '../printResultsUrl';
+import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES, WAIT_TIMEOUT_MS } from './constants';
+import { BuildStatusSource } from './types';
+
+/**
+ * Polls `statusSource` on a fixed interval until the build reaches a
+ * terminal state or the wait times out, then sets `process.exitCode` per the
+ * exit-code contract (0/1/2/3/130) and reprints the dashboard URL. Never
+ * throws - every exit path (terminal, timeout, poll error, SIGINT) resolves
+ * normally so the command can finish and exit with the code that was set.
+ */
+async function runWaitLoop({
+  statusSource,
+  url,
+}: {
+  statusSource: BuildStatusSource;
+  url: string;
+}): Promise<void> {
+  console.log(
+    `⏳ Waiting for the test run to finish (times out after ${WAIT_TIMEOUT_MINUTES} minutes)...\n`
+  );
+
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  const sigint = createSigintSignal();
+
+  try {
+    while (true) {
+      if (Date.now() >= deadline) {
+        printResultsUrl(url);
+        console.error(
+          `Timed out waiting for the test run to finish after ${WAIT_TIMEOUT_MINUTES} minutes`
+        );
+        process.exitCode = 3;
+        return;
+      }
+
+      const polled = await Promise.race([
+        statusSource
+          .poll()
+          .then((result) => ({ type: 'result' as const, result }))
+          .catch((error) => ({ type: 'error' as const, error })),
+        sigint.promise.then(() => ({ type: 'sigint' as const })),
+      ]);
+
+      if (polled.type === 'sigint') {
+        printResultsUrl(url);
+        process.exitCode = 130;
+        return;
+      }
+
+      if (polled.type === 'error') {
+        printResultsUrl(url);
+        console.error((polled.error as Error).message);
+        process.exitCode = 2;
+        return;
+      }
+
+      if (polled.result.terminal) {
+        printResultsUrl(url);
+        process.exitCode = polled.result.hasChangesToReview ? 1 : 0;
+        return;
+      }
+
+      const remainingMs = Math.max(deadline - Date.now(), 0);
+      const waited = await Promise.race([
+        delay(Math.min(POLL_INTERVAL_MS, remainingMs)).then(() => 'elapsed' as const),
+        sigint.promise.then(() => 'sigint' as const),
+      ]);
+
+      if (waited === 'sigint') {
+        printResultsUrl(url);
+        process.exitCode = 130;
+        return;
+      }
+    }
+  } finally {
+    sigint.cleanup();
+  }
+}
+
+export default runWaitLoop;
+
+/* ========================================================================== */
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Overrides Node's default "exit immediately" SIGINT behavior so the wait
+ * loop can stop cleanly, reprint the dashboard URL, and exit(130) itself
+ * instead of killing the process mid-print.
+ */
+function createSigintSignal(): { promise: Promise<void>; cleanup: () => void } {
+  let resolveSignal: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolveSignal = resolve;
+  });
+
+  const handler = () => resolveSignal();
+  process.once('SIGINT', handler);
+
+  return { promise, cleanup: () => process.off('SIGINT', handler) };
+}

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -14,11 +14,19 @@ async function runWaitLoop({
   statusSource,
   url,
   maxWaitTimeMinutes,
+  now = Date.now,
 }: {
   statusSource: BuildStatusSource;
   url: string;
   /** Overrides `WAIT_TIMEOUT_MINUTES` for this run when provided (e.g. `--maxWaitTime`). */
   maxWaitTimeMinutes?: number;
+  /**
+   * Injectable clock so the deadline tests can stub time deterministically
+   * instead of spying on the global `Date.now` - keeps them immune to any
+   * other `Date.now` caller in the process (e.g. a test reporter timestamping
+   * console output) under any test reporter.
+   */
+  now?: () => number;
 }): Promise<void> {
   const waitTimeoutMinutes = maxWaitTimeMinutes ?? WAIT_TIMEOUT_MINUTES;
   const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000;
@@ -27,12 +35,12 @@ async function runWaitLoop({
     `⏳ Waiting for the test run to finish (times out after ${waitTimeoutMinutes} minutes)...\n`
   );
 
-  const deadline = Date.now() + waitTimeoutMs;
+  const deadline = now() + waitTimeoutMs;
   const sigint = createSigintSignal();
 
   try {
     while (true) {
-      if (Date.now() >= deadline) {
+      if (now() >= deadline) {
         console.error(
           `⌛ ${chalk.yellow(
             `Deadline passed after ${waitTimeoutMinutes}min - the run is still open`
@@ -76,7 +84,7 @@ async function runWaitLoop({
         return;
       }
 
-      const remainingMs = Math.max(deadline - Date.now(), 0);
+      const remainingMs = Math.max(deadline - now(), 0);
       const waited = await Promise.race([
         delay(Math.min(POLL_INTERVAL_MS, remainingMs)).then(() => 'elapsed' as const),
         sigint.promise.then(() => 'sigint' as const),

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -34,7 +34,9 @@ async function runWaitLoop({
     while (true) {
       if (Date.now() >= deadline) {
         console.error(
-          `⌛ ${chalk.yellow(`Deadline passed after ${waitTimeoutMinutes}min - the run is still open`)}\n`
+          `⌛ ${chalk.yellow(
+            `Deadline passed after ${waitTimeoutMinutes}min - the run is still open`
+          )}\n`
         );
         printResultsUrl(url);
         process.exitCode = 3;

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import printResultsUrl from '../printResultsUrl';
-import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES, WAIT_TIMEOUT_MS } from './constants';
+import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES } from './constants';
 import { BuildStatusSource } from './types';
 
 /**
@@ -13,22 +13,28 @@ import { BuildStatusSource } from './types';
 async function runWaitLoop({
   statusSource,
   url,
+  maxWaitTimeMinutes,
 }: {
   statusSource: BuildStatusSource;
   url: string;
+  /** Overrides `WAIT_TIMEOUT_MINUTES` for this run when provided (e.g. `--maxWaitTime`). */
+  maxWaitTimeMinutes?: number;
 }): Promise<void> {
+  const waitTimeoutMinutes = maxWaitTimeMinutes ?? WAIT_TIMEOUT_MINUTES;
+  const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000;
+
   console.log(
-    `⏳ Waiting for the test run to finish (times out after ${WAIT_TIMEOUT_MINUTES} minutes)...\n`
+    `⏳ Waiting for the test run to finish (times out after ${waitTimeoutMinutes} minutes)...\n`
   );
 
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + waitTimeoutMs;
   const sigint = createSigintSignal();
 
   try {
     while (true) {
       if (Date.now() >= deadline) {
         console.error(
-          `⌛ ${chalk.yellow(`Deadline passed after ${WAIT_TIMEOUT_MINUTES}min - the run is still open`)}\n`
+          `⌛ ${chalk.yellow(`Deadline passed after ${waitTimeoutMinutes}min - the run is still open`)}\n`
         );
         printResultsUrl(url);
         process.exitCode = 3;

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import printResultsUrl from '../printResultsUrl';
 import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES, WAIT_TIMEOUT_MS } from './constants';
 import { BuildStatusSource } from './types';
@@ -26,10 +27,10 @@ async function runWaitLoop({
   try {
     while (true) {
       if (Date.now() >= deadline) {
-        printResultsUrl(url);
         console.error(
-          `Timed out waiting for the test run to finish after ${WAIT_TIMEOUT_MINUTES} minutes`
+          `⌛ ${chalk.yellow(`Deadline passed after ${WAIT_TIMEOUT_MINUTES}min - the run is still open`)}\n`
         );
+        printResultsUrl(url);
         process.exitCode = 3;
         return;
       }
@@ -43,19 +44,25 @@ async function runWaitLoop({
       ]);
 
       if (polled.type === 'sigint') {
+        console.log(`${chalk.dim('Stopped waiting. The run is still going in Sherlo:')}\n`);
         printResultsUrl(url);
         process.exitCode = 130;
         return;
       }
 
       if (polled.type === 'error') {
-        printResultsUrl(url);
         console.error((polled.error as Error).message);
+        printResultsUrl(url);
         process.exitCode = 2;
         return;
       }
 
       if (polled.result.terminal) {
+        if (polled.result.hasChangesToReview) {
+          console.log(`🟠 ${chalk.yellow('Run finished - snapshots require review')}\n`);
+        } else {
+          console.log(`✅ ${chalk.green('Run finished - nothing is waiting on a human')}\n`);
+        }
         printResultsUrl(url);
         process.exitCode = polled.result.hasChangesToReview ? 1 : 0;
         return;
@@ -68,6 +75,7 @@ async function runWaitLoop({
       ]);
 
       if (waited === 'sigint') {
+        console.log(`${chalk.dim('Stopped waiting. The run is still going in Sherlo:')}\n`);
         printResultsUrl(url);
         process.exitCode = 130;
         return;

--- a/packages/cli/src/helpers/waitForBuildResult/types.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/types.ts
@@ -2,9 +2,7 @@
  * One poll result from a build status source. `terminal: false` means keep
  * polling; `terminal: true` carries the final outcome.
  */
-export type BuildStatusPoll =
-  | { terminal: false }
-  | { terminal: true; hasChangesToReview: boolean };
+export type BuildStatusPoll = { terminal: false } | { terminal: true; hasChangesToReview: boolean };
 
 /**
  * The narrow interface `runWaitLoop` polls against. Today's implementation

--- a/packages/cli/src/helpers/waitForBuildResult/types.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/types.ts
@@ -1,0 +1,17 @@
+/**
+ * One poll result from a build status source. `terminal: false` means keep
+ * polling; `terminal: true` carries the final outcome.
+ */
+export type BuildStatusPoll =
+  | { terminal: false }
+  | { terminal: true; hasChangesToReview: boolean };
+
+/**
+ * The narrow interface `runWaitLoop` polls against. Today's implementation
+ * (`createPollingBuildStatusSource`) calls `getBuildStatus` on a fixed
+ * interval; a future push source (e.g. a subscription) can satisfy this same
+ * interface by resolving `poll()` as soon as a new status is pushed.
+ */
+export type BuildStatusSource = {
+  poll: () => Promise<BuildStatusPoll>;
+};

--- a/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
@@ -1,0 +1,23 @@
+import sdkClient from '@sherlo/sdk-client';
+import createPollingBuildStatusSource from './createPollingBuildStatusSource';
+import runWaitLoop from './runWaitLoop';
+
+async function waitForBuildResult({
+  client,
+  teamId,
+  projectIndex,
+  buildIndex,
+  url,
+}: {
+  client: ReturnType<typeof sdkClient>;
+  teamId: string;
+  projectIndex: number;
+  buildIndex: number;
+  url: string;
+}): Promise<void> {
+  const statusSource = createPollingBuildStatusSource({ client, teamId, projectIndex, buildIndex });
+
+  await runWaitLoop({ statusSource, url });
+}
+
+export default waitForBuildResult;

--- a/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
@@ -8,16 +8,19 @@ async function waitForBuildResult({
   projectIndex,
   buildIndex,
   url,
+  maxWaitTime,
 }: {
   client: ReturnType<typeof sdkClient>;
   teamId: string;
   projectIndex: number;
   buildIndex: number;
   url: string;
+  /** Overrides the default wait timeout (in minutes) for this run. */
+  maxWaitTime?: number;
 }): Promise<void> {
   const statusSource = createPollingBuildStatusSource({ client, teamId, projectIndex, buildIndex });
 
-  await runWaitLoop({ statusSource, url });
+  await runWaitLoop({ statusSource, url, maxWaitTimeMinutes: maxWaitTime });
 }
 
 export default waitForBuildResult;

--- a/packages/cli/src/helpers/withCommandTimeout.ts
+++ b/packages/cli/src/helpers/withCommandTimeout.ts
@@ -11,7 +11,9 @@ const TIMEOUT_IN_MINUTES = 30;
  * which owns the timeout exit code (3) for that case - this wrapper racing
  * it here would throw first and clobber that exit code.
  */
-function withCommandTimeout<T, P extends { wait?: boolean }>(commandFn: (options: P) => Promise<T>) {
+function withCommandTimeout<T, P extends { wait?: boolean }>(
+  commandFn: (options: P) => Promise<T>
+) {
   return async (options: P): Promise<T> => {
     if (options.wait) {
       return commandFn(options);

--- a/packages/cli/src/helpers/withCommandTimeout.ts
+++ b/packages/cli/src/helpers/withCommandTimeout.ts
@@ -5,9 +5,18 @@ const TIMEOUT_IN_MINUTES = 30;
 /**
  * Wraps a command function with a timeout mechanism.
  * If the command execution exceeds the timeout (30 minutes), it will throw a TimeoutError.
+ *
+ * Skipped when `options.wait` is set: `--wait` legitimately runs past this
+ * same 30-minute mark on its own bounded clock (see waitForBuildResult),
+ * which owns the timeout exit code (3) for that case - this wrapper racing
+ * it here would throw first and clobber that exit code.
  */
-function withCommandTimeout<T, P>(commandFn: (options: P) => Promise<T>) {
+function withCommandTimeout<T, P extends { wait?: boolean }>(commandFn: (options: P) => Promise<T>) {
   return async (options: P): Promise<T> => {
+    if (options.wait) {
+      return commandFn(options);
+    }
+
     let timeoutId: number | undefined;
 
     const timeoutPromise = new Promise<never>((_, reject) => {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -41,6 +41,7 @@ import {
   TEST_STANDARD_COMMAND,
   TOKEN_OPTION,
   WAIT_FOR_EAS_BUILD_OPTION,
+  WAIT_OPTION,
 } from './constants';
 import { logWarning, reporting, withCommandTimeout } from './helpers';
 
@@ -170,6 +171,11 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
     `--${WAIT_FOR_EAS_BUILD_OPTION}`,
     'Start waiting for EAS Build to be triggered manually',
   ],
+  [WAIT_OPTION]: [
+    `--${WAIT_OPTION}`,
+    'Wait for the test run to finish (times out after 30 minutes). Exit code: ' +
+      '0 = nothing to review, 1 = changes to review, 2 = error, 3 = timeout',
+  ],
 };
 
 function addInitCommand(program: Command) {
@@ -188,7 +194,7 @@ function addTestCommand(program: Command) {
   addCommand({
     program,
     command: TEST_COMMAND,
-    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
     action: test,
   });
 }
@@ -200,7 +206,7 @@ function addTestStandardCommand(program: Command) {
     program,
     command: TEST_STANDARD_COMMAND,
     oldCommand: 'local-builds',
-    options: [...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
     action: testStandard,
   });
 }
@@ -215,7 +221,12 @@ function addTestEasUpdateCommand(program: Command) {
     program,
     command: TEST_EAS_UPDATE_COMMAND,
     oldCommand: 'expo-update',
-    options: [BRANCH_OPTION, ...getTestCommonOptions('withPlatformPaths'), ...devtoolsOptions],
+    options: [
+      BRANCH_OPTION,
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      ...devtoolsOptions,
+    ],
     action: testEasUpdate,
   });
 }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -30,6 +30,7 @@ import {
   INIT_COMMAND,
   IOS_FILE_TYPES,
   IOS_OPTION,
+  MAX_WAIT_TIME_OPTION,
   MESSAGE_OPTION,
   PLATFORM_LABEL,
   PROFILE_OPTION,
@@ -44,6 +45,7 @@ import {
   WAIT_OPTION,
 } from './constants';
 import { logWarning, reporting, withCommandTimeout } from './helpers';
+import { WAIT_TIMEOUT_MINUTES } from './helpers/waitForBuildResult/constants';
 
 // Disable all Node.js warnings
 process.removeAllListeners('warning');
@@ -173,8 +175,14 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
   ],
   [WAIT_OPTION]: [
     `--${WAIT_OPTION}`,
-    'Wait for the test run to finish (times out after 30 minutes). Exit code: ' +
+    `Wait for the test run to finish (times out after ${WAIT_TIMEOUT_MINUTES} minutes, ` +
+      `override with --${MAX_WAIT_TIME_OPTION}). Exit code: ` +
       '0 = nothing to review, 1 = changes to review, 2 = error, 3 = timeout',
+  ],
+  [MAX_WAIT_TIME_OPTION]: [
+    `--${MAX_WAIT_TIME_OPTION} <minutes>`,
+    `Override how long --${WAIT_OPTION} waits before timing out (default: ${WAIT_TIMEOUT_MINUTES} minutes). ` +
+      'Must be an integer of at least 1',
   ],
 };
 
@@ -194,7 +202,12 @@ function addTestCommand(program: Command) {
   addCommand({
     program,
     command: TEST_COMMAND,
-    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
+      ...devtoolsOptions,
+    ],
     action: test,
   });
 }
@@ -206,7 +219,12 @@ function addTestStandardCommand(program: Command) {
     program,
     command: TEST_STANDARD_COMMAND,
     oldCommand: 'local-builds',
-    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
+      ...devtoolsOptions,
+    ],
     action: testStandard,
   });
 }
@@ -225,6 +243,7 @@ function addTestEasUpdateCommand(program: Command) {
       BRANCH_OPTION,
       ...getTestCommonOptions('withPlatformPaths'),
       WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
       ...devtoolsOptions,
     ],
     action: testEasUpdate,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -78,6 +78,14 @@ type CommonOptions<M extends OptionsMode, F extends OptionsFormat> = {
   [GIT_BRANCH_OPTION]?: string;
   [INCLUDE_OPTION]?: F extends 'raw' ? string : string[];
   [DIAGNOSTICS_OPTION]?: F extends 'raw' ? string : string[];
+  /**
+   * Registered only on the wait-capable test commands (`test`,
+   * `test:standard`, `test:eas-update`), but declared on the shared shape:
+   * `validateMaxWaitTime` and `getCommandParams` consume params typed by a
+   * GENERIC command `C`, and TypeScript cannot resolve `CommandOptions[C]`
+   * structurally while `C` is unresolved.
+   */
+  [MAX_WAIT_TIME_OPTION]?: string;
 } & (M extends 'withDefaults'
   ? { [CONFIG_OPTION]: string; [PROJECT_ROOT_OPTION]: string }
   : { [CONFIG_OPTION]?: string; [PROJECT_ROOT_OPTION]?: string });
@@ -87,7 +95,6 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
-    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_UPDATE_COMMAND]: {
     [BRANCH_OPTION]: string;
@@ -98,7 +105,6 @@ type CommandOptions = {
     [EAS_IOS_URL_OPTION]?: string;
     [EAS_UPDATE_SLUG_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
-    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_CLOUD_BUILD_COMMAND]: {
     [EAS_BUILD_SCRIPT_NAME_OPTION]?: string;
@@ -111,7 +117,6 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
-    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [INIT_COMMAND]: {};
   any: Partial<
@@ -124,19 +129,11 @@ type CommandOptions = {
 
 /* === COMMAND PARAMS === */
 
-/**
- * `maxWaitTime` is declared here (not only per-command in `CommandOptions`)
- * because `validateMaxWaitTime` consumes params typed by the GENERIC `C` -
- * TypeScript cannot resolve `CommandOptions[C]` structurally for an unresolved
- * `C`, so the shared params shape must carry the optional field itself.
- */
 export type CommandParams<C extends Command | 'any' = 'any'> = Config &
-  Options<C, 'withDefaults', 'normalized'> & { token: string } & {
-    [MAX_WAIT_TIME_OPTION]?: string;
-  };
+  Options<C, 'withDefaults', 'normalized'> & { token: string };
 
 export type InvalidatedCommandParams<C extends Command | 'any' = 'any'> = InvalidatedConfig &
-  Options<C, 'withDefaults', 'normalized'> & { [MAX_WAIT_TIME_OPTION]?: string };
+  Options<C, 'withDefaults', 'normalized'>;
 
 /* === OTHERS === */
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,6 +24,7 @@ import {
   TEST_STANDARD_COMMAND,
   TOKEN_OPTION,
   WAIT_FOR_EAS_BUILD_OPTION,
+  WAIT_OPTION,
 } from './constants';
 
 /* === GENERAL === */
@@ -84,6 +85,7 @@ type CommandOptions = {
   [TEST_STANDARD_COMMAND]: {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
+    [WAIT_OPTION]?: boolean;
   };
   [TEST_EAS_UPDATE_COMMAND]: {
     [BRANCH_OPTION]: string;
@@ -93,6 +95,7 @@ type CommandOptions = {
     [EAS_ANDROID_URL_OPTION]?: string;
     [EAS_IOS_URL_OPTION]?: string;
     [EAS_UPDATE_SLUG_OPTION]?: string;
+    [WAIT_OPTION]?: boolean;
   };
   [TEST_EAS_CLOUD_BUILD_COMMAND]: {
     [EAS_BUILD_SCRIPT_NAME_OPTION]?: string;
@@ -104,6 +107,7 @@ type CommandOptions = {
   [TEST_COMMAND]: {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
+    [WAIT_OPTION]?: boolean;
   };
   [INIT_COMMAND]: {};
   any: Partial<

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -124,11 +124,19 @@ type CommandOptions = {
 
 /* === COMMAND PARAMS === */
 
+/**
+ * `maxWaitTime` is declared here (not only per-command in `CommandOptions`)
+ * because `validateMaxWaitTime` consumes params typed by the GENERIC `C` -
+ * TypeScript cannot resolve `CommandOptions[C]` structurally for an unresolved
+ * `C`, so the shared params shape must carry the optional field itself.
+ */
 export type CommandParams<C extends Command | 'any' = 'any'> = Config &
-  Options<C, 'withDefaults', 'normalized'> & { token: string };
+  Options<C, 'withDefaults', 'normalized'> & { token: string } & {
+    [MAX_WAIT_TIME_OPTION]?: string;
+  };
 
 export type InvalidatedCommandParams<C extends Command | 'any' = 'any'> = InvalidatedConfig &
-  Options<C, 'withDefaults', 'normalized'>;
+  Options<C, 'withDefaults', 'normalized'> & { [MAX_WAIT_TIME_OPTION]?: string };
 
 /* === OTHERS === */
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -15,6 +15,7 @@ import {
   INIT_COMMAND,
   IOS_FILE_TYPES,
   IOS_OPTION,
+  MAX_WAIT_TIME_OPTION,
   MESSAGE_OPTION,
   PROFILE_OPTION,
   PROJECT_ROOT_OPTION,
@@ -86,6 +87,7 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_UPDATE_COMMAND]: {
     [BRANCH_OPTION]: string;
@@ -96,6 +98,7 @@ type CommandOptions = {
     [EAS_IOS_URL_OPTION]?: string;
     [EAS_UPDATE_SLUG_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_CLOUD_BUILD_COMMAND]: {
     [EAS_BUILD_SCRIPT_NAME_OPTION]?: string;
@@ -108,6 +111,7 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [INIT_COMMAND]: {};
   any: Partial<


### PR DESCRIPTION
Landing PR for epic "sherlo-cli-wait" - sherlo CLI --wait flag.

**E2E declaration:** extend [cli/errors, cli/test-standard]

<!-- e2e:declared
{"mode":"extend","suites":["cli/errors","cli/test-standard"]}
-->

🤖 Generated with brain