### PR TITLE
fix: runWaitLoop deadline tests hang in CI - global Date.now spy is order-fragile

### DIFF
--- a/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/__tests__/runWaitLoop.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import runWaitLoop from '../runWaitLoop';
 import { WAIT_TIMEOUT_MINUTES } from '../constants';
 import { BuildStatusSource } from '../types';
@@ -8,46 +8,51 @@ const neverPolls: BuildStatusSource = {
 };
 
 afterEach(() => {
-  vi.restoreAllMocks();
   process.exitCode = undefined;
 });
 
+/**
+ * Call-counted clock stub: first call is the deadline computation, every
+ * later call is the loop's deadline check. Passed in directly instead of
+ * spying on the global `Date.now`, so no other `Date.now` caller in the
+ * process (e.g. a test reporter timestamping console output) can perturb it.
+ */
+function makeClockStub(firstCallMs: number, laterCallsMs: number): () => number {
+  let callCount = 0;
+  return () => (callCount++ === 0 ? firstCallMs : laterCallsMs);
+}
+
 describe('runWaitLoop - deadline honors --maxWaitTime override', () => {
   it('times out after WAIT_TIMEOUT_MINUTES when no override is passed', async () => {
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
-    now.mockReturnValueOnce(WAIT_TIMEOUT_MINUTES * 60_000); // Date.now() >= deadline
+    const now = makeClockStub(0, WAIT_TIMEOUT_MINUTES * 60_000); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000
 
-    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com' });
+    await runWaitLoop({ statusSource: neverPolls, url: 'https://example.com', now });
 
     expect(process.exitCode).toBe(3);
   });
 
   it('honors a non-default maxWaitTimeMinutes for the deadline', async () => {
     const customMinutes = 2;
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + customMinutes * 60_000
-    now.mockReturnValueOnce(customMinutes * 60_000); // Date.now() >= deadline
+    const now = makeClockStub(0, customMinutes * 60_000); // deadline = 0 + customMinutes * 60_000
 
     await runWaitLoop({
       statusSource: neverPolls,
       url: 'https://example.com',
       maxWaitTimeMinutes: customMinutes,
+      now,
     });
 
     expect(process.exitCode).toBe(3);
   });
 
   it('does NOT time out at the custom-minutes mark when it is still under the default deadline', async () => {
-    const now = vi.spyOn(Date, 'now');
-    now.mockReturnValueOnce(0); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default)
-    now.mockReturnValueOnce(2 * 60_000); // well before the default deadline
+    const now = makeClockStub(0, 2 * 60_000); // deadline = 0 + WAIT_TIMEOUT_MINUTES * 60_000 (default), well before it
 
     const statusSource: BuildStatusSource = {
       poll: () => Promise.resolve({ terminal: true, hasChangesToReview: false }),
     };
 
-    await runWaitLoop({ statusSource, url: 'https://example.com' });
+    await runWaitLoop({ statusSource, url: 'https://example.com', now });
 
     // Reached the poll (and resolved terminal) instead of timing out.
     expect(process.exitCode).toBe(0);

--- a/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
+++ b/packages/cli/src/helpers/waitForBuildResult/runWaitLoop.ts
@@ -14,11 +14,19 @@ async function runWaitLoop({
   statusSource,
   url,
   maxWaitTimeMinutes,
+  now = Date.now,
 }: {
   statusSource: BuildStatusSource;
   url: string;
   /** Overrides `WAIT_TIMEOUT_MINUTES` for this run when provided (e.g. `--maxWaitTime`). */
   maxWaitTimeMinutes?: number;
+  /**
+   * Injectable clock so the deadline tests can stub time deterministically
+   * instead of spying on the global `Date.now` - keeps them immune to any
+   * other `Date.now` caller in the process (e.g. a test reporter timestamping
+   * console output) under any test reporter.
+   */
+  now?: () => number;
 }): Promise<void> {
   const waitTimeoutMinutes = maxWaitTimeMinutes ?? WAIT_TIMEOUT_MINUTES;
   const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000;
@@ -27,12 +35,12 @@ async function runWaitLoop({
     `⏳ Waiting for the test run to finish (times out after ${waitTimeoutMinutes} minutes)...\n`
   );
 
-  const deadline = Date.now() + waitTimeoutMs;
+  const deadline = now() + waitTimeoutMs;
   const sigint = createSigintSignal();
 
   try {
     while (true) {
-      if (Date.now() >= deadline) {
+      if (now() >= deadline) {
         console.error(
           `⌛ ${chalk.yellow(
             `Deadline passed after ${waitTimeoutMinutes}min - the run is still open`
@@ -76,7 +84,7 @@ async function runWaitLoop({
         return;
       }
 
-      const remainingMs = Math.max(deadline - Date.now(), 0);
+      const remainingMs = Math.max(deadline - now(), 0);
       const waited = await Promise.race([
         delay(Math.min(POLL_INTERVAL_MS, remainingMs)).then(() => 'elapsed' as const),
         sigint.promise.then(() => 'sigint' as const),


### PR DESCRIPTION
Channel PR for task "wait-unit-clock-fix".

**E2E declaration:** none - Unit-test determinism fix only: runWaitLoop gains an injectable now parameter DEFAULTING to Date.now (zero behavior change for every real caller) and its two deadline unit tests switch from a global Date.now spy to a passed-in stub. The --wait contract, CLI output, and exit codes are untouched, so the epic's device evidence (runs 31404528366, 31419807450) remains binding; the per-push oracle (checks (cli) unit tests) is exactly the thing this fixes.

<!-- e2e:declared
{"mode":"none","reason":"Unit-test determinism fix only: runWaitLoop gains an injectable now parameter DEFAULTING to Date.now (zero behavior change for every real caller) and its two deadline unit tests switch from a global Date.now spy to a passed-in stub. The --wait contract, CLI output, and exit codes are untouched, so the epic's device evidence (runs 31404528366, 31419807450) remains binding; the per-push oracle (checks (cli) unit tests) is exactly the thing this fixes."}
-->

🤖 Generated with brain