### PR TITLE
feat: lite-sdk-appendfile-selector

### DIFF
--- a/packages/react-native-storybook/ios/SherloModule.mm
+++ b/packages/react-native-storybook/ios/SherloModule.mm
@@ -126,23 +126,23 @@ void SherloShimRegisterImplV1(SherloImplV1 *impl) {
 }
 
 - (void)appendFile:(NSString *)path
-          content:(NSString *)content
-          resolve:(RCTPromiseResolveBlock)resolve
-           reject:(RCTPromiseRejectBlock)reject
+     base64Content:(NSString *)base64Content
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject
 {
   SherloImplV1 *impl = gImpl.load(std::memory_order_acquire);
   if (impl == NULL) {
     reject(@"sherlo_no_implementation", @"the shim is present but nothing was injected", nil);
     return;
   }
-  impl->appendFile(path ?: @"", content ?: @"",
+  impl->appendFile(path ?: @"", base64Content ?: @"",
                    ^(NSString *value) { resolve(value); },
                    ^(NSString *code, NSString *message) { reject(code, message, nil); });
 }
 
 - (void)readFile:(NSString *)path
-        resolve:(RCTPromiseResolveBlock)resolve
-         reject:(RCTPromiseRejectBlock)reject
+         resolve:(RCTPromiseResolveBlock)resolve
+          reject:(RCTPromiseRejectBlock)reject
 {
   SherloImplV1 *impl = gImpl.load(std::memory_order_acquire);
   if (impl == NULL) {

--- a/packages/react-native-storybook/src/__tests__/repoInvariants.test.ts
+++ b/packages/react-native-storybook/src/__tests__/repoInvariants.test.ts
@@ -38,3 +38,75 @@ describe('repo invariant - the native build never compiles or links private sour
     expect(offenders).toEqual([]);
   });
 });
+
+/**
+ * The frozen spec and the iOS shim must agree on every SELECTOR, not just on
+ * method names. React Native's codegen turns each spec method into an
+ * Objective-C selector built from the method name plus the name of EVERY
+ * parameter after the first (plus `resolve:reject:` when the method returns a
+ * Promise), and it dispatches on that exact selector at runtime. So renaming a
+ * parameter in the spec and not in `SherloModule.mm` produces a shim that
+ * compiles, autolinks, and then cannot answer the call at all - which is how
+ * `appendFile:content:` survived the six-method spec rewrite while the spec
+ * said `base64Content`. Android is immune to this class of bug (it dispatches
+ * positionally and the compiler checks the override), so only iOS is scanned.
+ */
+const SPEC_PATH = path.join(PACKAGE_ROOT, 'src/specs/NativeSherloModule.ts');
+const SHIM_PATH = path.join(PACKAGE_ROOT, 'ios/SherloModule.mm');
+
+/**
+ * Reads `name: (paramA: T, paramB: T) => R;` entries out of the spec interface
+ * and returns the Objective-C selector codegen will require for each.
+ */
+function selectorsRequiredBySpec(specSource: string): string[] {
+  const methodPattern = /^ {2}(\w+): \(([^)]*)\) => (.+);$/gm;
+
+  return Array.from(specSource.matchAll(methodPattern)).map((method) => {
+    const [, methodName, parameterList, returnType] = method;
+
+    const parameterNames = parameterList
+      .split(',')
+      .map((parameter) => parameter.trim().split(':')[0].trim())
+      .filter((parameterName) => parameterName.length > 0);
+
+    // The first parameter rides on the method name itself; every later one
+    // contributes its own selector keyword.
+    const keywords = [methodName, ...parameterNames.slice(1)];
+    if (returnType.startsWith('Promise<')) keywords.push('resolve', 'reject');
+
+    return keywords.length === 1 ? methodName : `${keywords.join(':')}:`;
+  });
+}
+
+/** Every `- (...)` method the shim actually defines, as selector strings. */
+function selectorsImplementedByShim(shimSource: string): string[] {
+  const definitionPattern = /^- \([^)]*\)([\s\S]*?)\{/gm;
+
+  return Array.from(shimSource.matchAll(definitionPattern)).map((definition) => {
+    const header = definition[1];
+    const keywords = Array.from(header.matchAll(/(\w+)\s*:/g)).map((keyword) => keyword[1]);
+
+    return keywords.length === 0 ? header.trim() : `${keywords.join(':')}:`;
+  });
+}
+
+describe('repo invariant - the iOS shim implements the selectors the spec generates', () => {
+  const specSource = fs.readFileSync(SPEC_PATH, 'utf8');
+  const shimSource = fs.readFileSync(SHIM_PATH, 'utf8');
+  const implemented = selectorsImplementedByShim(shimSource);
+
+  it('finds all six spec methods', () => {
+    expect(selectorsRequiredBySpec(specSource)).toEqual([
+      'getSherloConstants',
+      'reportEarlyJsError:message:stack:',
+      'appendFile:base64Content:resolve:reject:',
+      'readFile:resolve:reject:',
+      'invoke:argsJson:resolve:reject:',
+      'invokeSync:argsJson:',
+    ]);
+  });
+
+  it.each(selectorsRequiredBySpec(specSource))('SherloModule.mm implements %s', (selector) => {
+    expect(implemented).toContain(selector);
+  });
+});


### PR DESCRIPTION
Channel PR for task "lite-sdk-appendfile-selector".

**E2E declaration:** none - The regression is proven by sherlo-runner's tier2 device suites, which is where the crash was found and where the fix is verified; there is no separate e2e surface for a native selector name.

<!-- e2e:declared
{"mode":"none","reason":"The regression is proven by sherlo-runner's tier2 device suites, which is where the crash was found and where the fix is verified; there is no separate e2e surface for a native selector name."}
-->

🤖 Generated with brain