### PR TITLE
fix: --wait prints the build link once, not twice

### DIFF
--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -13,6 +13,7 @@ import waitForBuildResult, {
   EXIT_BLOCK,
   EXIT_ERROR,
   EXIT_GREEN,
+  EXIT_SIGINT,
   EXIT_TIMEOUT,
   fetchServerBypassReason,
 } from '../waitForBuildResult';
@@ -314,7 +315,7 @@ describe('waitForBuildResult', () => {
 
     it('falls back to the generic green message when diffScopeInfo is absent', async () => {
       // Not a bypass at openBuild (no counts) -> serverBypassed omitted -> today's
-      // behaviour, waiting line and URL included.
+      // behaviour, waiting line included.
       mockGraphqlResponse(
         200,
         buildResponse('finished', { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 })
@@ -365,12 +366,13 @@ describe('waitForBuildResult', () => {
       expect(printed).not.toContain('Nothing needed capturing');
     });
 
-    it('forward-compat degrade: counts say bypass but the poll carries no reason -> generic green WITH the link', async () => {
+    it('forward-compat degrade: counts say bypass but the poll carries no reason -> generic green, no link', async () => {
       // The gate condition (SHERLO-1952): 0 captured, >0 inherited, AND a
-      // per-platform reason. Reason absent (older API) -> keep the link. The
-      // caller still flags the bypass off the counts (serverBypassed: true), so
-      // the wait theatre is suppressed, but the closer keeps the URL because a
-      // working link beats silence.
+      // per-platform reason. Reason absent (older API) -> generic green
+      // message. The caller still flags the bypass off the counts
+      // (serverBypassed: true), so the wait theatre is suppressed. No ending
+      // ever reprints the build link - it was already printed once, right
+      // when the build became ready.
       mockGraphqlResponse(
         200,
         buildResponse(
@@ -389,8 +391,7 @@ describe('waitForBuildResult', () => {
       const printed = printedOutput(logSpy);
       expect(printed).toContain('All stories passed');
       expect(printed).not.toContain('Nothing needed capturing');
-      // The link is preserved - silence is never better than a working link.
-      expect(printed).toContain('http');
+      expect(printed).not.toContain('http');
     });
   });
 
@@ -733,6 +734,138 @@ describe('waitForBuildResult', () => {
 
     expect(result).toBe(EXIT_GREEN);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* LINK-ONCE-PER-PUSH - the build link is printed once, by the caller,  */
+  /* right after the build is ready. No --wait ending (clean finish,      */
+  /* timeout, or SIGINT) may reprint it.                                  */
+  /* ------------------------------------------------------------------ */
+
+  describe('epilogue never reprints the build link', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    function printedOutput(): string {
+      return logSpy.mock.calls.map((call: unknown[]) => call[0] ?? '').join('\n');
+    }
+
+    it('clean finish (GREEN) does not reprint the link', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse('finished', { approved: 5, noChanges: 10, reported: 0, unreviewed: 0 })
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_GREEN);
+      expect(printedOutput()).not.toContain('http');
+    });
+
+    it('clean finish (BLOCK) does not reprint the link', async () => {
+      mockGraphqlResponse(
+        200,
+        buildResponse('finished', { approved: 3, noChanges: 5, reported: 0, unreviewed: 3 })
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_BLOCK);
+      expect(printedOutput()).not.toContain('http');
+    });
+
+    it('clean finish (ERROR) does not reprint the link', async () => {
+      mockGraphqlResponse(200, buildResponse('error'));
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_ERROR);
+      expect(printedOutput()).not.toContain('http');
+    });
+
+    it('TIMEOUT does not reprint the link', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ data: buildResponse('inProgress') }),
+        })
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+        waitTimeoutMinutes: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      const result = await promise;
+
+      expect(result).toBe(EXIT_TIMEOUT);
+      expect(printedOutput()).not.toContain('http');
+    }, 10_000);
+
+    it('SIGINT does not reprint the link', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ data: buildResponse('inProgress') }),
+        })
+      );
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      // Let the first poll land and the loop reach its sleep, then Ctrl-C.
+      await vi.advanceTimersByTimeAsync(0);
+      process.emit('SIGINT');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const result = await promise;
+
+      expect(result).toBe(EXIT_SIGINT);
+      expect(printedOutput()).not.toContain('http');
+    });
   });
 });
 

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -858,7 +858,7 @@ describe('waitForBuildResult', () => {
 
       // Let the first poll land and the loop reach its sleep, then Ctrl-C.
       await vi.advanceTimersByTimeAsync(0);
-      process.emit('SIGINT' as NodeJS.Signals);
+      process.emit('SIGINT', 'SIGINT');
       await vi.advanceTimersByTimeAsync(0);
 
       const result = await promise;

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -866,6 +866,28 @@ describe('waitForBuildResult', () => {
       expect(result).toBe(EXIT_SIGINT);
       expect(printedOutput()).not.toContain('http');
     });
+
+    it('AuthError at poll time does not reprint the link', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({}),
+      });
+
+      const promise = waitForBuildResult({
+        token: TOKEN,
+        buildIndex: BUILD_INDEX,
+        projectIndex: PROJECT_INDEX,
+        teamId: TEAM_ID,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe(EXIT_ERROR);
+      expect(printedOutput()).not.toContain('http');
+    });
   });
 });
 

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -858,7 +858,7 @@ describe('waitForBuildResult', () => {
 
       // Let the first poll land and the loop reach its sleep, then Ctrl-C.
       await vi.advanceTimersByTimeAsync(0);
-      process.emit('SIGINT');
+      process.emit('SIGINT' as NodeJS.Signals);
       await vi.advanceTimersByTimeAsync(0);
 
       const result = await promise;

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch';
 import chalk from 'chalk';
-import getAppBuildUrl from './getAppBuildUrl';
 import getTokenParts from './getTokenParts';
 
 /*
@@ -18,8 +17,8 @@ import getTokenParts from './getTokenParts';
  *   3 - TIMEOUT: --wait-timeout elapsed before reaching a terminal state.
  *               Conservative - timeout is a BLOCK, never a pass.
  *   130 - SIGINT: the user pressed Ctrl-C while waiting. The run keeps going
- *               in Sherlo; we stop cleanly, reprint the dashboard URL, and
- *               exit with the conventional 128+SIGINT(2) code.
+ *               in Sherlo; we stop cleanly and exit with the conventional
+ *               128+SIGINT(2) code.
  *
  * GitHub check mapping (for reference):
  *   exit 0 → conclusion: "success"
@@ -111,7 +110,6 @@ async function waitForBuildResult({
   const timeoutMs = (waitTimeoutMinutes ?? DEFAULT_WAIT_TIMEOUT_MINUTES) * 60 * 1000;
   const startTime = now();
   const deadline = startTime + timeoutMs;
-  const url = getAppBuildUrl({ buildIndex, projectIndex, teamId });
 
   const { apiToken } = getTokenParts(token);
   const endpointUrl = getEndpointUrl();
@@ -130,8 +128,8 @@ async function waitForBuildResult({
   let pollCount = 0;
 
   // Overrides Node's default "exit immediately" SIGINT behavior so the wait
-  // loop can stop cleanly, reprint the dashboard URL, and exit(130) itself
-  // instead of killing the process mid-print. The run keeps going in Sherlo.
+  // loop can stop cleanly and exit(130) itself instead of killing the process
+  // mid-print. The run keeps going in Sherlo.
   const sigint = createSigintSignal();
 
   // Every sleep in the loop is bounded to the remaining time until the
@@ -148,8 +146,7 @@ async function waitForBuildResult({
 
   const printSigintCloser = (): number => {
     console.log();
-    console.log(chalk.dim('Stopped waiting. The run is still going in Sherlo:'));
-    console.log(chalk.blue(`   ${url}`));
+    console.log(chalk.dim('Stopped waiting. The run is still going in Sherlo.'));
     console.log();
     return EXIT_SIGINT;
   };
@@ -166,8 +163,7 @@ async function waitForBuildResult({
             } minutes.`
           )
         );
-        console.log(chalk.yellow('   The build may still be running. Check the dashboard:'));
-        console.log(chalk.blue(`   ${url}`));
+        console.log(chalk.yellow('   The build may still be running. Check the dashboard.'));
         console.log();
         return EXIT_TIMEOUT;
       }
@@ -194,7 +190,6 @@ async function waitForBuildResult({
         if (error instanceof AuthError) {
           console.log();
           console.log(chalk.red(`🔒 ${error.message}`));
-          console.log(chalk.blue(`   Dashboard: ${url}`));
           console.log();
           return EXIT_ERROR;
         }
@@ -224,7 +219,7 @@ async function waitForBuildResult({
         lastStatus = progressLine;
       }
 
-      const exitCode = evaluateTerminalState(build, url);
+      const exitCode = evaluateTerminalState(build);
 
       if (exitCode !== null) {
         return exitCode;
@@ -333,8 +328,7 @@ async function fetchBuildStatus(
 }
 
 function evaluateTerminalState(
-  build: NonNullable<BuildStatusResponse['getBuildStatus']>,
-  url: string
+  build: NonNullable<BuildStatusResponse['getBuildStatus']>
 ): number | null {
   const { runStatus, viewStatusesCount, diffScopeInfo } = build;
 
@@ -362,11 +356,12 @@ function evaluateTerminalState(
           // URL for a bypassed build, so omitting it here loses no link.
           printServerBypassCloser(serverBypassReason);
         } else {
-          // No verbatim reason -> today's behaviour, keeping the link. Covers the
+          // No verbatim reason -> today's generic message. Covers the
           // forward-compat degrade of a counts-bypassed build whose poll carries
-          // no prose (a working link beats silence) and every ordinary green build.
+          // no prose, and every ordinary green build. The build's link was
+          // already printed once, right when the build became ready - never
+          // repeated here.
           console.log(chalk.green('✅ All stories passed - no visual changes require review.'));
-          console.log(chalk.blue(`   ${url}`));
         }
         console.log();
         return EXIT_GREEN;
@@ -380,7 +375,6 @@ function evaluateTerminalState(
       if (reported > 0) {
         console.log(chalk.yellow(`   ${reported} story/stories reported.`));
       }
-      console.log(chalk.blue(`   Review here: ${url}`));
       console.log();
       return EXIT_BLOCK;
     }
@@ -392,7 +386,6 @@ function evaluateTerminalState(
       if (build.runError) {
         console.log(chalk.red(`   Error: ${JSON.stringify(build.runError)}`));
       }
-      console.log(chalk.blue(`   ${url}`));
       console.log();
       return EXIT_ERROR;
     }

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -163,7 +163,7 @@ async function waitForBuildResult({
             } minutes.`
           )
         );
-        console.log(chalk.yellow('   The build may still be running. Check the dashboard.'));
+        console.log(chalk.yellow('   The build may still be running.'));
         console.log();
         return EXIT_TIMEOUT;
       }


### PR DESCRIPTION
Channel PR for task "pep-wait-link-once".

**E2E declaration:** verify [cli/test-standard]

<!-- e2e:declared
{"mode":"verify","suites":["cli/test-standard"],"reason":"The change edits what the CLI prints on every --wait ending, and the four snapshots that record it all sit under the cli/test-standard selector (its wait-clean, wait-review and wait-deadline storyline projects). They must run to prove the new output is what the committed snapshots now claim. ARCHITECT CORRECTION 2026-08-12: this field was first written as the three Playwright PROJECT names, but declared-suites.ts validates against e2e/coverage-map.ts SLUGS, and cli/test-standard is the one slug whose path-prefix selector pulls in the whole wait family. cli/errors also lists a --wait feature but snapshots no wait output at all - no build link and no waiting header anywhere in that suite - so it is correctly outside this gate."}
-->

🤖 Generated with brain