### PR TITLE
feat: `sherlo project create` prints its own expected pane, instead of the tester quoting a claim

### DIFF
--- a/packages/cli/src/commands/projectCreate/projectCreatePose.ts
+++ b/packages/cli/src/commands/projectCreate/projectCreatePose.ts
@@ -51,7 +51,9 @@ export function decodeProjectCreatePose(document: unknown): ProjectCreateTranscr
     refusals.push('project.index: expected an integer');
   }
   if (typeof project.projectToken !== 'string' || project.projectToken.length === 0) {
-    refusals.push('project.projectToken: expected a non-empty string (mask it in the pose - the bytes are what is rendered, and a real token in a committed pose is a leaked token)');
+    refusals.push(
+      'project.projectToken: expected a non-empty string (mask it in the pose - the bytes are what is rendered, and a real token in a committed pose is a leaked token)'
+    );
   }
 
   const ambient = (doc.ambient ?? {}) as Record<string, unknown>;

--- a/packages/cli/src/commands/test/renderTranscript.ts
+++ b/packages/cli/src/commands/test/renderTranscript.ts
@@ -392,8 +392,9 @@ function readPose(source: string): DeclaredPose {
     if (family === 'project-create') return decodeProjectCreatePose(document);
     if (family === 'view' || family === undefined) return decodeViewPose(document);
     console.error(
-      `REFUSING TO RENDER (unknown pose family): '${String(family)}' is not a family this CLI can ` +
-        "render. Posable families: 'view', 'project-create'."
+      `REFUSING TO RENDER (unknown pose family): '${String(
+        family
+      )}' is not a family this CLI can ` + "render. Posable families: 'view', 'project-create'."
     );
     process.exit(1);
   } catch (error) {


### PR DESCRIPTION
Channel PR for task "branching-project-create-transcript".

**E2E declaration:** none - The proof is the Branching capture itself (branching-capture): once the family exists and the beats take transcriptState:, the eleven project-create cards print a pane from the shipped CLI instead of quoting an unproved claim. A separate gate would test the same thing twice.

<!-- e2e:declared
{"mode":"none","reason":"The proof is the Branching capture itself (branching-capture): once the family exists and the beats take transcriptState:, the eleven project-create cards print a pane from the shipped CLI instead of quoting an unproved claim. A separate gate would test the same thing twice."}
-->

🤖 Generated with brain