### PR TITLE
feat: lite-sdk-cli-lint

### DIFF
--- a/packages/cli/src/commands/test/diffScopeReport.ts
+++ b/packages/cli/src/commands/test/diffScopeReport.ts
@@ -267,8 +267,13 @@ export type DiffScopeSummaryInput = {
  * own bare-count degrade.
  */
 export function formatDiffScopeSummaryLine(input: DiffScopeSummaryInput): string | undefined {
-  const { full, capturedStoryFilePaths, totalStoriesInBundle: M, reason, allStoryFilePaths } =
-    input;
+  const {
+    full,
+    capturedStoryFilePaths,
+    totalStoriesInBundle: M,
+    reason,
+    allStoryFilePaths,
+  } = input;
 
   if (M === undefined || allStoryFilePaths === undefined) return undefined;
 

--- a/packages/cli/src/commands/view/view.transcripts.ts
+++ b/packages/cli/src/commands/view/view.transcripts.ts
@@ -202,7 +202,7 @@ export const VIEW_TRANSCRIPTS: Record<string, ViewTranscriptScenario> = {
   'view-metadata-diff-scope': {
     ...scenario(
       'THE DIFF SCOPE BLOCK, under `--metadata`. A partial-capture build: one story was left ' +
-        "out of this run and its accepted ancestor image was carried forward untouched - its " +
+        'out of this run and its accepted ancestor image was carried forward untouched - its ' +
         'status reads `not-captured` (distinct from `unchanged`, which means a fresh capture ' +
         "matched its baseline), and the wire's own `diffScope` names it in `inherited` alongside " +
         "the build it was carried from. `reason` is the server's own prose, printed verbatim.",


### PR DESCRIPTION
Channel PR for task "lite-sdk-cli-lint".

**E2E declaration:** none - A prettier reformat of two files changes no product behaviour, so there is no user-visible surface for an e2e suite to exercise. The CI lint job is itself the check.

<!-- e2e:declared
{"mode":"none","reason":"A prettier reformat of two files changes no product behaviour, so there is no user-visible surface for an e2e suite to exercise. The CI lint job is itself the check."}
-->

🤖 Generated with brain