### PR TITLE
feat: lite-sdk-methodqueue

### DIFF
--- a/packages/react-native-storybook/ios/SherloModule.mm
+++ b/packages/react-native-storybook/ios/SherloModule.mm
@@ -39,11 +39,6 @@ static void SherloEarlyInit(void) {
     return YES;
 }
 
-// Specifies the dispatch queue on which the module's methods should be executed.
-- (dispatch_queue_t)methodQueue {
-    return RCTGetUIManagerQueue();
-}
-
 // ---------------------------------------------------------------------------
 // The dispatch table.
 // ---------------------------------------------------------------------------

--- a/packages/react-native-storybook/src/__tests__/repoInvariants.test.ts
+++ b/packages/react-native-storybook/src/__tests__/repoInvariants.test.ts
@@ -110,3 +110,20 @@ describe('repo invariant - the iOS shim implements the selectors the spec genera
     expect(implemented).toContain(selector);
   });
 });
+
+/**
+ * The shim must take React Native's own dedicated TurboModule queue, not
+ * override it. Leaving `methodQueue` unimplemented makes
+ * `RCTTurboModuleManager` fall back to its `_sharedModuleQueue` - a serial
+ * queue that exists solely to run native-module methods. Overriding it to
+ * return `RCTGetUIManagerQueue()` instead puts every Sherlo native call on
+ * the Shadow Queue, the same queue reanimated, gesture-handler and svg use
+ * for their own shadow-tree work, so Sherlo calls queue up behind whatever
+ * those libraries are doing.
+ */
+describe('repo invariant - the iOS shim takes React Native’s own TurboModule queue', () => {
+  it('SherloModule.mm declares no methodQueue override', () => {
+    const shimSource = fs.readFileSync(SHIM_PATH, 'utf8');
+    expect(shimSource).not.toMatch(/-\s*\(dispatch_queue_t\)\s*methodQueue/);
+  });
+});


### PR DESCRIPTION
Channel PR for task "lite-sdk-methodqueue".

**E2E declaration:** none - The device evidence for this change is sherlo-runner's tier2 storybook-fixture suites, which are this epic's own member task lite-sdk-runner-suites. A separate e2e suite would test the same thing one layer further away.

<!-- e2e:declared
{"mode":"none","reason":"The device evidence for this change is sherlo-runner's tier2 storybook-fixture suites, which are this epic's own member task lite-sdk-runner-suites. A separate e2e suite would test the same thing one layer further away."}
-->

🤖 Generated with brain