### PR TITLE
feat: CLI-minted expectations - fixtures are emitted by the product, never hand-authored

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,11 +28,38 @@ jobs:
         with:
           node-version: '24'
 
+      # feature/sherlo-3 and every epic/** branch build against the SAME sherlo-api ref
+      # (feature/sherlo-3) - the S3 dev-stage canon can predate lib/SDK changes an epic's
+      # CLI code depends on (composition gap: CLI source is current, its @sherlo/* portal
+      # deps are not). A PR against main keeps the unchanged S3-canon path - empty `ref`
+      # here is that opt-out.
+      - name: Resolve sherlo-lib source
+        id: libs
+        run: |
+          if [ "$GITHUB_BASE_REF" = "feature/sherlo-3" ] || [[ "$GITHUB_BASE_REF" == epic/* ]]; then
+            echo "ref=feature/sherlo-3" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Only minted when a from-source libs build is actually needed - mirrors the
+      # release_to_dev.yml SHERLO_BOT app-token pattern, since GITHUB_TOKEN has no access
+      # to sherlo-io/sherlo-api (a separate private repo).
+      - name: Create GH App Token (sherlo-api clone)
+        if: steps.libs.outputs.ref != ''
+        id: github_app_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SHERLO_BOT_APP_ID }}
+          private_key: ${{ secrets.SHERLO_BOT_PRIVATE_KEY }}
+
       - name: Download Sherlo packages
         run: ./scripts/init-env.sh
         env:
           CLIENT_STAGE: dev
           PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+          LIBS_REF: ${{ steps.libs.outputs.ref }}
+          SHERLO_API_CLONE_TOKEN: ${{ steps.github_app_token.outputs.token }}
 
       - name: Eslint
         working-directory: ${{ matrix.package.dir }}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feature/sherlo-3
+      - epic/**
 
 jobs:
   checks:

--- a/packages/cli/src/commands/testBundled/__tests__/emitExpectation.test.ts
+++ b/packages/cli/src/commands/testBundled/__tests__/emitExpectation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for `test:bundled --dry-run --emit-expectation` (expectation-emit mode).
+ *
+ * The core claim under test (per the one-formatter law): for every scenario, the
+ * minted text is produced by the SAME guard + throwError formatter a live run
+ * uses - never a second, hand-written copy of the message. Each test triggers
+ * the guard directly (the "live" call) with the SAME synthetic input the
+ * scenario itself feeds the guard, then asserts the minted text equals the raw
+ * live message once the known volatile literal is masked back in - i.e. outside
+ * the placeholder span, the two are byte-for-byte identical, and the placeholder
+ * sits exactly where the volatile value was.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  EXPECTATION_PLACEHOLDERS,
+  EXPECTATION_SCENARIO_IDS,
+  renderExpectation,
+} from '../emitExpectation';
+import parseConfigFile from '../../../helpers/getValidatedCommandParams/getNormalizedConfig/parseConfigFile';
+import validateDevices from '../../../helpers/getValidatedCommandParams/validateCommandParams/validateDevices';
+import validateToken from '../../../helpers/getValidatedCommandParams/validateCommandParams/validateToken';
+import validateBinariesInfo from '../../../helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo';
+import { validatePlatformPaths } from '../../../helpers/shared';
+import { TEST_STANDARD_COMMAND } from '../../../constants';
+import { BinariesInfo, InvalidatedConfig } from '../../../types';
+
+/** Runs a guard expected to throw and returns the raw thrown message ("the live call"). */
+function liveMessage(runGuard: () => void): string {
+  try {
+    runGuard();
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error('expected guard to throw');
+}
+
+describe('renderExpectation - no volatile values', () => {
+  it("token-missing equals validateToken's live message verbatim", () => {
+    const live = liveMessage(() => validateToken({} as InvalidatedConfig));
+    expect(renderExpectation('token-missing')).toBe(live);
+  });
+
+  it("token-malformed equals validateToken's live message verbatim", () => {
+    const live = liveMessage(() =>
+      validateToken({ token: 'not-a-real-sherlo-token' } as InvalidatedConfig)
+    );
+    expect(renderExpectation('token-malformed')).toBe(live);
+  });
+
+  it("devices-empty equals validateDevices's live message verbatim", () => {
+    const live = liveMessage(() => validateDevices({ devices: [] } as InvalidatedConfig));
+    expect(renderExpectation('devices-empty')).toBe(live);
+  });
+
+  it("binary-path-missing equals validatePlatformPaths's live message verbatim", () => {
+    const live = liveMessage(() =>
+      validatePlatformPaths({
+        platformsToValidate: ['android'],
+        android: undefined,
+        command: TEST_STANDARD_COMMAND,
+      })
+    );
+    expect(renderExpectation('binary-path-missing')).toBe(live);
+  });
+});
+
+describe('renderExpectation - masks the volatile value it fed in', () => {
+  it('config-missing: masks the config path, byte-identical otherwise', () => {
+    const configPath = '/Users/sherlo-user/my-app/sherlo.config.json';
+    const live = liveMessage(() => parseConfigFile(configPath));
+    const minted = renderExpectation('config-missing');
+
+    expect(live).toContain(configPath);
+    expect(minted).not.toContain(configPath);
+    expect(minted).toContain(EXPECTATION_PLACEHOLDERS.CONFIG_PATH);
+    expect(minted).toBe(live.split(configPath).join(EXPECTATION_PLACEHOLDERS.CONFIG_PATH));
+  });
+
+  it('project-root-invalid: same guard/branch as config-missing, byte-identical outside the path', () => {
+    const configMissing = renderExpectation('config-missing');
+    const projectRootInvalid = renderExpectation('project-root-invalid');
+
+    expect(projectRootInvalid).toBe(configMissing);
+  });
+
+  it('binary-path-nonexistent: masks the android build path, byte-identical otherwise', () => {
+    const androidPath = '/Users/sherlo-user/my-app/builds/app-release.apk';
+    const live = liveMessage(() =>
+      validatePlatformPaths({
+        platformsToValidate: ['android'],
+        android: androidPath,
+        command: TEST_STANDARD_COMMAND,
+      })
+    );
+    const minted = renderExpectation('binary-path-nonexistent');
+
+    expect(live).toContain(androidPath);
+    expect(minted).not.toContain(androidPath);
+    expect(minted).toContain(EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_PATH);
+    expect(minted).toBe(live.split(androidPath).join(EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_PATH));
+  });
+
+  it('binary-abi-x86-only: masks the build file name, byte-identical otherwise, keeps the ABI list', () => {
+    const fileName = 'app-release.apk';
+    const binariesInfo: BinariesInfo = {
+      android: {
+        hash: 'stand-in-hash',
+        buildType: 'preview',
+        fileName,
+        s3Key: '',
+        sdkVersion: '2.0.0',
+        androidAbis: ['x86_64'],
+      },
+    };
+    const live = liveMessage(() =>
+      validateBinariesInfo({ binariesInfo, command: TEST_STANDARD_COMMAND })
+    );
+    const minted = renderExpectation('binary-abi-x86-only');
+
+    expect(live).toContain(fileName);
+    expect(minted).not.toContain(fileName);
+    expect(minted).toContain(EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_FILE_NAME);
+    expect(minted).toContain('x86_64');
+    expect(minted).toBe(
+      live.split(fileName).join(EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_FILE_NAME)
+    );
+  });
+});
+
+describe('renderExpectation - scenario catalogue', () => {
+  it('covers every guard the emit mode documents (one-formatter law, no parallel print path)', () => {
+    expect(EXPECTATION_SCENARIO_IDS.sort()).toEqual(
+      [
+        'token-missing',
+        'token-malformed',
+        'devices-empty',
+        'config-missing',
+        'project-root-invalid',
+        'binary-path-missing',
+        'binary-path-nonexistent',
+        'binary-abi-x86-only',
+      ].sort()
+    );
+  });
+
+  it('throws with the catalogue for an unknown scenario id', () => {
+    expect(() => renderExpectation('does-not-exist')).toThrow(
+      /Unknown --emit-expectation scenario/
+    );
+  });
+});

--- a/packages/cli/src/commands/testBundled/emitExpectation.ts
+++ b/packages/cli/src/commands/testBundled/emitExpectation.ts
@@ -1,0 +1,234 @@
+/**
+ * `test:bundled --dry-run --emit-expectation <scenario>` - expectation-emit mode.
+ *
+ * Renders the exact refusal text a LIVE run would print for a named preflight
+ * scenario - same guard function, same throwError formatter - so consumers that
+ * need an expected fixture for that refusal never hand-author one: they mint it
+ * by running the CLI itself. Every volatile value the guard would have embedded
+ * (an absolute path, a build's file name) is replaced by a stable placeholder at
+ * mint time; the placeholder vocabulary is {@link EXPECTATION_PLACEHOLDERS},
+ * published below so a consumer never has to invent its own names.
+ *
+ * Each scenario calls the SAME guard export the live command path calls, with a
+ * synthetic input built to fail in exactly the one way the scenario names. There
+ * is no second copy of the error text anywhere in this file - only the input
+ * differs, never the formatter. Every guard exercised here (validateToken,
+ * validateDevices, parseConfigFile, validatePlatformPaths, validateBinariesInfo)
+ * runs entirely against local input and never touches the network, matching
+ * every real invocation of these guards elsewhere in the CLI.
+ */
+import { TEST_STANDARD_COMMAND } from '../../constants';
+import { BinariesInfo, InvalidatedConfig } from '../../types';
+import parseConfigFile from '../../helpers/getValidatedCommandParams/getNormalizedConfig/parseConfigFile';
+import validateDevices from '../../helpers/getValidatedCommandParams/validateCommandParams/validateDevices';
+import validateToken from '../../helpers/getValidatedCommandParams/validateCommandParams/validateToken';
+import validateBinariesInfo from '../../helpers/getValidatedBinariesInfoAndNextBuildIndex/validateBinariesInfo';
+import { validatePlatformPaths } from '../../helpers/shared';
+
+/**
+ * Placeholder vocabulary for volatile values a guard's message may embed. Defined
+ * ONCE here and reused by every scenario below - a consumer reads these off
+ * `--emit-expectation list`, never invents its own names.
+ */
+export const EXPECTATION_PLACEHOLDERS = {
+  CONFIG_PATH: '<SHERLO_CONFIG_PATH>',
+  ANDROID_BUILD_PATH: '<SHERLO_ANDROID_BUILD_PATH>',
+  ANDROID_BUILD_FILE_NAME: '<SHERLO_ANDROID_BUILD_FILE_NAME>',
+} as const;
+
+/** The command context every scenario's guard is evaluated under. */
+const SCENARIO_COMMAND = TEST_STANDARD_COMMAND;
+
+type ExpectationScenario = {
+  guard: string;
+  description: string;
+  /** Placeholder names (keys of {@link EXPECTATION_PLACEHOLDERS}) this scenario's rendered text may contain. */
+  placeholders: (keyof typeof EXPECTATION_PLACEHOLDERS)[];
+  /** Triggers the real guard against a synthetic input and returns its raw thrown message. */
+  trigger: () => string;
+};
+
+const SCENARIOS: Record<string, ExpectationScenario> = {
+  'token-missing': {
+    guard: 'validateToken',
+    description: 'The `token` option/config property is omitted entirely.',
+    placeholders: [],
+    trigger: () => triggerThrow(() => validateToken({} as InvalidatedConfig)),
+  },
+  'token-malformed': {
+    guard: 'validateToken',
+    description: 'A `token` is present but is not a valid Sherlo token.',
+    placeholders: [],
+    trigger: () =>
+      triggerThrow(() => validateToken({ token: 'not-a-real-sherlo-token' } as InvalidatedConfig)),
+  },
+  'devices-empty': {
+    guard: 'validateDevices',
+    description: 'Config `devices` is an empty array.',
+    placeholders: [],
+    trigger: () => triggerThrow(() => validateDevices({ devices: [] } as InvalidatedConfig)),
+  },
+  'config-missing': {
+    guard: 'parseConfigFile',
+    description: 'No config file exists at the resolved (default project root) path.',
+    placeholders: ['CONFIG_PATH'],
+    trigger: () => {
+      const configPath = '/Users/sherlo-user/my-app/sherlo.config.json';
+      return maskLiteral(
+        triggerThrow(() => parseConfigFile(configPath)),
+        configPath,
+        EXPECTATION_PLACEHOLDERS.CONFIG_PATH
+      );
+    },
+  },
+  'project-root-invalid': {
+    guard: 'parseConfigFile',
+    description:
+      '--project-root points at a directory with no config file. Renders byte-identical to ' +
+      '`config-missing` (same guard, same branch) - proof the CLI has exactly one message for ' +
+      '"no config file found at the resolved path", not a second one for a wrong project root.',
+    placeholders: ['CONFIG_PATH'],
+    trigger: () => {
+      const configPath = '/Users/sherlo-user/wrong-project-root/sherlo.config.json';
+      return maskLiteral(
+        triggerThrow(() => parseConfigFile(configPath)),
+        configPath,
+        EXPECTATION_PLACEHOLDERS.CONFIG_PATH
+      );
+    },
+  },
+  'binary-path-missing': {
+    guard: 'validatePlatformPaths',
+    description: 'Neither --android nor the config `android` property was passed.',
+    placeholders: [],
+    trigger: () =>
+      triggerThrow(() =>
+        validatePlatformPaths({
+          platformsToValidate: ['android'],
+          android: undefined,
+          command: SCENARIO_COMMAND,
+        })
+      ),
+  },
+  'binary-path-nonexistent': {
+    guard: 'validatePlatformPaths',
+    description: 'An --android path was passed but nothing exists there.',
+    placeholders: ['ANDROID_BUILD_PATH'],
+    trigger: () => {
+      const androidPath = '/Users/sherlo-user/my-app/builds/app-release.apk';
+      return maskLiteral(
+        triggerThrow(() =>
+          validatePlatformPaths({
+            platformsToValidate: ['android'],
+            android: androidPath,
+            command: SCENARIO_COMMAND,
+          })
+        ),
+        androidPath,
+        EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_PATH
+      );
+    },
+  },
+  'binary-abi-x86-only': {
+    guard: 'validateBinariesInfo',
+    description: 'An Android build carries native libraries but none for arm64-v8a.',
+    placeholders: ['ANDROID_BUILD_FILE_NAME'],
+    trigger: () => {
+      const fileName = 'app-release.apk';
+      const binariesInfo: BinariesInfo = {
+        android: {
+          hash: 'stand-in-hash',
+          buildType: 'preview',
+          fileName,
+          s3Key: '',
+          sdkVersion: '2.0.0',
+          androidAbis: ['x86_64'],
+        },
+      };
+      return maskLiteral(
+        triggerThrow(() => validateBinariesInfo({ binariesInfo, command: SCENARIO_COMMAND })),
+        fileName,
+        EXPECTATION_PLACEHOLDERS.ANDROID_BUILD_FILE_NAME
+      );
+    },
+  },
+};
+
+export const EXPECTATION_SCENARIO_IDS = Object.keys(SCENARIOS);
+
+/**
+ * Renders the named scenario's minted expectation text (pure - no I/O, no
+ * process control). Throws for an unknown scenario id; the guard's own throw is
+ * caught internally and never propagates - a known scenario id always returns.
+ */
+export function renderExpectation(scenarioId: string): string {
+  const scenario = SCENARIOS[scenarioId];
+  if (!scenario) {
+    throw new Error(
+      `Unknown --emit-expectation scenario: "${scenarioId}"\n\n${formatScenarioCatalogue()}`
+    );
+  }
+
+  return scenario.trigger();
+}
+
+/**
+ * Runs the named scenario and prints its minted expectation to stdout, or prints
+ * the scenario catalogue (`list`). Exits the process: 0 on success (including
+ * `list`), 1 for an unknown scenario id.
+ */
+export function runEmitExpectation(scenarioId: string): void {
+  if (scenarioId === 'list') {
+    console.log(formatScenarioCatalogue());
+    process.exit(0);
+  }
+
+  let rendered: string;
+  try {
+    rendered = renderExpectation(scenarioId);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  console.log(rendered);
+  process.exit(0);
+}
+
+/* ========================================================================== */
+
+/** Calls a guard that is expected to throw and returns the thrown error's message. */
+function triggerThrow(runGuard: () => void): string {
+  try {
+    runGuard();
+  } catch (error) {
+    return (error as Error).message;
+  }
+
+  throw new Error(
+    'Expectation-emit scenario did not throw - the guard now accepts input it used to refuse.'
+  );
+}
+
+/** Replaces every occurrence of a known literal (a value we fed in) with its placeholder. */
+function maskLiteral(message: string, literal: string, placeholder: string): string {
+  return message.split(literal).join(placeholder);
+}
+
+function formatScenarioCatalogue(): string {
+  const scenarioLines = Object.entries(SCENARIOS).map(
+    ([id, { guard, description }]) => `  ${id} (${guard})\n    ${description}`
+  );
+
+  const placeholderLines = Object.values(EXPECTATION_PLACEHOLDERS).map((token) => `  ${token}`);
+
+  return [
+    'Available --emit-expectation scenarios:',
+    '',
+    ...scenarioLines,
+    '',
+    'Placeholder vocabulary (volatile values substituted at mint time):',
+    '',
+    ...placeholderLines,
+  ].join('\n');
+}

--- a/packages/cli/src/commands/testBundled/testBundled.ts
+++ b/packages/cli/src/commands/testBundled/testBundled.ts
@@ -36,6 +36,7 @@ import {
   logWarning,
   printSherloIntro,
   reporting,
+  throwError,
   waitForBuildResult,
 } from '../../helpers';
 import printLink from '../../helpers/printLink';
@@ -51,6 +52,7 @@ import { parseStagedGateRefusal, FALLBACK_LINE, type StagedGateRefusal } from '.
 import { getOnStaleMode, handleStaleBase } from './onStale';
 import uploadStagedArtifacts, { type StagedUploadKeys } from './uploadStagedArtifacts';
 import { runDryRunPreview } from './dryRun';
+import { runEmitExpectation } from './emitExpectation';
 import { countBundleStories } from './readModuleManifest';
 import { formatDiffScopeReport, type DiffScopePlatformReport } from './diffScopeReport';
 
@@ -96,6 +98,21 @@ type DiffScopeInfoWithPlatformReasons = {
 
 async function testBundled(passedOptions: Options<THIS_COMMAND>): Promise<{ url: string }> {
   printSherloIntro();
+
+  // --emit-expectation (expectation-emit mode): rides the --dry-run path rather
+  // than a parallel print path. Runs before command params are even validated -
+  // the mode builds its own synthetic, scenario-specific input for the guard it
+  // exercises, so it needs none of this invocation's real options. See
+  // ./emitExpectation for the scenario catalogue and placeholder vocabulary.
+  if (passedOptions.emitExpectation !== undefined) {
+    if (passedOptions.dryRun !== true) {
+      throwError({
+        message: '--emit-expectation requires --dry-run',
+      });
+    }
+    runEmitExpectation(passedOptions.emitExpectation);
+    return { url: '' }; // unreachable - runEmitExpectation always exits the process
+  }
 
   // 1. Validate params (no platform binary paths required - bundle only).
   const commandParams = getValidatedCommandParams(

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -82,6 +82,7 @@ export const FULL_INIT_COMMAND = 'npx sherlo init';
 export const ANDROID_OPTION = 'android';
 export const BRANCH_OPTION = 'branch';
 export const DRY_RUN_OPTION = 'dryRun';
+export const EMIT_EXPECTATION_OPTION = 'emitExpectation';
 export const GIT_BRANCH_OPTION = 'gitBranch';
 export const CONFIG_OPTION = 'config';
 export const DIAGNOSTICS_OPTION = 'diagnostics';

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -161,7 +161,9 @@ async function waitForBuildResult({
         console.log();
         console.log(
           chalk.yellow(
-            `⏰ Timeout reached after ${waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES} minutes.`
+            `⏰ Timeout reached after ${
+              waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES
+            } minutes.`
           )
         );
         console.log(chalk.yellow('   The build may still be running. Check the dashboard:'));

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -28,6 +28,7 @@ import {
   EAS_BUILD_SCRIPT_NAME_OPTION,
   EAS_IOS_URL_OPTION,
   EAS_UPDATE_SLUG_OPTION,
+  EMIT_EXPECTATION_OPTION,
   GIT_BRANCH_OPTION,
   INCLUDE_OPTION,
   INIT_COMMAND,
@@ -179,6 +180,14 @@ const OPTION_DEFINITION: Record<string, [string, string]> = {
       'decision, and prints the per-platform "would capture" lists with reasons. ' +
       'Creates no build and uploads nothing.',
   ],
+  [EMIT_EXPECTATION_OPTION]: [
+    '--emit-expectation <scenario>',
+    'Expectation-emit mode (requires --dry-run): renders the exact refusal text a real ' +
+      'run would print for <scenario> - the same guard, the same formatter - with every ' +
+      'volatile value (an absolute path, a build file name) replaced by a stable ' +
+      'placeholder (e.g. <SHERLO_CONFIG_PATH>). Pass "list" to print every scenario and ' +
+      'the full placeholder vocabulary. Makes no build, no upload, no network call.',
+  ],
   [JSON_OPTION]: [`--${JSON_OPTION}`, 'Output machine-readable JSON instead of formatted text'],
   [MESSAGE_OPTION]: [`--${MESSAGE_OPTION} <message>`, 'Custom message to label the test'],
   [ON_STALE_OPTION]: [
@@ -310,6 +319,7 @@ function addTestBundledCommand(program: Command) {
       ...getTestCommonOptions('withoutPlatformPaths'),
       ON_STALE_OPTION,
       DRY_RUN_OPTION,
+      EMIT_EXPECTATION_OPTION,
       WAIT_OPTION,
       WAIT_TIMEOUT_OPTION,
       ...devtoolsOptions,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -11,6 +11,7 @@ import {
   EAS_BUILD_SCRIPT_NAME_OPTION,
   EAS_IOS_URL_OPTION,
   EAS_UPDATE_SLUG_OPTION,
+  EMIT_EXPECTATION_OPTION,
   GIT_BRANCH_OPTION,
   INCLUDE_OPTION,
   INIT_COMMAND,
@@ -141,6 +142,12 @@ type CommandOptions = {
      * is a read-only preview.
      */
     [DRY_RUN_OPTION]?: boolean;
+    /**
+     * Expectation-emit mode (requires --dry-run): renders the exact refusal text a
+     * live run would print for the named preflight scenario, then exits - no
+     * bundling, no build, no network. See ../commands/testBundled/emitExpectation.
+     */
+    [EMIT_EXPECTATION_OPTION]?: string;
   };
   [STAGED_CHECK_COMMAND]: {
     [JSON_OPTION]?: boolean;

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -1,19 +1,72 @@
 #!/bin/bash
-# Download @sherlo packages from S3, extract for portal links, install + build.
-# Used by CI and local development. Self-contained (no switch-env.sh dependency).
+# Populate sherlo-lib/extracted/@sherlo/<name> - the portal: targets packages/cli's
+# package.json resolves @sherlo/{sdk-client,api-types,common-client,shared} through -
+# then install + build. Used by CI and local development. Self-contained (no
+# switch-env.sh dependency).
+#
+# Two ways to populate sherlo-lib/extracted:
+#   - default: download the four packages from the S3 dev/test/prod canon (PACKAGE_TOKEN).
+#   - LIBS_REF set: build them from sherlo-io/sherlo-api@LIBS_REF's own workspace instead
+#     (SHERLO_API_CLONE_TOKEN - a token with clone access to that private repo). For a PR
+#     whose S3 canon predates the lib/SDK changes it depends on (the "epic's CLI still
+#     links against pre-epic canon libs" composition gap) - see pr_checks.yml for when
+#     this is set. Same law as everywhere else this pattern is used: a missing/inaccessible
+#     ref or a broken build FAILS the script - it never falls back to the S3 canon, which
+#     would silently re-create the exact gap this branch exists to close.
 set -euo pipefail
 STAGE="${CLIENT_STAGE:-dev}"
-API="https://8gbu9wv7jd.execute-api.eu-central-1.amazonaws.com/dev/get-package-endpoint"
-if [ -z "${PACKAGE_TOKEN:-}" ] && [ -f .env ]; then source .env; fi
-if [ -z "${PACKAGE_TOKEN:-}" ]; then echo "Error: PACKAGE_TOKEN not set" >&2; exit 1; fi
 PKGS=("sherlo-sdk-client" "sherlo-api-types" "sherlo-common-client" "sherlo-shared")
 NAMES=("@sherlo/sdk-client" "@sherlo/api-types" "@sherlo/common-client" "@sherlo/shared")
-mkdir -p sherlo-lib; rm -rf sherlo-lib/extracted
-for i in "${!PKGS[@]}"; do
-  url=$(curl -sf "$API?token=$PACKAGE_TOKEN&objectKey=$STAGE/${PKGS[$i]}.tgz")
-  curl -sfL -o "sherlo-lib/${PKGS[$i]}.tgz" "$url"
-  dir="sherlo-lib/extracted/${NAMES[$i]}"; mkdir -p "$dir"
-  tar -xzf "sherlo-lib/${PKGS[$i]}.tgz" -C "$dir" --strip-components=1
-  touch "$dir/yarn.lock"
-done
+SHERLO_API_REPO="sherlo-io/sherlo-api"
+
+mkdir -p sherlo-lib
+rm -rf sherlo-lib/extracted
+
+if [ -n "${LIBS_REF:-}" ]; then
+  if [ -z "${SHERLO_API_CLONE_TOKEN:-}" ]; then
+    echo "Error: LIBS_REF is set but SHERLO_API_CLONE_TOKEN is not - it authenticates the git fetch of $SHERLO_API_REPO (a private repo)" >&2
+    exit 1
+  fi
+
+  echo "Building sherlo-lib/extracted/@sherlo/* from $SHERLO_API_REPO@$LIBS_REF (source build, not S3 canon)"
+  API_BUILD_DIR=$(mktemp -d)
+  trap 'rm -rf "$API_BUILD_DIR"' EXIT
+
+  git -C "$API_BUILD_DIR" init -q
+  git -C "$API_BUILD_DIR" remote add origin "https://x-access-token:${SHERLO_API_CLONE_TOKEN}@github.com/${SHERLO_API_REPO}.git"
+  git -C "$API_BUILD_DIR" fetch --depth 1 origin "$LIBS_REF"
+  git -C "$API_BUILD_DIR" checkout -q FETCH_HEAD
+
+  # Repoint the client packages' env.json at $STAGE before building - the same repoint
+  # sherlo-api's own release workflows do before publishing to S3 canon.
+  # --caller-restores is irrelevant here (this checkout is deleted regardless via the
+  # trap above), but is the mode meant for an ephemeral caller, matching upstream usage.
+  (cd "$API_BUILD_DIR" && bash scripts/set-package-env.sh "$STAGE" --caller-restores)
+
+  # sherlo-api pins yarn@1.22.22 (Classic) via its own package.json `packageManager` -
+  # unrelated to this repo's yarn@4 (Berry). Bare `yarn` here resolves whatever this
+  # runner has on PATH for a repo with no `.yarnrc.yml`/`yarnPath` override, which is
+  # sherlo-api's own pin.
+  (cd "$API_BUILD_DIR" && yarn install)
+  (cd "$API_BUILD_DIR" && bash scripts/prepare-packages.sh)
+
+  for i in "${!PKGS[@]}"; do
+    dir="sherlo-lib/extracted/${NAMES[$i]}"; mkdir -p "$dir"
+    tar -xzf "$API_BUILD_DIR/sherlo-lib/${PKGS[$i]}.tgz" -C "$dir" --strip-components=1
+    touch "$dir/yarn.lock"
+  done
+else
+  API="https://8gbu9wv7jd.execute-api.eu-central-1.amazonaws.com/dev/get-package-endpoint"
+  if [ -z "${PACKAGE_TOKEN:-}" ] && [ -f .env ]; then source .env; fi
+  if [ -z "${PACKAGE_TOKEN:-}" ]; then echo "Error: PACKAGE_TOKEN not set" >&2; exit 1; fi
+
+  for i in "${!PKGS[@]}"; do
+    url=$(curl -sf "$API?token=$PACKAGE_TOKEN&objectKey=$STAGE/${PKGS[$i]}.tgz")
+    curl -sfL -o "sherlo-lib/${PKGS[$i]}.tgz" "$url"
+    dir="sherlo-lib/extracted/${NAMES[$i]}"; mkdir -p "$dir"
+    tar -xzf "sherlo-lib/${PKGS[$i]}.tgz" -C "$dir" --strip-components=1
+    touch "$dir/yarn.lock"
+  done
+fi
+
 yarn install

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -47,7 +47,21 @@ if [ -n "${LIBS_REF:-}" ]; then
   # unrelated to this repo's yarn@4 (Berry). Bare `yarn` here resolves whatever this
   # runner has on PATH for a repo with no `.yarnrc.yml`/`yarnPath` override, which is
   # sherlo-api's own pin.
+  #
+  # `yarn install`'s postinstall (scripts/build-unless-ci.sh) skips the build whenever
+  # CI=true (GitHub Actions sets this) - it exists purely for a local bare `yarn` to
+  # produce working dist/ output, and defers to CI's own explicit build step otherwise
+  # (see that script's own comment). sherlo-api's own workflows always follow `yarn`
+  # with an explicit `yarn build` for exactly this reason; skipping it here left
+  # `dist/` empty on every real (CI=true) runner, unnoticed locally only because a
+  # bare `yarn` outside CI builds anyway. `yarn build` (scripts/build.sh) builds every
+  # client package in DEPENDENCY order (api-types, shared, then the *-client packages
+  # that import shared) - required before scripts/prepare-packages.sh below, whose own
+  # per-package rebuild loop is ordered admin/app/sdk/runner-client THEN shared last,
+  # so admin-client/app-client's rebuild fails resolving `@sherlo/shared` types unless
+  # shared's dist already exists on disk from this step.
   (cd "$API_BUILD_DIR" && yarn install)
+  (cd "$API_BUILD_DIR" && yarn build)
   (cd "$API_BUILD_DIR" && bash scripts/prepare-packages.sh)
 
   for i in "${!PKGS[@]}"; do


### PR DESCRIPTION
Channel PR for task "s3cv-minted-expectations".

**E2E declaration:** none - The deliverable IS the evidence layer of the device-free recut lanes: fixtures regenerated through the CLI's own emit mode, pair parity proven by running those zero-device lanes at settle and reading the re-rendered report. The per-push oracle is each repo's unit lane (CLI emit-path tests in sherlo; registry guards + expectation meta-tests in sherlo-tester). No device capture exists to gate on.

<!-- e2e:declared
{"mode":"none","reason":"The deliverable IS the evidence layer of the device-free recut lanes: fixtures regenerated through the CLI's own emit mode, pair parity proven by running those zero-device lanes at settle and reading the re-rendered report. The per-push oracle is each repo's unit lane (CLI emit-path tests in sherlo; registry guards + expectation meta-tests in sherlo-tester). No device capture exists to gate on."}
-->

🤖 Generated with brain