### PR TITLE
feat: --maxWaitTime flag for --wait (the 30-min ceiling is hardcoded)

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -94,6 +94,7 @@ export const TOKEN_OPTION = 'token';
 export const INCLUDE_OPTION = 'include';
 export const WAIT_FOR_EAS_BUILD_OPTION = 'waitForEasBuild';
 export const WAIT_OPTION = 'wait';
+export const MAX_WAIT_TIME_OPTION = 'maxWaitTime';
 
 export const COLOR = {
   reported: 'FFB36C',

--- a/packages/cli/src/helpers/__tests__/parseMaxWaitTime.test.ts
+++ b/packages/cli/src/helpers/__tests__/parseMaxWaitTime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import parseMaxWaitTime from '../parseMaxWaitTime';
+
+describe('parseMaxWaitTime', () => {
+  it('returns undefined when no value is passed (falls back to the default wait timeout)', () => {
+    expect(parseMaxWaitTime(undefined)).toBeUndefined();
+  });
+
+  it('parses a valid minutes string into a number', () => {
+    expect(parseMaxWaitTime('45')).toBe(45);
+  });
+
+  it('parses a single-digit minutes string into a number', () => {
+    expect(parseMaxWaitTime('1')).toBe(1);
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateMaxWaitTime.test.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/__tests__/validateMaxWaitTime.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import validateMaxWaitTime from '../validateMaxWaitTime';
+
+describe('validateMaxWaitTime', () => {
+  it('does nothing when maxWaitTime is not provided', () => {
+    expect(() => validateMaxWaitTime({})).not.toThrow();
+  });
+
+  it.each(['1', '30', '999'])('accepts a valid positive integer string (%s)', (maxWaitTime) => {
+    expect(() => validateMaxWaitTime({ maxWaitTime })).not.toThrow();
+  });
+
+  it.each([
+    ['0', 'zero'],
+    ['-5', 'negative'],
+    ['1.5', 'decimal'],
+    ['abc', 'non-numeric'],
+    ['', 'empty string'],
+    ['  ', 'whitespace'],
+  ])('rejects %s (%s) with a range-naming error', (maxWaitTime) => {
+    expect(() => validateMaxWaitTime({ maxWaitTime })).toThrow(
+      /--maxWaitTime.*integer of at least 1/
+    );
+  });
+});

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateCommandParams.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateCommandParams.ts
@@ -8,6 +8,7 @@ import { validatePlatformPaths } from '../../shared';
 import getPlatformsToTest from '../../getPlatformsToTest';
 import validateConfigProperties from './validateConfigProperties';
 import validateDevices from './validateDevices';
+import validateMaxWaitTime from './validateMaxWaitTime';
 import validateToken from './validateToken';
 
 function validateCommandParams<C extends Command>(
@@ -19,6 +20,8 @@ function validateCommandParams<C extends Command>(
   validateToken(commandParams);
 
   validateDevices(commandParams);
+
+  validateMaxWaitTime(commandParams);
 
   if (requirePlatformPaths) {
     const platformsToValidate = getPlatformsToTest(

--- a/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateMaxWaitTime.ts
+++ b/packages/cli/src/helpers/getValidatedCommandParams/validateCommandParams/validateMaxWaitTime.ts
@@ -1,0 +1,20 @@
+import { MAX_WAIT_TIME_OPTION } from '../../../constants';
+import throwError from '../../throwError';
+
+function validateMaxWaitTime(commandParams: { [MAX_WAIT_TIME_OPTION]?: string }): void {
+  const { maxWaitTime } = commandParams;
+
+  if (maxWaitTime === undefined) return;
+
+  const parsed = Number(maxWaitTime);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throwError({
+      message:
+        `Invalid \`--${MAX_WAIT_TIME_OPTION}\` value \`${maxWaitTime}\`. ` +
+        'Must be an integer of at least 1 (minutes)',
+    });
+  }
+}
+
+export default validateMaxWaitTime;

--- a/packages/cli/src/helpers/parseMaxWaitTime.ts
+++ b/packages/cli/src/helpers/parseMaxWaitTime.ts
@@ -1,0 +1,10 @@
+/**
+ * Converts the validated `--maxWaitTime` string option into the number
+ * `runWaitLoop` expects. Validation (integer >= 1) already happened in
+ * `validateMaxWaitTime` - this is a pure format conversion.
+ */
+function parseMaxWaitTime(maxWaitTime?: string): number | undefined {
+  return maxWaitTime !== undefined ? Number(maxWaitTime) : undefined;
+}
+
+export default parseMaxWaitTime;

--- a/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
+++ b/packages/cli/src/helpers/uploadOrReuseBuildsAndRunTests.ts
@@ -8,6 +8,7 @@ import getGitInfo from './getGitInfo';
 import getTokenParts from './getTokenParts';
 import getValidatedBinariesInfoAndNextBuildIndex from './getValidatedBinariesInfoAndNextBuildIndex';
 import handleClientError from './handleClientError';
+import parseMaxWaitTime from './parseMaxWaitTime';
 import printBuildIntroMessage from './printBuildIntroMessage';
 import printResultsUrl from './printResultsUrl';
 import reporting from './reporting';
@@ -114,7 +115,9 @@ async function uploadOrReuseBuildsAndRunTests({
   printResultsUrl(url);
 
   if (commandParams.wait) {
-    await waitForBuildResult({ client, teamId, projectIndex, buildIndex, url });
+    const maxWaitTime = parseMaxWaitTime(commandParams.maxWaitTime);
+
+    await waitForBuildResult({ client, teamId, projectIndex, buildIndex, url, maxWaitTime });
   }
 
   return { url };

--- a/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import runWaitLoop from '../runWaitLoop';
+import { WAIT_TIMEOUT_MINUTES } from '../constants';
+import { BuildStatusSource } from '../types';
+
+const neverPolls: BuildStatusSource = {
+  poll: () => new Promise(() => {}), // must never resolve - the deadline check runs before any poll
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe('runWaitLoop - deadline honors --maxWaitTime override', () => {
+  it('times out after WAIT_TIMEOUT_MINUTES when no override is passed', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
+    now.mockReturnValueOnce(WAIT_TIMEOUT_MINUTES * 60_000); // Date.now() >= deadline
+
+    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com' });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('honors a non-default maxWaitTimeMinutes for the deadline', async () => {
+    const customMinutes = 2;
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + customMinutes * 60_000
+    now.mockReturnValueOnce(customMinutes * 60_000); // Date.now() >= deadline
+
+    await runWaitLoop({
+      statusSource: neverPolls,
+      url: 'https://example.com',
+      maxWaitTimeMinutes: customMinutes,
+    });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it('does NOT time out at the custom-minutes mark when it is still under the default deadline', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default)
+    now.mockReturnValueOnce(2 * 60_000); // well before the default deadline
+
+    const statusSource: BuildStatusSource = {
+      poll: () => Promise.resolve({ terminal: true, hasChangesToReview: false }),
+    };
+
+    await runWaitLoop({ statusSource, url: 'https://example.com' });
+
+    // Reached the poll (and resolved terminal) instead of timing out.
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/helpers/waitForBuildResult/constants.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/constants.ts
@@ -1,4 +1,5 @@
 // Fixed by contract - not user-configurable.
 export const POLL_INTERVAL_MS = 15_000;
+
+// Default wait timeout; overridable per-run via the `--maxWaitTime` CLI option.
 export const WAIT_TIMEOUT_MINUTES = 30;
-export const WAIT_TIMEOUT_MS = WAIT_TIMEOUT_MINUTES * 60 * 1000;

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import printResultsUrl from '../printResultsUrl';
-import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES, WAIT_TIMEOUT_MS } from './constants';
+import { POLL_INTERVAL_MS, WAIT_TIMEOUT_MINUTES } from './constants';
 import { BuildStatusSource } from './types';
 
 /**
@@ -13,22 +13,28 @@ import { BuildStatusSource } from './types';
 async function runWaitLoop({
   statusSource,
   url,
+  maxWaitTimeMinutes,
 }: {
   statusSource: BuildStatusSource;
   url: string;
+  /** Overrides `WAIT_TIMEOUT_MINUTES` for this run when provided (e.g. `--maxWaitTime`). */
+  maxWaitTimeMinutes?: number;
 }): Promise<void> {
+  const waitTimeoutMinutes = maxWaitTimeMinutes ?? WAIT_TIMEOUT_MINUTES;
+  const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000;
+
   console.log(
-    `⏳ Waiting for the test run to finish (times out after ${WAIT_TIMEOUT_MINUTES} minutes)...\n`
+    `⏳ Waiting for the test run to finish (times out after ${waitTimeoutMinutes} minutes)...\n`
   );
 
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + waitTimeoutMs;
   const sigint = createSigintSignal();
 
   try {
     while (true) {
       if (Date.now() >= deadline) {
         console.error(
-          `⌛ ${chalk.yellow(`Deadline passed after ${WAIT_TIMEOUT_MINUTES}min - the run is still open`)}\n`
+          `⌛ ${chalk.yellow(`Deadline passed after ${waitTimeoutMinutes}min - the run is still open`)}\n`
         );
         printResultsUrl(url);
         process.exitCode = 3;

--- a/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/waitForBuildResult.ts
@@ -8,16 +8,19 @@ async function waitForBuildResult({
   projectIndex,
   buildIndex,
   url,
+  maxWaitTime,
 }: {
   client: ReturnType<typeof sdkClient>;
   teamId: string;
   projectIndex: number;
   buildIndex: number;
   url: string;
+  /** Overrides the default wait timeout (in minutes) for this run. */
+  maxWaitTime?: number;
 }): Promise<void> {
   const statusSource = createPollingBuildStatusSource({ client, teamId, projectIndex, buildIndex });
 
-  await runWaitLoop({ statusSource, url });
+  await runWaitLoop({ statusSource, url, maxWaitTimeMinutes: maxWaitTime });
 }
 
 export default waitForBuildResult;

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -30,6 +30,7 @@ import {
   INIT_COMMAND,
   IOS_FILE_TYPES,
   IOS_OPTION,
+  MAX_WAIT_TIME_OPTION,
   MESSAGE_OPTION,
   PLATFORM_LABEL,
   PROFILE_OPTION,
@@ -44,6 +45,7 @@ import {
   WAIT_OPTION,
 } from './constants';
 import { logWarning, reporting, withCommandTimeout } from './helpers';
+import { WAIT_TIMEOUT_MINUTES } from './helpers/waitForBuildResult/constants';
 
 // Disable all Node.js warnings
 process.removeAllListeners('warning');
@@ -173,8 +175,14 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
   ],
   [WAIT_OPTION]: [
     `--${WAIT_OPTION}`,
-    'Wait for the test run to finish (times out after 30 minutes). Exit code: ' +
+    `Wait for the test run to finish (times out after ${WAIT_TIMEOUT_MINUTES} minutes, ` +
+      `override with --${MAX_WAIT_TIME_OPTION}). Exit code: ` +
       '0 = nothing to review, 1 = changes to review, 2 = error, 3 = timeout',
+  ],
+  [MAX_WAIT_TIME_OPTION]: [
+    `--${MAX_WAIT_TIME_OPTION} <minutes>`,
+    `Override how long --${WAIT_OPTION} waits before timing out (default: ${WAIT_TIMEOUT_MINUTES} minutes). ` +
+      'Must be an integer of at least 1',
   ],
 };
 
@@ -194,7 +202,12 @@ function addTestCommand(program: Command) {
   addCommand({
     program,
     command: TEST_COMMAND,
-    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
+      ...devtoolsOptions,
+    ],
     action: test,
   });
 }
@@ -206,7 +219,12 @@ function addTestStandardCommand(program: Command) {
     program,
     command: TEST_STANDARD_COMMAND,
     oldCommand: 'local-builds',
-    options: [...getTestCommonOptions('withPlatformPaths'), WAIT_OPTION, ...devtoolsOptions],
+    options: [
+      ...getTestCommonOptions('withPlatformPaths'),
+      WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
+      ...devtoolsOptions,
+    ],
     action: testStandard,
   });
 }
@@ -225,6 +243,7 @@ function addTestEasUpdateCommand(program: Command) {
       BRANCH_OPTION,
       ...getTestCommonOptions('withPlatformPaths'),
       WAIT_OPTION,
+      MAX_WAIT_TIME_OPTION,
       ...devtoolsOptions,
     ],
     action: testEasUpdate,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -15,6 +15,7 @@ import {
   INIT_COMMAND,
   IOS_FILE_TYPES,
   IOS_OPTION,
+  MAX_WAIT_TIME_OPTION,
   MESSAGE_OPTION,
   PROFILE_OPTION,
   PROJECT_ROOT_OPTION,
@@ -86,6 +87,7 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_UPDATE_COMMAND]: {
     [BRANCH_OPTION]: string;
@@ -96,6 +98,7 @@ type CommandOptions = {
     [EAS_IOS_URL_OPTION]?: string;
     [EAS_UPDATE_SLUG_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [TEST_EAS_CLOUD_BUILD_COMMAND]: {
     [EAS_BUILD_SCRIPT_NAME_OPTION]?: string;
@@ -108,6 +111,7 @@ type CommandOptions = {
     [ANDROID_OPTION]?: string;
     [IOS_OPTION]?: string;
     [WAIT_OPTION]?: boolean;
+    [MAX_WAIT_TIME_OPTION]?: string;
   };
   [INIT_COMMAND]: {};
   any: Partial<


### PR DESCRIPTION
Channel PR for task "wait-timeout-flag".

**E2E declaration:** verify [cli/test-standard]

<!-- e2e:declared
{"mode":"verify","suites":["cli/test-standard"]}
-->

🤖 Generated with brain