### PR TITLE
feat: sherlo: `--wait` does not print a verdict on a build whose stories are still settling

### DIFF
--- a/packages/cli/src/commands/projectList/projectList.ts
+++ b/packages/cli/src/commands/projectList/projectList.ts
@@ -67,7 +67,7 @@ function refuseRejectedToken(teamId: string): never {
       '      projects) or the `team:read` scope (looks the team up by id);\n' +
       '    - the token was mistyped or truncated in transit.\n' +
       '\n' +
-      `  Find the team id with \`sherlo team list\`, or by creating a project first:\n` +
+      '  Find the team id with `sherlo team list`, or by creating a project first:\n' +
       `  \`sherlo project create --${NAME_OPTION} <name> --${TEAM_OPTION} <teamId>\`.`,
   });
 }

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -1003,3 +1003,71 @@ describe('fetchServerBypassReason', () => {
     expect(mockFetch.mock.calls[0][1]).toMatchObject({ timeout: 10_000 });
   });
 });
+
+/*
+ * THE STORIES MUST HAVE STOPPED MOVING BEFORE A VERDICT IS PRINTED (2026-09-09).
+ * `finished` is the runner's word; the per-story rows land after it, one at a
+ * time, and a verdict printed over a half-written list is a wrong verdict a
+ * chained `--metadata` read would repeat as the truth.
+ */
+describe('waitForBuildResult settles stories[] before closing on a finished build', () => {
+  const GREEN = { approved: 0, noChanges: 2, reported: 0, unreviewed: 0 };
+  const CAPTURED = { capturedSnapshotCount: 2, inheritedSnapshotCount: 0 };
+  const story = (name: string, baseline: number | null) => ({ name, status: 'unchanged', baseline: baseline === null ? null : { buildIndex: baseline } });
+  const finished = (stories: unknown[] | undefined) => ({
+    getBuildStatus: { runStatus: 'finished', viewStatusesCount: GREEN, diffScopeInfo: CAPTURED, ...(stories ? { stories } : {}) },
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads a finished build twice and closes when the second read carries the same stories', async () => {
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
+
+    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps reading while the stories are still arriving, and closes once they hold still', async () => {
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1)]));
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', null)]));
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
+    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
+
+    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('closes at once on a finished build whose wire carries no stories - there is nothing to settle', async () => {
+    mockGraphqlResponse(200, finished(undefined));
+
+    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toBe(EXIT_GREEN);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hold an errored build - there is no comparison to wait for', async () => {
+    mockGraphqlResponse(200, buildResponse('error', undefined, 'boom'));
+
+    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    await vi.runAllTimersAsync();
+
+    expect(await promise).toBe(EXIT_ERROR);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
+++ b/packages/cli/src/helpers/__tests__/waitForBuildResult.test.ts
@@ -1013,9 +1013,18 @@ describe('fetchServerBypassReason', () => {
 describe('waitForBuildResult settles stories[] before closing on a finished build', () => {
   const GREEN = { approved: 0, noChanges: 2, reported: 0, unreviewed: 0 };
   const CAPTURED = { capturedSnapshotCount: 2, inheritedSnapshotCount: 0 };
-  const story = (name: string, baseline: number | null) => ({ name, status: 'unchanged', baseline: baseline === null ? null : { buildIndex: baseline } });
+  const story = (name: string, baseline: number | null) => ({
+    name,
+    status: 'unchanged',
+    baseline: baseline === null ? null : { buildIndex: baseline },
+  });
   const finished = (stories: unknown[] | undefined) => ({
-    getBuildStatus: { runStatus: 'finished', viewStatusesCount: GREEN, diffScopeInfo: CAPTURED, ...(stories ? { stories } : {}) },
+    getBuildStatus: {
+      runStatus: 'finished',
+      viewStatusesCount: GREEN,
+      diffScopeInfo: CAPTURED,
+      ...(stories ? { stories } : {}),
+    },
   });
 
   beforeEach(() => {
@@ -1031,7 +1040,12 @@ describe('waitForBuildResult settles stories[] before closing on a finished buil
     mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
     mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
 
-    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
     await vi.runAllTimersAsync();
 
     expect(await promise).toBe(EXIT_GREEN);
@@ -1040,11 +1054,19 @@ describe('waitForBuildResult settles stories[] before closing on a finished buil
 
   it('keeps reading while the stories are still arriving, and closes once they hold still', async () => {
     mockGraphqlResponse(200, finished([story('Hello - Basic', 1)]));
-    mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', null)]));
+    mockGraphqlResponse(
+      200,
+      finished([story('Hello - Basic', 1), story('Typography - Dense', null)])
+    );
     mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
     mockGraphqlResponse(200, finished([story('Hello - Basic', 1), story('Typography - Dense', 1)]));
 
-    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
     await vi.runAllTimersAsync();
 
     expect(await promise).toBe(EXIT_GREEN);
@@ -1054,7 +1076,12 @@ describe('waitForBuildResult settles stories[] before closing on a finished buil
   it('closes at once on a finished build whose wire carries no stories - there is nothing to settle', async () => {
     mockGraphqlResponse(200, finished(undefined));
 
-    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
     await vi.runAllTimersAsync();
 
     expect(await promise).toBe(EXIT_GREEN);
@@ -1064,7 +1091,12 @@ describe('waitForBuildResult settles stories[] before closing on a finished buil
   it('does not hold an errored build - there is no comparison to wait for', async () => {
     mockGraphqlResponse(200, buildResponse('error', undefined, 'boom'));
 
-    const promise = waitForBuildResult({ token: TOKEN, buildIndex: BUILD_INDEX, projectIndex: PROJECT_INDEX, teamId: TEAM_ID });
+    const promise = waitForBuildResult({
+      token: TOKEN,
+      buildIndex: BUILD_INDEX,
+      projectIndex: PROJECT_INDEX,
+      teamId: TEAM_ID,
+    });
     await vi.runAllTimersAsync();
 
     expect(await promise).toBe(EXIT_ERROR);

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -264,7 +264,9 @@ async function waitForBuildResult({
   // deadline, so a timeout fires on time instead of overshooting by up to one
   // poll interval - and is raced against SIGINT so Ctrl-C never has to wait
   // out a sleep.
-  const sleepUnlessInterrupted = async (intervalMs = POLL_INTERVAL_MS): Promise<'elapsed' | 'sigint'> => {
+  const sleepUnlessInterrupted = async (
+    intervalMs = POLL_INTERVAL_MS
+  ): Promise<'elapsed' | 'sigint'> => {
     const remainingMs = Math.max(deadline - now(), 0);
     return Promise.race([
       sleep(Math.min(intervalMs, remainingMs)).then(() => 'elapsed' as const),
@@ -521,7 +523,12 @@ async function fetchBuildStatus(
 function storiesFingerprint(build: BuildStatus): string | null {
   if (!build.stories) return null;
   return build.stories
-    .map((story) => `${story.name}|${story.status}|${story.baseline?.buildIndex ?? 'none'}|${story.reason ?? ''}`)
+    .map(
+      (story) =>
+        `${story.name}|${story.status}|${story.baseline?.buildIndex ?? 'none'}|${
+          story.reason ?? ''
+        }`
+    )
     .join('\n');
 }
 

--- a/packages/cli/src/helpers/waitForBuildResult.ts
+++ b/packages/cli/src/helpers/waitForBuildResult.ts
@@ -14,6 +14,23 @@ import { decideSparseBuildVerdict, routesThroughSparseVerdict } from './sparseBu
 
 const DEFAULT_WAIT_TIMEOUT_MINUTES = 45;
 const POLL_INTERVAL_MS = 15_000; // fixed interval, no API hammering
+/**
+ * THE STORIES MUST HAVE STOPPED MOVING BEFORE A VERDICT IS PRINTED (2026-09-09).
+ *
+ * `runStatus: finished` says the runner is done; it does not say the comparison
+ * is. The per-story rows behind `stories[]` (names, statuses, the baseline each
+ * was judged against) are written after the build closes, one at a time, so a
+ * read taken the instant the build turns terminal can see a half-populated list
+ * - and a `--metadata` read chained after `--wait` would print it as the truth.
+ * The e2e harness used to paper over this with a private GraphQL poll of its
+ * own; a user has no such poll, so the wait has to be right here.
+ *
+ * The rule: once finished, the verdict is held until two consecutive reads of
+ * `stories[]` are identical. The confirming read comes a few seconds after the
+ * first, not a whole poll interval later - a settled build pays seconds, an
+ * unsettled one waits exactly as long as it takes.
+ */
+const SETTLE_CONFIRM_MS = 3_000;
 
 /**
  * The `getBuildStatus` wire shape, exported because two things outside this file
@@ -234,6 +251,9 @@ async function waitForBuildResult({
 
   let lastStatus = '';
   let pollCount = 0;
+  // The `stories[]` the previous read of a FINISHED build carried (see
+  // SETTLE_CONFIRM_MS); `undefined` until a finished build has been read once.
+  let storiesLastRead: string | undefined;
 
   // Overrides Node's default "exit immediately" SIGINT behavior so the wait
   // loop can stop cleanly and exit(130) itself instead of killing the process
@@ -244,10 +264,10 @@ async function waitForBuildResult({
   // deadline, so a timeout fires on time instead of overshooting by up to one
   // poll interval - and is raced against SIGINT so Ctrl-C never has to wait
   // out a sleep.
-  const sleepUnlessInterrupted = async (): Promise<'elapsed' | 'sigint'> => {
+  const sleepUnlessInterrupted = async (intervalMs = POLL_INTERVAL_MS): Promise<'elapsed' | 'sigint'> => {
     const remainingMs = Math.max(deadline - now(), 0);
     return Promise.race([
-      sleep(Math.min(POLL_INTERVAL_MS, remainingMs)).then(() => 'elapsed' as const),
+      sleep(Math.min(intervalMs, remainingMs)).then(() => 'elapsed' as const),
       sigint.promise.then(() => 'sigint' as const),
     ]);
   };
@@ -334,6 +354,18 @@ async function waitForBuildResult({
       const exitCode = evaluateTerminalState(build);
 
       if (exitCode !== null) {
+        // A FINISHED BUILD IS CLOSED ON ONLY ONCE ITS STORIES HAVE STOPPED MOVING
+        // (SETTLE_CONFIRM_MS). An errored or canceled build has no comparison to
+        // wait for, and a wire that carries no `stories` at all has nothing to
+        // settle; both close at once, as before.
+        const storiesNow = build.runStatus === 'finished' ? storiesFingerprint(build) : null;
+        if (storiesNow !== null && storiesNow !== storiesLastRead) {
+          storiesLastRead = storiesNow;
+          if ((await sleepUnlessInterrupted(SETTLE_CONFIRM_MS)) === 'sigint') {
+            return printSigintCloser();
+          }
+          continue;
+        }
         if (metadata) {
           emit({ kind: 'build-details', details: buildDetailsOf(build, metadata.git) });
           emit({ kind: 'blank-line' });
@@ -480,6 +512,17 @@ async function fetchBuildStatus(
   }
 
   return json.data?.getBuildStatus ?? null;
+}
+
+/**
+ * One line per story - name, status, baseline build, review reason - so two reads
+ * compare as strings. `null` when the wire carried no `stories` at all.
+ */
+function storiesFingerprint(build: BuildStatus): string | null {
+  if (!build.stories) return null;
+  return build.stories
+    .map((story) => `${story.name}|${story.status}|${story.baseline?.buildIndex ?? 'none'}|${story.reason ?? ''}`)
+    .join('\n');
 }
 
 function evaluateTerminalState(


### PR DESCRIPTION
Channel PR for task "cli-wait-settles-stories".

**E2E declaration:** none - CLI wait-loop contract; the storyline lanes that read `sherlo view --wait` are the proof

<!-- e2e:declared
{"mode":"none","reason":"CLI wait-loop contract; the storyline lanes that read `sherlo view --wait` are the proof"}
-->

🤖 Generated with brain