### PR TITLE
fix: Fix the two prettier errors blocking sherlo#235

### DIFF
--- a/packages/cli/src/helpers/waitForBuildResult/types.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/types.ts
@@ -2,9 +2,7 @@
  * One poll result from a build status source. `terminal: false` means keep
  * polling; `terminal: true` carries the final outcome.
  */
-export type BuildStatusPoll =
-  | { terminal: false }
-  | { terminal: true; hasChangesToReview: boolean };
+export type BuildStatusPoll = { terminal: false } | { terminal: true; hasChangesToReview: boolean };
 
 /**
  * The narrow interface `runWaitLoop` polls against. Today's implementation

--- a/packages/cli/src/helpers/withCommandTimeout.ts
+++ b/packages/cli/src/helpers/withCommandTimeout.ts
@@ -11,7 +11,9 @@ const TIMEOUT_IN_MINUTES = 30;
  * which owns the timeout exit code (3) for that case - this wrapper racing
  * it here would throw first and clobber that exit code.
  */
-function withCommandTimeout<T, P extends { wait?: boolean }>(commandFn: (options: P) => Promise<T>) {
+function withCommandTimeout<T, P extends { wait?: boolean }>(
+  commandFn: (options: P) => Promise<T>
+) {
   return async (options: P): Promise<T> => {
     if (options.wait) {
       return commandFn(options);


### PR DESCRIPTION
Channel PR for task "cli-wait-lint-fix".

**E2E declaration:** none - prettier-only formatting fix, zero behavior change; the landing PR's own CI (including the e2e suites already declared by cli-wait-ship) re-runs on push and is the verification.

<!-- e2e:declared
{"mode":"none","reason":"prettier-only formatting fix, zero behavior change; the landing PR's own CI (including the e2e suites already declared by cli-wait-ship) re-runs on push and is the verification."}
-->

🤖 Generated with brain